### PR TITLE
HTTP WRITE support

### DIFF
--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -500,7 +500,11 @@ void HTTPFileSystem::FlushBuffer(HTTPFileHandle &hfh) {
 
 	HeaderMap header_map;
 	hfh.AddHeaders(header_map);
-	HTTPHeaders headers(header_map);
+
+	HTTPHeaders headers;
+	for (const auto &kv : header_map) {
+		headers.Insert(kv.first, kv.second);
+	}
 
 	auto &http_util = hfh.http_params.http_util;
 

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -22,23 +22,6 @@
 
 namespace duckdb {
 
-string HTTPFSUtil::GetName() const {
-	return "httpfs";
-}
-
-unordered_map<string, string> HTTPFSUtil::ParseGetParameters(const string &text) {
-	unordered_map<string, string> result;
-	auto pairs = StringUtil::Split(text, '&');
-	for (const auto &pair : pairs) {
-		auto kv = StringUtil::Split(pair, '=');
-		if (kv.size() != 2) {
-			throw IOException("Error parsing GET parameters");
-		}
-		result[kv[0]] = kv[1];
-	}
-	return result;
-}
-
 shared_ptr<HTTPUtil> HTTPFSUtil::GetHTTPUtil(optional_ptr<FileOpener> opener) {
 	if (opener) {
 		auto db = opener->TryGetDatabase();

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
+#include "duckdb/storage/buffer_manager.hpp"
 #include "http_state.hpp"
 
 #include <chrono>
@@ -59,6 +60,7 @@ HTTPParams HTTPParams::ReadFrom(optional_ptr<FileOpener> opener, optional_ptr<Fi
 	                                 info);
 	FileOpener::TryGetCurrentSetting(opener, "ca_cert_file", result.ca_cert_file, info);
 	FileOpener::TryGetCurrentSetting(opener, "hf_max_per_page", result.hf_max_per_page, info);
+	FileOpener::TryGetCurrentSetting(opener, "enable_http_write", result.enable_http_write, info);
 
 	// HTTP Secret lookups
 	KeyValueSecretReader settings_reader(*opener, info, "http");
@@ -576,7 +578,100 @@ int64_t HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes)
 }
 
 void HTTPFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
-	throw NotImplementedException("Writing to HTTP files not implemented");
+	auto &hfh = handle.Cast<HTTPFileHandle>();
+
+	// Check if HTTP write is enabled
+	if (!hfh.http_params.enable_http_write) {
+		throw NotImplementedException("Writing to HTTP files not implemented");
+	}
+
+	if (!buffer || nr_bytes <= 1) {
+		return;
+	}
+
+	// Initialize the write buffer if it is not already done
+	if (hfh.write_buffer.empty()) {
+		hfh.write_buffer.resize(hfh.WRITE_BUFFER_LEN);
+		hfh.write_buffer_idx = 0;
+	}
+
+	idx_t bytes_to_copy = nr_bytes;
+	idx_t buffer_offset = 0;
+
+	// Accumulate data into the write buffer
+	while (bytes_to_copy > 0) {
+		idx_t space_in_buffer = hfh.WRITE_BUFFER_LEN - hfh.write_buffer_idx;
+		idx_t copy_amount = MinValue<idx_t>(space_in_buffer, bytes_to_copy);
+
+		// Copy data to the write buffer
+		memcpy(hfh.write_buffer.data() + hfh.write_buffer_idx, (char *)buffer + buffer_offset, copy_amount);
+		hfh.write_buffer_idx += copy_amount;
+		bytes_to_copy -= copy_amount;
+		buffer_offset += copy_amount;
+
+		// std::cout << "Write buffer idx after write: " << hfh.write_buffer_idx << std::endl;
+
+		// If the buffer is full, send the data
+		if (hfh.write_buffer_idx == hfh.WRITE_BUFFER_LEN) {
+			// Perform the HTTP POST request
+			FlushBuffer(hfh);
+		}
+	}
+
+	// Update the file offset
+	hfh.file_offset += nr_bytes;
+
+	// std::cout << "Completed Write operation. Total bytes written: " << nr_bytes << std::endl;
+}
+
+void HTTPFileSystem::FlushBuffer(HTTPFileHandle &hfh) {
+	// If no data in buffer, return
+	if (hfh.write_buffer_idx <= 1) {
+		return;
+	}
+
+	// Prepare the URL and headers for the HTTP POST request
+	string path, proto_host_port;
+	ParseUrl(hfh.path, path, proto_host_port);
+
+	HeaderMap header_map;
+	auto headers = InitializeHeaders(header_map, hfh.http_params);
+
+	// Define the request lambda
+	std::function<duckdb_httplib_openssl::Result(void)> request([&]() {
+		auto client = GetClient(hfh.http_params, proto_host_port.c_str(), &hfh);
+		duckdb_httplib_openssl::Request req;
+		req.method = "POST";
+		req.path = path;
+		req.headers = *headers;
+		req.headers.emplace("Content-Type", "application/octet-stream");
+
+		// Prepare the request body from the write buffer
+		req.body = std::string(reinterpret_cast<const char *>(hfh.write_buffer.data()), hfh.write_buffer_idx);
+
+		// std::cout << "Sending request with " << hfh.write_buffer_idx << " bytes of data" << std::endl;
+
+		return client->send(req);
+	});
+
+	// Perform the HTTP POST request and handle retries
+	auto response = RunRequestWithRetry(request, hfh.path, "POST", hfh.http_params);
+
+	// Check if the response was successful (HTTP 200-299 status code)
+	if (response->code < 200 || response->code >= 300) {
+		throw HTTPException(*response, "HTTP POST request failed to '%s' with status code: %d", hfh.path.c_str(),
+		                    response->code);
+	}
+
+	// Reset the write buffer index after sending data
+	hfh.write_buffer_idx = 0;
+}
+
+void HTTPFileHandle::Close() {
+	auto &fs = (HTTPFileSystem &)file_system;
+	if (flags.OpenForWriting()) {
+		fs.FlushBuffer(*this);
+	}
 }
 
 int64_t HTTPFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
@@ -829,5 +924,15 @@ ResponseWrapper::ResponseWrapper(duckdb_httplib_openssl::Response &res, string &
 	body = res.body;
 }
 
-HTTPFileHandle::~HTTPFileHandle() = default;
+HTTPFileHandle::~HTTPFileHandle() {
+	if (Exception::UncaughtException()) {
+		return;
+	}
+
+	try {
+		Close();
+	} catch (...) { // NOLINT
+	}
+}
+
 } // namespace duckdb

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -804,4 +804,8 @@ void HTTPFileSystem::Verify() {
 	// TODO
 }
 
