### PR TITLE
HTTP retry on 503 status code

### DIFF
--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -157,7 +157,6 @@ HTTPFileSystem::RunRequestWithRetry(const std::function<duckdb_httplib_openssl::
 			case 418: // Server is pretending to be a teapot
 			case 429: // Rate limiter hit
 			case 500: // Server has error
-			case 503: // Server has error
 			case 504: // Server has error
 				break;
 			default:


### PR DESCRIPTION
I saw discussion thread: https://github.com/duckdb/duckdb/issues/6153, which mentions 503 is a status code which indicates slow response and should be retried.

Copy from AWS official doc:
```
If you are not using an AWS SDK, you should implement retry logic when receiving the HTTP 503 error.
```
Ref: https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance-design-patterns.html#optimizing-performance-timeouts-retries

Other reference docs: https://docs.digitalocean.com/products/spaces/details/limits/#:~:text=Applications%20should%20retry%20with%20exponential%20backoff%20on%20503%20Slow%20Down%20errors.
(more in the discussion thread)