### PR TITLE
HTTPException no longer inherits from IOException

### DIFF
--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -146,6 +146,8 @@ HTTPFileSystem::RunRequestWithRetry(const std::function<duckdb_httplib_openssl::
 			}
 		} catch (IOException &e) {
 			caught_e = std::current_exception();
+		} catch (HTTPException &e) {
+			caught_e = std::current_exception();
 		}
 
 		// Note: all duckdb_httplib_openssl::Error types will be retried.

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -324,7 +324,11 @@ void S3FileSystem::UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuf
 			throw IOException("Unexpected response when uploading part to S3");
 		}
 
-	} catch (IOException &ex) {
+	} catch (std::exception &ex) {
+		ErrorData error(ex);
+		if (error.Type() != ExceptionType::IO && error.Type() != ExceptionType::HTTP) {
+			throw;
+		}
 		// Ensure only one thread sets the exception
 		bool f = false;
 		auto exchanged = file_handle.uploader_has_error.compare_exchange_strong(f, true);
@@ -333,7 +337,6 @@ void S3FileSystem::UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuf
 		}
 
 		NotifyUploadsInProgress(file_handle);
-
 		return;
 	}
 


### PR DESCRIPTION
Mirrored from @Mytherin's https://github.com/duckdb/duckdb/pull/14585