+void HTTPFileHandle::AddHeaders(HeaderMap &map) {
+	// Add any necessary headers here. For now, this is a stub to resolve the linker error.
+}
+
 } // namespace duckdb

--- a/extension/httpfs/httpfs_extension.cpp
+++ b/extension/httpfs/httpfs_extension.cpp
@@ -39,6 +39,9 @@ static void LoadInternal(DatabaseInstance &instance) {
 	                          LogicalType::BOOLEAN, Value(false));
 	config.AddExtensionOption("ca_cert_file", "Path to a custom certificate file for self-signed certificates.",
 	                          LogicalType::VARCHAR, Value(""));
+        // Experimental HTTPFS write
+	config.AddExtensionOption("enable_http_write", "Enable HTTPFS POST write", LogicalType::BOOLEAN, Value(false));
+
 	// Global S3 config
 	config.AddExtensionOption("s3_region", "S3 Region", LogicalType::VARCHAR, Value("us-east-1"));
 	config.AddExtensionOption("s3_access_key_id", "S3 Access Key ID", LogicalType::VARCHAR);

--- a/extension/httpfs/include/httpfs.hpp
+++ b/extension/httpfs/include/httpfs.hpp
@@ -9,6 +9,7 @@
 #include "duckdb/main/client_data.hpp"
 #include "http_metadata_cache.hpp"
 #include "httpfs_client.hpp"
