### PR TITLE
Secret auto-refresh

### DIFF
--- a/.github/workflows/MinioTests.yml
+++ b/.github/workflows/MinioTests.yml
@@ -1,0 +1,71 @@
+name: Minio Tests
+on: [push, pull_request,repository_dispatch]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  cancel-in-progress: true
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  minio-tests:
+    name: Minio Tests
+    runs-on: ubuntu-20.04
+    env:
+      S3_TEST_SERVER_AVAILABLE: 1
+      AWS_DEFAULT_REGION: eu-west-1
+      AWS_ACCESS_KEY_ID: minio_duckdb_user
+      AWS_SECRET_ACCESS_KEY: minio_duckdb_user_password
+      DUCKDB_S3_ENDPOINT: duckdb-minio.com:9000
+      DUCKDB_S3_USE_SSL: false
+      GEN: ninja
+      VCPKG_TARGET_TRIPLET: x64-linux
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.7'
+
+      - name: Install Ninja
+        shell: bash
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
+
+      - name: Setup Ccache
+        uses: hendrikmuhs/ccache-action@main
+        with:
+          key: ${{ github.job }}
+          save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.1
+        with:
+          vcpkgGitCommitId: 5e5d0e1cd7785623065e77eff011afdeec1a3574
+
+      - name: Build
+        shell: bash
+        run: make
+
+      - name: Start S3/HTTP test server
+        shell: bash
+        run: |
+          cd duckdb
+          mkdir data/attach_test
+          touch data/attach_test/attach.db
+          sudo ./scripts/install_s3_test_server.sh
+          source ./scripts/run_s3_test_server.sh
+          sleep 30
+
+      - name: Write AWS credentials file
+        shell: bash
+        run: |
+          ./scripts/create_minio_credential_file.sh
+
+      - name: Test
+        shell: bash
+        run: |
+          make test

--- a/.github/workflows/MinioTests.yml
+++ b/.github/workflows/MinioTests.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.10'
 
       - name: Install Ninja
         shell: bash

--- a/.github/workflows/MinioTests.yml
+++ b/.github/workflows/MinioTests.yml
@@ -60,11 +60,6 @@ jobs:
           source ./scripts/run_s3_test_server.sh
           sleep 30
 
-      - name: Write AWS credentials file
-        shell: bash
-        run: |
-          ./scripts/create_minio_credential_file.sh
-
       - name: Test
         shell: bash
         run: |

--- a/.github/workflows/MinioTests.yml
+++ b/.github/workflows/MinioTests.yml
@@ -10,7 +10,7 @@ defaults:
 jobs:
   minio-tests:
     name: Minio Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       S3_TEST_SERVER_AVAILABLE: 1
       AWS_DEFAULT_REGION: eu-west-1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,8 @@ project(HTTPFsExtension)
 
 add_extension_definitions()
 
-include_directories(extension/httpfs/include ${DUCKDB_MODULE_BASE_DIR}/third_party/httplib)
+include_directories(extension/httpfs/include
+                    ${DUCKDB_MODULE_BASE_DIR}/third_party/httplib)
 
 build_static_extension(
   httpfs
@@ -38,16 +39,17 @@ endif()
 find_package(OpenSSL REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR})
 if(EMSCRIPTEN)
-else()
-target_link_libraries(httpfs_loadable_extension duckdb_mbedtls
-                      ${OPENSSL_LIBRARIES})
-target_link_libraries(httpfs_extension duckdb_mbedtls ${OPENSSL_LIBRARIES})
 
