### PR TITLE
Implement `RemoveFile` & `RemoveDirectory` for s3fs

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,33 @@
+---
+BasedOnStyle: LLVM
+SortIncludes: false
+TabWidth: 4
+IndentWidth: 4
+ColumnLimit: 120
+AllowShortFunctionsOnASingleLine: false
+---
+UseTab: ForIndentation
+DerivePointerAlignment: false
+PointerAlignment: Right
+AlignConsecutiveMacros: true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AlignAfterOpenBracket: Align
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+AllowShortLambdasOnASingleLine: Inline
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakTemplateDeclarations: Yes
+IncludeBlocks: Regroup
+Language: Cpp
+AccessModifierOffset: -4
+---
+Language: Java
+SpaceAfterCStyleCast: true
+---

--- a/extension/httpfs/http_state.cpp
+++ b/extension/httpfs/http_state.cpp
@@ -52,6 +52,7 @@ void HTTPState::Reset() {
 	get_count = 0;
 	put_count = 0;
 	post_count = 0;
+	delete_count = 0;
 	total_bytes_received = 0;
 	total_bytes_sent = 0;
 
@@ -78,6 +79,7 @@ void HTTPState::WriteProfilingInformation(std::ostream &ss) {
 	string get = "#GET: " + to_string(get_count);
 	string put = "#PUT: " + to_string(put_count);
 	string post = "#POST: " + to_string(post_count);
+	string del = "#DELETE: " + to_string(delete_count);
 
 	constexpr idx_t TOTAL_BOX_WIDTH = 39;
 	ss << "┌─────────────────────────────────────┐\n";
@@ -90,6 +92,7 @@ void HTTPState::WriteProfilingInformation(std::ostream &ss) {
 	ss << "││" + QueryProfiler::DrawPadded(get, TOTAL_BOX_WIDTH - 4) + "││\n";
 	ss << "││" + QueryProfiler::DrawPadded(put, TOTAL_BOX_WIDTH - 4) + "││\n";
 	ss << "││" + QueryProfiler::DrawPadded(post, TOTAL_BOX_WIDTH - 4) + "││\n";
+	ss << "││" + QueryProfiler::DrawPadded(del, TOTAL_BOX_WIDTH - 4) + "││\n";
 	ss << "│└───────────────────────────────────┘│\n";
 	ss << "└─────────────────────────────────────┘\n";
 }

--- a/extension/httpfs/include/http_state.hpp
+++ b/extension/httpfs/include/http_state.hpp
@@ -79,14 +79,15 @@ public:
 	static shared_ptr<HTTPState> TryGetState(optional_ptr<FileOpener> opener);
 
 	bool IsEmpty() {
-		return head_count == 0 && get_count == 0 && put_count == 0 && post_count == 0 && total_bytes_received == 0 &&
-		       total_bytes_sent == 0;
+		return head_count == 0 && get_count == 0 && put_count == 0 && post_count == 0 && delete_count == 0 &&
+		       total_bytes_received == 0 && total_bytes_sent == 0;
 	}
 
 	atomic<idx_t> head_count {0};
 	atomic<idx_t> get_count {0};
 	atomic<idx_t> put_count {0};
 	atomic<idx_t> post_count {0};
+	atomic<idx_t> delete_count {0};
 	atomic<idx_t> total_bytes_received {0};
 	atomic<idx_t> total_bytes_sent {0};
 

--- a/extension/httpfs/include/httpfs.hpp
+++ b/extension/httpfs/include/httpfs.hpp
@@ -168,6 +168,8 @@ public:
 	virtual duckdb::unique_ptr<ResponseWrapper> PutRequest(FileHandle &handle, string url, HeaderMap header_map,
 	                                                       char *buffer_in, idx_t buffer_in_len, string params = "");
 
+	virtual duckdb::unique_ptr<ResponseWrapper> DeleteRequest(FileHandle &handle, string url, HeaderMap header_map);
+
 	// FS methods
 	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 	int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;

--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -186,6 +186,7 @@ public:
 	duckdb::unique_ptr<ResponseWrapper> PutRequest(FileHandle &handle, string s3_url, HeaderMap header_map,
 	                                               char *buffer_in, idx_t buffer_in_len,
 	                                               string http_params = "") override;
+	duckdb::unique_ptr<ResponseWrapper> DeleteRequest(FileHandle &handle, string s3_url, HeaderMap header_map) override;
 
 	static void Verify();
 
@@ -193,6 +194,8 @@ public:
 	bool OnDiskFile(FileHandle &handle) override {
 		return false;
 	}
+	void RemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr) override;
+	void RemoveDirectory(const string &directory, optional_ptr<FileOpener> opener = nullptr) override;
 	void FileSync(FileHandle &handle) override;
 	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 

--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -19,6 +19,8 @@
 #include <exception>
 #include <iostream>
 
+#undef RemoveDirectory
+
 namespace duckdb {
 
 struct S3AuthParams {

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -875,8 +875,8 @@ void S3FileSystem::RemoveDirectory(const string &path, optional_ptr<FileOpener> 
 		    try {
 			    this->RemoveFile(file, opener);
 		    } catch (IOException &e) {
-			    std::string_view error = e.what();
-			    if (error.find("No such file or directory") != std::string::npos) {
+				string errmsg(e.what());
+			    if (errmsg.find("No such file or directory") != std::string::npos) {
 				    return;
 			    }
 			    throw;


### PR DESCRIPTION
Support S3 files deletion via `DELETE` request. This feature allow systems leveraging Duckdb, such as [pg_mooncake](https://github.com/Mooncake-Labs/pg_mooncake/), to fully manage their storage files, including deletion.

fix #20 