+#include "duckdb/common/http_util.hpp"
 
 #include <mutex>
 
@@ -21,48 +22,13 @@ using HeaderMap = case_insensitive_map_t<string>;
 // avoid including httplib in header
 struct ResponseWrapper {
 public:
-	explicit ResponseWrapper(duckdb_httplib_openssl::Response &res, string &original_url);
+	explicit ResponseWrapper(HTTPResponse &res, string &original_url);
 	int code;
 	string error;
 	HeaderMap headers;
 	string http_url;
 	string body;
 };
-
-struct HTTPParams {
-
-	static constexpr uint64_t DEFAULT_TIMEOUT_SECONDS = 30; // 30 sec
-	static constexpr uint64_t DEFAULT_RETRIES = 3;
-	static constexpr uint64_t DEFAULT_RETRY_WAIT_MS = 100;
-	static constexpr float DEFAULT_RETRY_BACKOFF = 4;
-	static constexpr bool DEFAULT_FORCE_DOWNLOAD = false;
-	static constexpr bool DEFAULT_ENABLE_HTTP_WRITE = false;
-	static constexpr bool DEFAULT_KEEP_ALIVE = true;
-	static constexpr bool DEFAULT_ENABLE_SERVER_CERT_VERIFICATION = false;
-	static constexpr uint64_t DEFAULT_HF_MAX_PER_PAGE = 0;
-
-	uint64_t timeout = DEFAULT_TIMEOUT_SECONDS; // seconds component of a timeout
-	uint64_t timeout_usec = 0;                  // usec component of a timeout
-	uint64_t retries = DEFAULT_RETRIES;
-	uint64_t retry_wait_ms = DEFAULT_RETRY_WAIT_MS;
-	float retry_backoff = DEFAULT_RETRY_BACKOFF;
-	bool force_download = DEFAULT_FORCE_DOWNLOAD;
-	bool enable_http_write = DEFAULT_ENABLE_HTTP_WRITE;
-	bool keep_alive = DEFAULT_KEEP_ALIVE;
-	bool enable_server_cert_verification = DEFAULT_ENABLE_SERVER_CERT_VERIFICATION;
-	idx_t hf_max_per_page = DEFAULT_HF_MAX_PER_PAGE;
-
-	string ca_cert_file;
-	string http_proxy;
-	idx_t http_proxy_port;
-	string http_proxy_username;
-	string http_proxy_password;
-	string bearer_token;
-	unordered_map<string, string> extra_headers;
-
-	static HTTPParams ReadFrom(optional_ptr<FileOpener> opener, optional_ptr<FileOpenerInfo> info);
-};
-
 
 class HTTPClientCache {
 public:

--- a/extension/httpfs/include/httpfs.hpp
+++ b/extension/httpfs/include/httpfs.hpp
@@ -42,6 +42,7 @@ struct HTTPParams {
 	static constexpr uint64_t DEFAULT_RETRY_WAIT_MS = 100;
 	static constexpr float DEFAULT_RETRY_BACKOFF = 4;
 	static constexpr bool DEFAULT_FORCE_DOWNLOAD = false;
+	static constexpr bool DEFAULT_ENABLE_HTTP_WRITE = false;
 	static constexpr bool DEFAULT_KEEP_ALIVE = true;
 	static constexpr bool DEFAULT_ENABLE_SERVER_CERT_VERIFICATION = false;
 	static constexpr uint64_t DEFAULT_HF_MAX_PER_PAGE = 0;
@@ -52,6 +53,7 @@ struct HTTPParams {
 	uint64_t retry_wait_ms = DEFAULT_RETRY_WAIT_MS;
 	float retry_backoff = DEFAULT_RETRY_BACKOFF;
 	bool force_download = DEFAULT_FORCE_DOWNLOAD;
+	bool enable_http_write = DEFAULT_ENABLE_HTTP_WRITE;
 	bool keep_alive = DEFAULT_KEEP_ALIVE;
 	bool enable_server_cert_verification = DEFAULT_ENABLE_SERVER_CERT_VERIFICATION;
 	idx_t hf_max_per_page = DEFAULT_HF_MAX_PER_PAGE;
@@ -116,6 +118,12 @@ public:
 	duckdb::unique_ptr<data_t[]> read_buffer;
 	constexpr static idx_t READ_BUFFER_LEN = 1000000;
 
+        // duckdb::unique_ptr<data_t[]> write_buffer;
+	constexpr static idx_t WRITE_BUFFER_LEN = 1000000;
+	std::vector<data_t> write_buffer; // Use a vector instead of a fixed-size array
+	idx_t write_buffer_idx = 0;       // Tracks the current index in the buffer
+	idx_t current_buffer_len;
+
 	shared_ptr<HTTPState> state;
 
 	void AddHeaders(HeaderMap &map);
@@ -126,8 +134,7 @@ public:
 	void StoreClient(unique_ptr<duckdb_httplib_openssl::Client> client);
 
 public:
-	void Close() override {
-	}
+	void Close() override;
 
 protected:
 	//! Create a new Client
@@ -139,6 +146,8 @@ private:
 };
 
 class HTTPFileSystem : public FileSystem {
+    friend HTTPFileHandle;
+
 public:
 	static duckdb::unique_ptr<duckdb_httplib_openssl::Client>
 	GetClient(const HTTPParams &http_params, const char *proto_host_port, optional_ptr<HTTPFileHandle> hfs);
@@ -211,6 +220,7 @@ private:
 	// Global cache
 	mutex global_cache_lock;
 	duckdb::unique_ptr<HTTPMetadataCache> global_metadata_cache;
+	void FlushBuffer(HTTPFileHandle &hfh);
 };
 
 } // namespace duckdb

--- a/extension/httpfs/include/httpfs_client.hpp
+++ b/extension/httpfs/include/httpfs_client.hpp
@@ -19,6 +19,9 @@ struct HTTPFSParams : public HTTPParams {
 	idx_t hf_max_per_page = DEFAULT_HF_MAX_PER_PAGE;
 	bool enable_server_cert_verification = DEFAULT_ENABLE_SERVER_CERT_VERIFICATION;
 	string ca_cert_file;
+	bool enable_http_write = false;
+	string bearer_token;
+	shared_ptr<HTTPState> state;
 };
 
 class HTTPFSUtil : public HTTPUtil {

--- a/extension/httpfs/include/httpfs_client.hpp
+++ b/extension/httpfs/include/httpfs_client.hpp
@@ -9,31 +9,30 @@ struct FileOpenerInfo;
 class HTTPState;
 
 struct HTTPFSParams : public HTTPParams {
-	HTTPFSParams(HTTPUtil &http_util) : HTTPParams(http_util) {
-	}
+	using HTTPParams::HTTPParams;
 
-	static constexpr bool DEFAULT_ENABLE_SERVER_CERT_VERIFICATION = false;
-	static constexpr uint64_t DEFAULT_HF_MAX_PER_PAGE = 0;
 	static constexpr bool DEFAULT_FORCE_DOWNLOAD = false;
+	static constexpr uint64_t DEFAULT_HF_MAX_PER_PAGE = 0;
+	static constexpr bool DEFAULT_ENABLE_SERVER_CERT_VERIFICATION = true;
 
 	bool force_download = DEFAULT_FORCE_DOWNLOAD;
-	bool enable_server_cert_verification = DEFAULT_ENABLE_SERVER_CERT_VERIFICATION;
 	idx_t hf_max_per_page = DEFAULT_HF_MAX_PER_PAGE;
+	bool enable_server_cert_verification = DEFAULT_ENABLE_SERVER_CERT_VERIFICATION;
 	string ca_cert_file;
-	string bearer_token;
-	shared_ptr<HTTPState> state;
 };
 
-class HTTPFSUtil : public HTTPUtil {
+class HTTPClient {
 public:
-	unique_ptr<HTTPParams> InitializeParameters(optional_ptr<FileOpener> opener,
-	                                            optional_ptr<FileOpenerInfo> info) override;
-	unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
+	virtual ~HTTPClient() = default;
 
-	static unordered_map<string, string> ParseGetParameters(const string &text);
-	static shared_ptr<HTTPUtil> GetHTTPUtil(optional_ptr<FileOpener> opener);
-
-	string GetName() const override;
+	virtual duckdb::unique_ptr<HTTPResponse> Get(const string &url, HTTPHeaders &headers, idx_t file_offset,
+	                                             char *buffer_out, idx_t buffer_out_len);
+	virtual duckdb::unique_ptr<HTTPResponse> Head(const string &url, HTTPHeaders &headers);
+	virtual duckdb::unique_ptr<HTTPResponse> Post(const string &url, HTTPHeaders &headers, const char *buffer_in,
+	                                              idx_t buffer_in_len, string &result_p, string &params_p);
+	virtual duckdb::unique_ptr<HTTPResponse> Put(const string &url, HTTPHeaders &headers, const char *buffer_in,
+	                                             idx_t buffer_in_len, const string &params);
+	virtual duckdb::unique_ptr<HTTPResponse> Delete(const string &url, HTTPHeaders &headers);
 };
 
 } // namespace duckdb

--- a/extension/httpfs/include/httpfs_client.hpp
+++ b/extension/httpfs/include/httpfs_client.hpp
@@ -21,18 +21,16 @@ struct HTTPFSParams : public HTTPParams {
 	string ca_cert_file;
 };
 
-class HTTPClient {
+class HTTPFSUtil : public HTTPUtil {
 public:
-	virtual ~HTTPClient() = default;
+	unique_ptr<HTTPParams> InitializeParameters(optional_ptr<FileOpener> opener,
+	                                            optional_ptr<FileOpenerInfo> info) override;
+	unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
 
-	virtual duckdb::unique_ptr<HTTPResponse> Get(const string &url, HTTPHeaders &headers, idx_t file_offset,
-	                                             char *buffer_out, idx_t buffer_out_len);
-	virtual duckdb::unique_ptr<HTTPResponse> Head(const string &url, HTTPHeaders &headers);
-	virtual duckdb::unique_ptr<HTTPResponse> Post(const string &url, HTTPHeaders &headers, const char *buffer_in,
-	                                              idx_t buffer_in_len, string &result_p, string &params_p);
-	virtual duckdb::unique_ptr<HTTPResponse> Put(const string &url, HTTPHeaders &headers, const char *buffer_in,
-	                                             idx_t buffer_in_len, const string &params);
-	virtual duckdb::unique_ptr<HTTPResponse> Delete(const string &url, HTTPHeaders &headers);
+	static unordered_map<string, string> ParseGetParameters(const string &text);
+	static shared_ptr<HTTPUtil> GetHTTPUtil(optional_ptr<FileOpener> opener);
+
+	string GetName() const override;
 };
 
 } // namespace duckdb

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -1016,7 +1016,7 @@ HTTPException S3FileSystem::GetS3Error(S3AuthParams &s3_auth_params, const HTTPR
 	if (response.status == HTTPStatusCode::Forbidden_403) {
 		extra_text = GetS3AuthError(s3_auth_params);
 	}
-	auto status_message = HTTPFSUtil::GetStatusMessage(response.status);
+	auto status_message = HTTPUtil::GetStatusMessage(response.status);
 	throw HTTPException(response, "HTTP GET error reading '%s' in region '%s' (HTTP %d %s)%s", url,
 	                    s3_auth_params.region, response.status, status_message, extra_text);
 }

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -1044,16 +1044,15 @@ string AWSListObjectV2::Request(string &path, HTTPParams &http_params, S3AuthPar
 		req_params += "&delimiter=%2F";
 	}
 
-	string listobjectv2_url = req_path + "?" + req_params;
+	string listobjectv2_url = parsed_url.http_proto + parsed_url.host + req_path + "?" + req_params;
 
 	auto header_map =
 	    create_s3_header(req_path, req_params, parsed_url.host, "s3", "GET", s3_auth_params, "", "", "", "");
 
 	// Get requests use fresh connection
-	string full_host = parsed_url.http_proto + parsed_url.host;
 	std::stringstream response;
 	GetRequestInfo get_request(
-	    full_host, listobjectv2_url, header_map, http_params,
+	    listobjectv2_url, header_map, http_params,
 	    [&](const HTTPResponse &response) {
 		    if (static_cast<int>(response.status) >= 400) {
 			    string trimmed_path = path;

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -9,7 +9,7 @@ else ()
 endif()
 
 duckdb_extension_load(httpfs
-	DONT_LINK
+###	DONT_LINK
 	SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
 	INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/extension/httpfs/include
 	${LOAD_HTTPFS_TESTS}


### PR DESCRIPTION
This (humble) PR implements basic write (POST) support for the HTTPFS extension - similarly to the S3 features.

The implementation is intentionally simple, extending existing methods without introducing new dependencies.
The scope can be extended to be generally compatible with Web APIs when it comes to file management.

The current validation uses a very generic and simple [backend service](https://gist.github.com/lmangani/57550cce344e41608782cc4021fda39f) handling vanilla GET/POST requests and generally compatible with the ClickHouse url function, with nothing special to it. The [demo backend](https://github.com/lmangani/duckdb-urlengine) is also deployed in [public](https://github.com/lmangani/duckdb-urlengine) and open for testing, where the /path is the unique key to set/get data.


```sql
--- For backwards compatibility, WRITE support is disabled by default
D SET enable_http_write = 1;

--- COPY to remote servers using FORMAT
D SET enable_http_write = true;
D COPY (SELECT version() as version, 9999 as number) TO 'https://duckserver.glitch.me/.json' (FORMAT JSON);
D SELECT * FROM read_json_auto('https://duckserver.glitch.me/test9999');
┌─────────┬────────┐
│ version │ number │
│ varchar │ int64  │
├─────────┼────────┤
│ v1.1.0  │   9999 │
└─────────┴────────┘

--- COPY to remote servers using FORMAT auto-detection via extension
D COPY (SELECT version() as version, 9999 as number) TO 'https://duckserver.glitch.me/test.parquet';
D SELECT * FROM read_parquet('https://duckserver.glitch.me/test.parquet');
┌─────────┬────────┐
│ version │ number │
│ varchar │ int64  │
├─────────┼────────┤
│ v1.2.0  │   9999 │
└─────────┴────────┘

D SELECT * FROM parquet_schema('https://duckserver.glitch.me/test.parquet');
┌──────────────────────┬───────────────┬────────────┬─────────────┬───┬────────────────┬───────┬───────────┬──────────┬──────────────┐
│      file_name       │     name      │    type    │ type_length │ … │ converted_type │ scale │ precision │ field_id │ logical_type │
│       varchar        │    varchar    │  varchar   │   varchar   │   │    varchar     │ int64 │   int64   │  int64   │   varchar    │
├──────────────────────┼───────────────┼────────────┼─────────────┼───┼────────────────┼───────┼───────────┼──────────┼──────────────┤
│ https://duckserver…  │ duckdb_schema │            │             │ … │                │       │           │          │              │
│ https://duckserver…  │ version       │ BYTE_ARRAY │             │ … │ UTF8           │       │           │          │              │
│ https://duckserver…  │ number        │ INT32      │             │ … │ INT_32         │       │           │          │              │
├──────────────────────┴───────────────┴────────────┴─────────────┴───┴────────────────┴───────┴───────────┴──────────┴──────────────┤
│ 3 rows                                                                                                        11 columns (9 shown) │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```