### PR TITLE
Fix timeout to default to 30 seconds instead of 30000 seconds

### DIFF
--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -244,9 +244,9 @@ unique_ptr<duckdb_httplib_openssl::Client> HTTPFileSystem::GetClient(const HTTPP
 		client->set_ca_cert_path(http_params.ca_cert_file.c_str());
 	}
 	client->enable_server_certificate_verification(http_params.enable_server_cert_verification);
-	client->set_write_timeout(http_params.timeout);
-	client->set_read_timeout(http_params.timeout);
-	client->set_connection_timeout(http_params.timeout);
+	client->set_write_timeout(http_params.timeout, http_params.timeout_usec);
+	client->set_read_timeout(http_params.timeout, http_params.timeout_usec);
+	client->set_connection_timeout(http_params.timeout, http_params.timeout_usec);
 	client->set_decompress(false);
 	if (hfh && hfh->http_logger) {
 		client->set_logger(

--- a/extension/httpfs/httpfs_extension.cpp
+++ b/extension/httpfs/httpfs_extension.cpp
@@ -22,8 +22,8 @@ static void LoadInternal(DatabaseInstance &instance) {
 
 	// Global HTTP config
 	// Single timeout value is used for all 4 types of timeouts, we could split it into 4 if users need that
-	config.AddExtensionOption("http_timeout", "HTTP timeout read/write/connection/retry", LogicalType::UBIGINT,
-	                          Value(30000));
+	config.AddExtensionOption("http_timeout", "HTTP timeout read/write/connection/retry (in seconds)", LogicalType::UBIGINT,
+	                          Value::UBIGINT(HTTPParams::DEFAULT_TIMEOUT_SECONDS));
 	config.AddExtensionOption("http_retries", "HTTP retries on I/O error", LogicalType::UBIGINT, Value(3));
 	config.AddExtensionOption("http_retry_wait_ms", "Time between retries", LogicalType::UBIGINT, Value(100));
 	config.AddExtensionOption("force_download", "Forces upfront download of file", LogicalType::BOOLEAN, Value(false));

--- a/extension/httpfs/include/httpfs.hpp
+++ b/extension/httpfs/include/httpfs.hpp
@@ -37,7 +37,7 @@ public:
 
 struct HTTPParams {
 
-	static constexpr uint64_t DEFAULT_TIMEOUT = 30000; // 30 sec
+	static constexpr uint64_t DEFAULT_TIMEOUT_SECONDS = 30; // 30 sec
 	static constexpr uint64_t DEFAULT_RETRIES = 3;
 	static constexpr uint64_t DEFAULT_RETRY_WAIT_MS = 100;
 	static constexpr float DEFAULT_RETRY_BACKOFF = 4;
@@ -46,7 +46,8 @@ struct HTTPParams {
 	static constexpr bool DEFAULT_ENABLE_SERVER_CERT_VERIFICATION = false;
 	static constexpr uint64_t DEFAULT_HF_MAX_PER_PAGE = 0;
 
-	uint64_t timeout = DEFAULT_TIMEOUT;
+	uint64_t timeout = DEFAULT_TIMEOUT_SECONDS; // seconds component of a timeout
+	uint64_t timeout_usec = 0;                  // usec component of a timeout
 	uint64_t retries = DEFAULT_RETRIES;
 	uint64_t retry_wait_ms = DEFAULT_RETRY_WAIT_MS;
 	float retry_backoff = DEFAULT_RETRY_BACKOFF;


### PR DESCRIPTION
Found by @ywelsch

httplib splits the timeout into two components (sec and usec): 

```cpp
Server &set_write_timeout(time_t sec, time_t usec = 0);
```

We were passing the timeout into the seconds component:

```cpp
client->set_write_timeout(http_params.timeout);
```

With a somewhat high default value of 30000. This fixes it so the default is 30 seconds.
