### PR TITLE
Add support for SSE KMS on S3

### DIFF
--- a/extension/httpfs/create_secret_functions.cpp
+++ b/extension/httpfs/create_secret_functions.cpp
@@ -61,6 +61,8 @@ unique_ptr<BaseSecret> CreateS3SecretFunctions::CreateSecretFunctionInternal(Cli
 				                            lower_name, named_param.second.type().ToString());
 			}
 			secret->secret_map["use_ssl"] = Value::BOOLEAN(named_param.second.GetValue<bool>());
+		} else if (lower_name == "kms_key_id") {
+			secret->secret_map["kms_key_id"] = named_param.second.ToString();
 		} else if (lower_name == "url_compatibility_mode") {
 			if (named_param.second.type() != LogicalType::BOOLEAN) {
 				throw InvalidInputException("Invalid type past to secret option: '%s', found '%s', expected: 'BOOLEAN'",
@@ -90,6 +92,7 @@ void CreateS3SecretFunctions::SetBaseNamedParams(CreateSecretFunction &function,
 	function.named_parameters["endpoint"] = LogicalType::VARCHAR;
 	function.named_parameters["url_style"] = LogicalType::VARCHAR;
 	function.named_parameters["use_ssl"] = LogicalType::BOOLEAN;
+	function.named_parameters["kms_key_id"] = LogicalType::VARCHAR;
 	function.named_parameters["url_compatibility_mode"] = LogicalType::BOOLEAN;
 
 	if (type == "r2") {

--- a/extension/httpfs/httpfs_extension.cpp
+++ b/extension/httpfs/httpfs_extension.cpp
@@ -47,6 +47,7 @@ static void LoadInternal(DatabaseInstance &instance) {
 	config.AddExtensionOption("s3_endpoint", "S3 Endpoint", LogicalType::VARCHAR);
 	config.AddExtensionOption("s3_url_style", "S3 URL style", LogicalType::VARCHAR, Value("vhost"));
 	config.AddExtensionOption("s3_use_ssl", "S3 use SSL", LogicalType::BOOLEAN, Value(true));
+	config.AddExtensionOption("s3_kms_key_id", "S3 KMS Key ID", LogicalType::VARCHAR);
 	config.AddExtensionOption("s3_url_compatibility_mode", "Disable Globs and Query Parameters on S3 URLs",
 	                          LogicalType::BOOLEAN, Value(false));
 

--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -27,6 +27,7 @@ struct S3AuthParams {
 	string secret_access_key;
 	string session_token;
 	string endpoint;
+	string kms_key_id;
 	string url_style;
 	bool use_ssl = true;
 	bool s3_url_compatibility_mode = false;
@@ -42,6 +43,7 @@ struct AWSEnvironmentCredentialsProvider {
 	static constexpr const char *SESSION_TOKEN_ENV_VAR = "AWS_SESSION_TOKEN";
 	static constexpr const char *DUCKDB_ENDPOINT_ENV_VAR = "DUCKDB_S3_ENDPOINT";
 	static constexpr const char *DUCKDB_USE_SSL_ENV_VAR = "DUCKDB_S3_USE_SSL";
+	static constexpr const char *DUCKDB_KMS_KEY_ID_ENV_VAR = "DUCKDB_S3_KMS_KEY_ID";
 
 	explicit AWSEnvironmentCredentialsProvider(DBConfig &config) : config(config) {};
 


### PR DESCRIPTION
This adds support for [Server Side Encryption via KMS on S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html), by adding a new option to S3 secret named `kms_key_id`, and inject the proper headers to use the provided key identifier when present.

```sql
CREATE SECRET encrypted (
    TYPE S3,
    PROVIDER CREDENTIAL_CHAIN,
    CHAIN 'config',
    REGION 'eu-west-1',
    KMS_KEY_ID 'arn:aws:kms:region:acct-id:key/key-id',
    SCOPE 's3://bucket/sub/path'
);
```

This was tested against S3 directly, there is no tests against minio, as this seems it requires another piece of software (KES).

This is the same PR as [duckdb#14475](https://github.com/duckdb/duckdb/pull/14475).