-if(MINGW)
-  find_package(ZLIB)
-  target_link_libraries(httpfs_loadable_extension ZLIB::ZLIB -lcrypt32)
-  target_link_libraries(httpfs_extension ZLIB::ZLIB -lcrypt32)
-endif()
+else()
+  target_link_libraries(httpfs_loadable_extension duckdb_mbedtls
+                        ${OPENSSL_LIBRARIES})
+  target_link_libraries(httpfs_extension duckdb_mbedtls ${OPENSSL_LIBRARIES})
+
+  if(MINGW)
+    find_package(ZLIB)
+    target_link_libraries(httpfs_loadable_extension ZLIB::ZLIB -lcrypt32)
+    target_link_libraries(httpfs_extension ZLIB::ZLIB -lcrypt32)
+  endif()
 endif()
 
 install(

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 EXT_NAME=httpfs
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
-CORE_EXTENSIONS='aws'
+CORE_EXTENSIONS=''
 
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile

--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,7 @@ PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 EXT_NAME=httpfs
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
+CORE_EXTENSIONS='aws'
+
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile

--- a/extension/httpfs/create_secret_functions.cpp
+++ b/extension/httpfs/create_secret_functions.cpp
@@ -14,7 +14,6 @@ void CreateS3SecretFunctions::Register(DatabaseInstance &instance) {
 static Value MapToStruct(const Value &map){
 	auto children = MapValue::GetChildren(map);
 
-	// Convert refresh info from map to struct
 	child_list_t<Value> struct_fields;
 	for (const auto &kv_child : children) {
 		auto kv_pair = StructValue::GetChildren(kv_child);

--- a/extension/httpfs/create_secret_functions.cpp
+++ b/extension/httpfs/create_secret_functions.cpp
@@ -151,9 +151,10 @@ bool CreateS3SecretFunctions::TryRefreshS3Secret(ClientContext &context, const S
 		auto &new_secret = dynamic_cast<const KeyValueSecret&>(*res->secret);
 		DUCKDB_LOG_INFO(context, "httpfs.SecretRefresh", "Successfully refreshed secret: %s, new key_id: %s", secret_to_refresh.secret->GetName(), new_secret.TryGetValue("key_id").ToString());
 		return true;
-	} catch (InvalidInputException &e) {
-		DUCKDB_LOG_WARN(context, "httpfs.SecretRefresh", "Failed to refresh secret %s: %s", secret_to_refresh.secret->GetName(), e.what());
-		return false;
+	} catch (std::exception &ex) {
+		ErrorData error(ex);
+		string new_message = StringUtil::Format("Exception thrown while trying to refresh secret %s. To fix this, please recreate or remove the secret and try again. Error: '%s'", secret_to_refresh.secret->GetName(), error.Message());
+		throw Exception(error.Type(), new_message);
 	}
 }
 

--- a/extension/httpfs/create_secret_functions.cpp
+++ b/extension/httpfs/create_secret_functions.cpp
@@ -89,8 +89,8 @@ unique_ptr<BaseSecret> CreateS3SecretFunctions::CreateSecretFunctionInternal(Cli
 			if (refresh) {
 				throw InvalidInputException("Can not set `refresh` and `refresh_info` at the same time");
 			}
-			refresh = named_param.second.GetValue<bool>();
-			secret->secret_map["refresh"] = Value::BOOLEAN(refresh);
+			refresh = named_param.second.GetValue<string>() == "auto";
+			secret->secret_map["refresh"] = Value("auto");
 			child_list_t<Value> struct_fields;
 			for (const auto &named_param : input.options) {
 				auto lower_name = StringUtil::Lower(named_param.first);
@@ -174,7 +174,15 @@ void CreateS3SecretFunctions::SetBaseNamedParams(CreateSecretFunction &function,
 	function.named_parameters["url_compatibility_mode"] = LogicalType::BOOLEAN;
 
 	// Whether a secret refresh attempt should be made when the secret appears to be incorrect
-	function.named_parameters["refresh"] = LogicalType::BOOLEAN;
+	function.named_parameters["refresh"] = LogicalType::VARCHAR;
+
+	// Refresh Modes
+	// - auto
+	// - disabled
+	// - on_error
+	// - on_timeout
+
+	// - on_use: every time a secret is used, it will refresh.
 
 	// Debugging/testing option: it allows specifying how the secret will be refreshed using a manually specfied MAP
 	function.named_parameters["refresh_info"] = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR);

--- a/extension/httpfs/create_secret_functions.cpp
+++ b/extension/httpfs/create_secret_functions.cpp
@@ -86,6 +86,9 @@ unique_ptr<BaseSecret> CreateS3SecretFunctions::CreateSecretFunctionInternal(Cli
 		} else if (lower_name == "account_id") {
 			continue; // handled already
 		} else if (lower_name == "refresh") {
+			if (refresh) {
+				throw InvalidInputException("Can not set `refresh` and `refresh_info` at the same time");
+			}
 			refresh = named_param.second.GetValue<bool>();
 			secret->secret_map["refresh"] = Value::BOOLEAN(refresh);
 			child_list_t<Value> struct_fields;
@@ -98,6 +101,7 @@ unique_ptr<BaseSecret> CreateS3SecretFunctions::CreateSecretFunctionInternal(Cli
 			if (refresh) {
 				throw InvalidInputException("Can not set `refresh` and `refresh_info` at the same time");
 			}
+			refresh = true;
 			secret->secret_map["refresh_info"] = MapToStruct(named_param.second);
 		} else {
 			throw InvalidInputException("Unknown named parameter passed to CreateSecretFunctionInternal: " + lower_name);

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -331,7 +331,7 @@ unique_ptr<ResponseWrapper> HTTPFileSystem::GetRequest(FileHandle &handle, strin
 					    error += " This could mean the file was changed. Try disabling the duckdb http metadata cache "
 					             "if enabled, and confirm the server supports range requests.";
 				    }
-				    throw IOException(error);
+				    throw HTTPException(error);
 			    }
 			    return true;
 		    },

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -331,7 +331,7 @@ unique_ptr<ResponseWrapper> HTTPFileSystem::GetRequest(FileHandle &handle, strin
 					    error += " This could mean the file was changed. Try disabling the duckdb http metadata cache "
 					             "if enabled, and confirm the server supports range requests.";
 				    }
-				    throw HTTPException(error);
+				    throw IOException(error);
 			    }
 			    return true;
 		    },

--- a/extension/httpfs/include/create_secret_functions.hpp
+++ b/extension/httpfs/include/create_secret_functions.hpp
@@ -7,11 +7,17 @@ struct CreateSecretInput;
 struct S3AuthParams;
 class CreateSecretFunction;
 class BaseSecret;
+struct CreateSecretInfo;
+struct SecretEntry;
 
 struct CreateS3SecretFunctions {
 public:
 	//! Register all CreateSecretFunctions
 	static void Register(DatabaseInstance &instance);
+
+	//! Secret refreshing mechanisms
+	static CreateSecretInfo GenerateRefreshSecretInfo(const SecretEntry &secret_entry, Value &refresh_info);
+	static bool TryRefreshS3Secret(ClientContext &context, const SecretEntry &secret_to_refresh);
 
 protected:
 	//! Internal function to create BaseSecret from S3AuthParams

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -157,9 +157,7 @@ S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerI
 	}
 
 	const char *secret_types[] = {"s3", "r2", "gcs"};
-	idx_t secret_types_len = sizeof(secret_types) / sizeof(const char *);
-
-	KeyValueSecretReader secret_reader(*opener, info, secret_types, secret_types_len);
+	KeyValueSecretReader secret_reader(*opener, info, secret_types, 3);
 
 	// These settings we just set or leave to their S3AuthParams default value
 	secret_reader.TryGetSecretKeyOrSetting("region", "s3_region", result.region);
@@ -794,30 +792,29 @@ void S3FileSystem::Verify() {
 	// TODO add a test that checks the signing for path-style
 }
 
+
 void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 	try {
 		HTTPFileHandle::Initialize(opener);
-	} catch (Exception &e) {
-		if (StringUtil::Contains(e.what(), "40") && opener) {
-			bool refreshed_secret = false;
-			auto context = opener->TryGetClientContext();
-			if (context) {
-				auto transaction = CatalogTransaction::GetSystemCatalogTransaction(*context);
-				for (const string &type : {"s3", "r2", "gcs"}) {
-					auto res = context->db->GetSecretManager().LookupSecret(transaction, path, type);
-					if (res.HasMatch()) {
-						refreshed_secret |= CreateS3SecretFunctions::TryRefreshS3Secret(*context, *res.secret_entry);
-					}
+	} catch (HTTPException &e) {
+		bool refreshed_secret = false;
+		auto context = opener->TryGetClientContext();
+		if (context) {
+			auto transaction = CatalogTransaction::GetSystemCatalogTransaction(*context);
+			for (const string type : {"s3", "r2", "gcs"}) {
+				auto res = context->db->GetSecretManager().LookupSecret(transaction, path, type);
+				if (res.HasMatch()) {
+					refreshed_secret |= CreateS3SecretFunctions::TryRefreshS3Secret(*context, *res.secret_entry);
 				}
 			}
+		}
 
-			if (refreshed_secret) {
-				// We have succesfully refreshed a secret: retry initializing with new credentials
-				FileOpenerInfo info = {path};
-				auth_params = S3AuthParams::ReadFrom(opener, info);
-				HTTPFileHandle::Initialize(opener);
-				return;
-			}
+		if (refreshed_secret) {
+			// We have succesfully refreshed a secret: retry initializing with new credentials
+			FileOpenerInfo info = {path};
+			auth_params = S3AuthParams::ReadFrom(opener, info);
+			HTTPFileHandle::Initialize(opener);
+			return;
 		}
 		throw;
 	}

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -9,7 +9,6 @@ else ()
 endif()
 
 duckdb_extension_load(httpfs
-	DONT_LINK
 	SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
 	INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/extension/httpfs/include
 	${LOAD_HTTPFS_TESTS}

--- a/test/sql/secret/secret_refresh.test
+++ b/test/sql/secret/secret_refresh.test
@@ -109,7 +109,7 @@ FROM "s3://test-bucket/test-file.parquet"
 ----
 Exception thrown while trying to refresh secret s1
 
-# Cleanup: drop secret and logs
+# Cleanup: drop secret
 statement ok
 DROP SECRET s1;
 

--- a/test/sql/secret/secret_refresh.test
+++ b/test/sql/secret/secret_refresh.test
@@ -103,21 +103,15 @@ CREATE SECRET s1 (
     }
 )
 
-# We still just get an HTTP 403, user is unaware of failed refresh attempt (doesn't really matter, the key was invalid, and still is)
+# For now, we throw the actual error that get's thrown during refresh. Since refresh is op-in for now that ensures user can understand what's happening
 statement error
 FROM "s3://test-bucket/test-file.parquet"
 ----
-HTTP 403
-
-# The log will show the failed refresh attempt
-query II
-SELECT log_level, message FROM duckdb_logs WHERE type='httpfs.SecretRefresh'
-----
-WARN	Failed to refresh secret s1: {"exception_type":"Invalid Input","exception_message":"Unknown named parameter passed to CreateSecretFunctionInternal: this_key_does_not_exist"}
+Exception thrown while trying to refresh secret s1
 
 # Cleanup: drop secret and logs
 statement ok
-DROP SECRET s1;set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+DROP SECRET s1;
 
 # Set incorrect key id to force query to fail without secret
 statement ok

--- a/test/sql/secret/secret_refresh.test
+++ b/test/sql/secret/secret_refresh.test
@@ -1,0 +1,135 @@
+# name: test/sql/secret/secret_refresh.test
+# description: Tests secret refreshing
+# group: [secrets]
+
+require-env S3_TEST_SERVER_AVAILABLE 1
+
+require-env AWS_DEFAULT_REGION
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+require-env DUCKDB_S3_ENDPOINT
+
+require-env DUCKDB_S3_USE_SSL
+
+require httpfs
+
+require parquet
+
+statement ok
+SET enable_logging=true
+
+statement ok
+set s3_use_ssl='${DUCKDB_S3_USE_SSL}'
+
+statement ok
+set s3_endpoint='${DUCKDB_S3_ENDPOINT}'
+
+statement ok
+set s3_region='${AWS_DEFAULT_REGION}'
+
+# Create some test data
+statement ok
+CREATE SECRET s1 (
+    TYPE S3,
+    KEY_ID '${AWS_ACCESS_KEY_ID}',
+    SECRET '${AWS_SECRET_ACCESS_KEY}'
+)
+
+statement ok
+copy (select 1 as a) to 's3://test-bucket/test-file.parquet'
+
+statement ok
+DROP SECRET s1;
+
+# Firstly: a secret that is initially wrong, but correct after refresh
+statement ok
+CREATE SECRET s1 (
+    TYPE S3,
+    KEY_ID 'BOGUS',
+    SECRET 'ALSO BOGUS',
+    REFRESH_INFO MAP {
+        'KEY_ID': '${AWS_ACCESS_KEY_ID}',
+        'SECRET': '${AWS_SECRET_ACCESS_KEY}'
+    }
+)
+
+# Make the request: initial request will fail, but refresh will get triggered and the request succeeds on second attempt
+statement ok
+FROM "s3://test-bucket/test-file.parquet"
+
+query I
+SELECT message[0:46] FROM duckdb_logs WHERE type='httpfs.SecretRefresh'
+----
+Successfully refreshed secret: s1, new key_id:
+
+# Cleanup: drop secret and logs
+statement ok
+DROP SECRET s1;set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+
+# Secondly: a secret that is initially wrong, and still incorrect afterwards (REFRESH will just use the original secret input to refresh)
+statement ok
+CREATE SECRET s1 (
+    TYPE S3,
+    KEY_ID 'BOGUS',
+    SECRET 'ALSO BOGUS',
+    REFRESH 1
+)
+
+statement error
+FROM "s3://test-bucket/test-file.parquet"
+----
+HTTP 403
+
+query I
+SELECT message[0:46] FROM duckdb_logs WHERE type='httpfs.SecretRefresh'
+----
+Successfully refreshed secret: s1, new key_id:
+
+# Cleanup: drop secret and logs
+statement ok
+DROP SECRET s1;set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+
+# Thirdly: a secret that is initially wrong, and contains incorrect REFRESH_INFO
+statement ok
+CREATE SECRET s1 (
+    TYPE S3,
+    KEY_ID 'BOGUS',
+    SECRET 'ALSO BOGUS',
+    REFRESH_INFO MAP {
+        'THIS_KEY_DOES_NOT_EXIST': '${BOGUS}'
+    }
+)
+
+# We still just get an HTTP 403, user is unaware of failed refresh attempt (doesn't really matter, the key was invalid, and still is)
+statement error
+FROM "s3://test-bucket/test-file.parquet"
+----
+HTTP 403
+
+# The log will show the failed refresh attempt
+query II
+SELECT log_level, message FROM duckdb_logs WHERE type='httpfs.SecretRefresh'
+----
+WARN	Failed to refresh secret s1: {"exception_type":"Invalid Input","exception_message":"Unknown named parameter passed to CreateSecretFunctionInternal: this_key_does_not_exist"}
+
+# Cleanup: drop secret and logs
+statement ok
+DROP SECRET s1;set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+
+# Set incorrect key id to force query to fail without secret
+statement ok
+set s3_access_key_id='bogus'
+
+# Without secret this query will fail, but since there are no suitable secrets, no refresh attempt will be made
+statement error
+FROM "s3://test-bucket/test-file.parquet"
+----
+HTTP 403
+
+# -> log empty
+query II
+SELECT log_level, message FROM duckdb_logs WHERE type='httpfs.SecretRefresh'
+----

--- a/test/sql/secret/secret_refresh_attach.test
+++ b/test/sql/secret/secret_refresh_attach.test
@@ -36,7 +36,7 @@ CREATE SECRET uhuh_this_mah_sh (
     REGION '${AWS_DEFAULT_REGION}',
     ENDPOINT '${DUCKDB_S3_ENDPOINT}',
     USE_SSL '${DUCKDB_S3_USE_SSL}',
-    REFRESH 1
+    REFRESH 'auto'
 )
 
 statement error

--- a/test/sql/secret/secret_refresh_attach.test
+++ b/test/sql/secret/secret_refresh_attach.test
@@ -1,0 +1,50 @@
+# name: test/sql/secret/secret_refresh_attach.test
+# description: Tests secret refreshing
+# group: [secrets]
+
+require-env S3_TEST_SERVER_AVAILABLE 1
+
+require-env AWS_DEFAULT_REGION
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+require-env DUCKDB_S3_ENDPOINT
+
+require-env DUCKDB_S3_USE_SSL
+
+require-env S3_ATTACH_DB
+
+require httpfs
+
+require parquet
+
+statement ok
+SET enable_logging=true
+
+statement ok
+set s3_use_ssl='${DUCKDB_S3_USE_SSL}'
+
+# Create secret with incorrect credentials to trigger secret refreshing
+statement ok
+CREATE SECRET uhuh_this_mah_sh (
+    TYPE S3,
+    PROVIDER config,
+    KEY_ID 'all the girls',
+    SECRET 'stomp yo feet like dis',
+    REGION '${AWS_DEFAULT_REGION}',
+    ENDPOINT '${DUCKDB_S3_ENDPOINT}',
+    USE_SSL '${DUCKDB_S3_USE_SSL}',
+    REFRESH 1
+)
+
+statement error
+ATTACH 's3://test-bucket/presigned/attach.db' AS db (READONLY 1);
+----
+
+# Secret refresh has been triggered
+query II
+SELECT log_level, message FROM duckdb_logs WHERE type='httpfs.SecretRefresh'
+----
+INFO	Successfully refreshed secret: uhuh_this_mah_sh, new key_id: all the girls

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,10 @@
 {
   "dependencies": [
+    "zlib",
+    {
+      "name": "aws-sdk-cpp",
+      "features": [ "sso", "sts" , "identity-management"]
+    },
     "openssl"
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,10 +1,5 @@
 {
   "dependencies": [
-    "zlib",
-    {
-      "name": "aws-sdk-cpp",
-      "features": [ "sso", "sts" , "identity-management"]
-    },
     "openssl"
   ]
 }


### PR DESCRIPTION
This PR implements a first version of secret refreshing.

### Problem
Currently, S3 secrets cannot be automatically refreshed. What this means is that a secret like:
```
CREATE SECRET s1 (TYPE S3, PROVIDER credential_chain);
```
Will actually call into the AWS SDK on secret creation, grab the key_id, secret, etc. and store it physically in the secret. 

This is actually kindof problematic because in various situations these credentials will actually only be temporary credentials. This is super annoying because it requires manually refreshing the secret by the user. This causes issues like https://github.com/duckdb/duckdb-aws/issues/61

### Feature
This PR adds an initial implementation of an automatic refresh mechanism. This first implementation is compatible with duckdb v1.2.0, but future implementations should probably consider improving on this by adding support for this directly in duckdb's secret manager.

The refresh mechanism works by setting the `refresh` key to true for the secret, which store all keys of the secret create statement in a separate `refresh_info` field in the secret. To refresh a secret, this field is then used to make a new create secret call.

To illustrate, lets consider the folllowing secret:

```SQL
CREATE SECRET s1 (
    TYPE S3,
    PROVIDER credential_chain,
    PROFILE 'my_profile'
    CHAIN 'config',
    REFRESH 'auto'
)
```
This statement will result in DuckDB making a KeyValue secret with the following keys:
```
- KEY_ID:  <fetched automatically by AWS SDK>
- SECRET: <fetched automatically by AWS SDK>
- SESSION_TOKEN: <fetched automatically by AWS SDK>
- REGION: <fetched automatically by AWS SDK>
- REFRESH_INFO:
     - PROFILE: my_profile
     - CHAIN: config
     - REFRESH: auto
```

The refresh mechanism is triggered whenever `S3FileHandle::Initialize` hits an HTTPException. When this happens, the secret for the corresponding path is fetched, and inspected for this `REFRESH_INFO` field. If the field exists, meaning that the secret is setup for refreshing, we will attempt to automatically re-create the secret by using the fields from the `REFRESH_INFO` field as input to what is basically a `CREATE OR REPLACE SECRET s1 ...` statement. When this succeeds, we retry the `S3FileHandle::Initialize` call.

### Testing
The refresh mechanism only really makes sense now for the `credential_chain` provider, however that live in the aws extension. To properly test this feature in this extension, i've added the option to manually pass the `REFRESH_INFO` info field. This allows testing this with the `config` provider in a meaningful way.

### TODO
This needs to be added to the aws extension for the `credential_chain` provider. This will actually make the feature useful.

This is implemented using the regular KeyValue mechanism. This allows it to work on v1.2.0. However I think it makes sense to add native support for this to the secret manager APIs which can allows us to cleanly do other stuff like refreshing secrets automatically based on expiration timestamps.

Finally: now we only support 'auto' refreshing, which is intended to mean: "let duckdb figure out the most sane thing" and is supposed to become the default value at some point. We probably want to support things like `disabled`, `on_use`, `on_error` or `on_timeout`. We can improve on this incrementally though








