### PR TITLE
add aws secret type

### DIFF
--- a/extension/httpfs/create_secret_functions.cpp
+++ b/extension/httpfs/create_secret_functions.cpp
@@ -7,6 +7,7 @@ namespace duckdb {
 
 void CreateS3SecretFunctions::Register(DatabaseInstance &instance) {
 	RegisterCreateSecretFunction(instance, "s3");
+	RegisterCreateSecretFunction(instance, "aws");
 	RegisterCreateSecretFunction(instance, "r2");
 	RegisterCreateSecretFunction(instance, "gcs");
 }
@@ -39,6 +40,8 @@ unique_ptr<BaseSecret> CreateS3SecretFunctions::CreateSecretFunctionInternal(Cli
 		} else if (input.type == "gcs") {
 			scope.push_back("gcs://");
 			scope.push_back("gs://");
+		} else if (input.type == "aws") {
+			scope.push_back("");
 		} else {
 			throw InternalException("Unknown secret type found in httpfs extension: '%s'", input.type);
 		}

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -156,7 +156,7 @@ S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerI
 		return result;
 	}
 
-	const char *secret_types[] = {"s3", "r2", "gcs"};
+	const char *secret_types[] = {"s3", "r2", "gcs", "aws"};
 	KeyValueSecretReader secret_reader(*opener, info, secret_types, 3);
 
 	// These settings we just set or leave to their S3AuthParams default value
@@ -803,7 +803,7 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 			auto context = opener->TryGetClientContext();
 			if (context) {
 				auto transaction = CatalogTransaction::GetSystemCatalogTransaction(*context);
-				for (const string type : {"s3", "r2", "gcs"}) {
+				for (const string type : {"s3", "r2", "gcs", "aws"}) {
 					auto res = context->db->GetSecretManager().LookupSecret(transaction, path, type);
 					if (res.HasMatch()) {
 						refreshed_secret |= CreateS3SecretFunctions::TryRefreshS3Secret(*context, *res.secret_entry);

--- a/test/sql/secret/secret_aws.test
+++ b/test/sql/secret/secret_aws.test
@@ -1,0 +1,47 @@
+# name: test/sql/secret/secret_aws.test
+# description: Tests secret refreshing
+# group: [secrets]
+
+require-env S3_TEST_SERVER_AVAILABLE 1
+
+require-env AWS_DEFAULT_REGION
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+require-env DUCKDB_S3_ENDPOINT
+
+require-env DUCKDB_S3_USE_SSL
+
+require httpfs
+
+require parquet
+
+statement ok
+SET enable_logging=true
+
+statement ok
+set s3_use_ssl='${DUCKDB_S3_USE_SSL}'
+
+statement ok
+set s3_endpoint='${DUCKDB_S3_ENDPOINT}'
+
+statement ok
+set s3_region='${AWS_DEFAULT_REGION}'
+
+# Create some test data
+statement ok
+CREATE SECRET s1 (
+    TYPE AWS,
+    KEY_ID '${AWS_ACCESS_KEY_ID}',
+    SECRET '${AWS_SECRET_ACCESS_KEY}'
+)
+
+statement ok
+copy (select 1 as a) to 's3://test-bucket/test-file.parquet'
+
+query I
+FROM "s3://test-bucket/test-file.parquet"
+----
+1


### PR DESCRIPTION
adds a new alias for the `s3` secret type `aws`, it does the exact same thing, but is semantically more correct when these credentials are used for non-s3 purposes.

They might diverge later as aws type secrets could contain other fields that are irrelevant for s3


### TODO
- autoloading for this type in duckdb