### PR TITLE
Read etag, last_modified and file size during S3 glob and use that information when constructing the HTTPFileHandle to skip doing the head request

### DIFF
--- a/extension/httpfs/hffs.cpp
+++ b/extension/httpfs/hffs.cpp
@@ -288,19 +288,19 @@ unique_ptr<ResponseWrapper> HuggingFaceFileSystem::GetRangeRequest(FileHandle &h
 	return HTTPFileSystem::GetRangeRequest(handle, http_url, header_map, file_offset, buffer_out, buffer_out_len);
 }
 
-unique_ptr<HTTPFileHandle> HuggingFaceFileSystem::CreateHandle(const string &path, FileOpenFlags flags,
+unique_ptr<HTTPFileHandle> HuggingFaceFileSystem::CreateHandle(const OpenFileInfo &file, FileOpenFlags flags,
                                                                optional_ptr<FileOpener> opener) {
 	D_ASSERT(flags.Compression() == FileCompressionType::UNCOMPRESSED);
 
-	auto parsed_url = HFUrlParse(path);
+	auto parsed_url = HFUrlParse(file.path);
 
 	FileOpenerInfo info;
-	info.file_path = path;
+	info.file_path = file.path;
 
 	auto params = HTTPParams::ReadFrom(opener, info);
-	SetParams(params, path, opener);
+	SetParams(params, file.path, opener);
 
-	return duckdb::make_uniq<HFFileHandle>(*this, std::move(parsed_url), path, flags, params);
+	return duckdb::make_uniq<HFFileHandle>(*this, std::move(parsed_url), file, flags, params);
 }
 
 void HuggingFaceFileSystem::SetParams(HTTPParams &params, const string &path, optional_ptr<FileOpener> opener) {

--- a/extension/httpfs/hffs.cpp
+++ b/extension/httpfs/hffs.cpp
@@ -201,7 +201,7 @@ end:
 // - hf://datasets/lhoestq/demo1/default/train/*.parquet
 // - hf://datasets/lhoestq/demo1/*/train/file_[abc].parquet
 // - hf://datasets/lhoestq/demo1/**/train/*.parquet
-vector<string> HuggingFaceFileSystem::Glob(const string &path, FileOpener *opener) {
+vector<OpenFileInfo> HuggingFaceFileSystem::Glob(const string &path, FileOpener *opener) {
 	// Ensure the glob pattern is a valid HF url
 	auto parsed_glob_url = HFUrlParse(path);
 	auto first_wildcard_pos = parsed_glob_url.path.find_first_of("*[\\");
@@ -251,7 +251,7 @@ vector<string> HuggingFaceFileSystem::Glob(const string &path, FileOpener *opene
 	}
 
 	vector<string> pattern_splits = StringUtil::Split(parsed_glob_url.path, "/");
-	vector<string> result;
+	vector<OpenFileInfo> result;
 	for (const auto &file : files) {
 
 		vector<string> file_splits = StringUtil::Split(file, "/");

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -462,23 +462,58 @@ unique_ptr<ResponseWrapper> HTTPFileSystem::GetRangeRequest(FileHandle &handle, 
 	return response;
 }
 
-HTTPFileHandle::HTTPFileHandle(FileSystem &fs, const string &path, FileOpenFlags flags, const HTTPParams &http_params)
-    : FileHandle(fs, path, flags), http_params(http_params), flags(flags), length(0), buffer_available(0),
-      buffer_idx(0), file_offset(0), buffer_start(0), buffer_end(0) {
+void TimestampToTimeT(timestamp_t timestamp, time_t &result) {
+	auto components = Timestamp::GetComponents(timestamp);
+	struct tm tm {};
+	tm.tm_year = components.year - 1900;
+	tm.tm_mon = components.month - 1;
+	tm.tm_mday = components.day;
+	tm.tm_hour = components.hour;
+	tm.tm_min = components.minute;
+	tm.tm_sec = components.second;
+	tm.tm_isdst = 0;
+	result = mktime(&tm);
 }
 
-unique_ptr<HTTPFileHandle> HTTPFileSystem::CreateHandle(const string &path, FileOpenFlags flags,
+HTTPFileHandle::HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags, const HTTPParams &http_params)
+    : FileHandle(fs, file.path, flags), http_params(http_params), flags(flags), length(0), buffer_available(0),
+      buffer_idx(0), file_offset(0), buffer_start(0), buffer_end(0) {
+	// check if the handle has extended properties that can be set directly in the handle
+	// if we have these properties we don't need to do a head request to obtain them later
+	if (file.extended_info) {
+		auto &info = file.extended_info->options;
+		auto lm_entry = info.find("last_modified");
+		if (lm_entry != info.end()) {
+			TimestampToTimeT(lm_entry->second.GetValue<timestamp_t>(), last_modified);
+		}
+		auto etag_entry = info.find("etag");
+		if (etag_entry != info.end()) {
+			etag = StringValue::Get(etag_entry->second);
+		}
+		auto fs_entry = info.find("file_size");
+		if (fs_entry != info.end()) {
+			length = fs_entry->second.GetValue<uint64_t>();
+		}
+		if (lm_entry != info.end() && etag_entry != info.end() && fs_entry != info.end()) {
+			// we found all relevant entries (last_modified, etag and file size)
+			// skip head request
+			initialized = true;
+		}
+	}
+}
+
+unique_ptr<HTTPFileHandle> HTTPFileSystem::CreateHandle(const OpenFileInfo &file, FileOpenFlags flags,
                                                         optional_ptr<FileOpener> opener) {
 	D_ASSERT(flags.Compression() == FileCompressionType::UNCOMPRESSED);
 
 	FileOpenerInfo info;
-	info.file_path = path;
+	info.file_path = file.path;
 	auto params = HTTPParams::ReadFrom(opener, info);
 
 	auto secret_manager = FileOpener::TryGetSecretManager(opener);
 	auto transaction = FileOpener::TryGetCatalogTransaction(opener);
 	if (secret_manager && transaction) {
-		auto secret_match = secret_manager->LookupSecret(*transaction, path, "bearer");
+		auto secret_match = secret_manager->LookupSecret(*transaction, file.path, "bearer");
 
 		if (secret_match.HasMatch()) {
 			const auto &kv_secret = dynamic_cast<const KeyValueSecret &>(*secret_match.secret_entry->secret);
@@ -486,23 +521,21 @@ unique_ptr<HTTPFileHandle> HTTPFileSystem::CreateHandle(const string &path, File
 		}
 	}
 
-	auto result = duckdb::make_uniq<HTTPFileHandle>(*this, path, flags, params);
-
+	auto result = duckdb::make_uniq<HTTPFileHandle>(*this, file, flags, params);
 	auto client_context = FileOpener::TryGetClientContext(opener);
 	if (client_context && ClientConfig::GetConfig(*client_context).enable_http_logging) {
 		result->http_logger = client_context->client_data->http_logger.get();
 	}
-
 	return result;
 }
 
-unique_ptr<FileHandle> HTTPFileSystem::OpenFile(const string &path, FileOpenFlags flags,
+unique_ptr<FileHandle> HTTPFileSystem::OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,
                                                 optional_ptr<FileOpener> opener) {
 	D_ASSERT(flags.Compression() == FileCompressionType::UNCOMPRESSED);
 
 	if (flags.ReturnNullIfNotExists()) {
 		try {
-			auto handle = CreateHandle(path, flags, opener);
+			auto handle = CreateHandle(file, flags, opener);
 			handle->Initialize(opener);
 			return std::move(handle);
 		} catch (...) {
@@ -510,7 +543,7 @@ unique_ptr<FileHandle> HTTPFileSystem::OpenFile(const string &path, FileOpenFlag
 		}
 	}
 
-	auto handle = CreateHandle(path, flags, opener);
+	auto handle = CreateHandle(file, flags, opener);
 	handle->Initialize(opener);
 	return std::move(handle);
 }
@@ -724,6 +757,53 @@ bool HTTPFileSystem::TryParseLastModifiedTime(const string &timestamp, time_t &r
 	return true;
 }
 
+void HTTPFileHandle::LoadFileInfo() {
+	if (initialized) {
+		// already initialized
+		return;
+	}
+	auto &hfs = file_system.Cast<HTTPFileSystem>();
+	auto res = hfs.HeadRequest(*this, path, {});
+	string range_length;
+
+	if (res->code != 200) {
+		if (flags.OpenForWriting() && res->code == 404) {
+			if (!flags.CreateFileIfNotExists() && !flags.OverwriteExistingFile()) {
+				throw IOException("Unable to open URL \"" + path +
+				                  "\" for writing: file does not exist and CREATE flag is not set");
+			}
+			length = 0;
+			return;
+		} else {
+			// HEAD request fail, use Range request for another try (read only one byte)
+			if (flags.OpenForReading() && res->code != 404) {
+				auto range_res = hfs.GetRangeRequest(*this, path, {}, 0, nullptr, 2);
+				if (range_res->code != 206 && range_res->code != 202 && range_res->code != 200) {
+					throw IOException("Unable to connect to URL \"%s\": %d (%s).", path, res->code, res->error);
+				}
+				auto range_find = range_res->headers["Content-Range"].find("/");
+				if (!(range_find == std::string::npos || range_res->headers["Content-Range"].size() < range_find + 1)) {
+					range_length = range_res->headers["Content-Range"].substr(range_find + 1);
+					if (range_length != "*") {
+						res = std::move(range_res);
+					}
+				}
+			} else {
+				// It failed again
+				throw HTTPException(*res, "Unable to connect to URL \"%s\": %s (%s).", res->http_url,
+				                    to_string(res->code), res->error);
+			}
+		}
+	}
+	if (!res->headers["Last-Modified"].empty()) {
+		HTTPFileSystem::TryParseLastModifiedTime(res->headers["Last-Modified"], last_modified);
+	}
+	if (!res->headers["Etag"].empty()) {
+		etag = res->headers["Etag"];
+	}
+	initialized = true;
+}
+
 void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 	auto &hfs = file_system.Cast<HTTPFileSystem>();
 	state = HTTPState::TryGetState(opener);
@@ -766,71 +846,16 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 	if (current_cache && flags.OpenForWriting()) {
 		current_cache->Erase(path);
 	}
-
-	auto res = hfs.HeadRequest(*this, path, {});
-	string range_length;
-
-	if (res->code != 200) {
-		if (flags.OpenForWriting() && res->code == 404) {
-			if (!flags.CreateFileIfNotExists() && !flags.OverwriteExistingFile()) {
-				throw IOException("Unable to open URL \"" + path +
-				                  "\" for writing: file does not exist and CREATE flag is not set");
-			}
-			length = 0;
-			return;
-		} else {
-			// HEAD request fail, use Range request for another try (read only one byte)
-			if (flags.OpenForReading() && res->code != 404) {
-				auto range_res = hfs.GetRangeRequest(*this, path, {}, 0, nullptr, 2);
-				if (range_res->code != 206 && range_res->code != 202 && range_res->code != 200) {
-					throw IOException("Unable to connect to URL \"%s\": %d (%s).", path, res->code, res->error);
-				}
-				auto range_find = range_res->headers["Content-Range"].find("/");
-				if (!(range_find == std::string::npos || range_res->headers["Content-Range"].size() < range_find + 1)) {
-					range_length = range_res->headers["Content-Range"].substr(range_find + 1);
-					if (range_length != "*") {
-						res = std::move(range_res);
-					}
-				}
-			} else {
-				// It failed again
-				throw HTTPException(*res, "Unable to connect to URL \"%s\": %s (%s).", res->http_url,
-				                    to_string(res->code), res->error);
-			}
-		}
-	}
+	LoadFileInfo();
 
 	// Initialize the read buffer now that we know the file exists
 	if (flags.OpenForReading()) {
 		read_buffer = duckdb::unique_ptr<data_t[]>(new data_t[READ_BUFFER_LEN]);
 	}
 
-	if (res->headers.find("Content-Length") == res->headers.end() || res->headers["Content-Length"].empty()) {
-		// There was no content-length header, we can not do range requests here, so we set the length to 0
-		length = 0;
-	} else {
-		try {
-			if (res->headers.find("Content-Range") == res->headers.end() || res->headers["Content-Range"].empty()) {
-				length = std::stoll(res->headers["Content-Length"]);
-			} else {
-				length = std::stoll(range_length);
-			}
-		} catch (std::invalid_argument &e) {
-			throw IOException("Invalid Content-Length header received: %s", res->headers["Content-Length"]);
-		} catch (std::out_of_range &e) {
-			throw IOException("Invalid Content-Length header received: %s", res->headers["Content-Length"]);
-		}
-	}
 	if (state && length == 0) {
 		FullDownload(hfs, should_write_cache);
 	}
-	if (!res->headers["Last-Modified"].empty()) {
-		HTTPFileSystem::TryParseLastModifiedTime(res->headers["Last-Modified"], last_modified);
-	}
-	if (!res->headers["Etag"].empty()) {
-		etag = res->headers["Etag"];
-	}
-
 	if (should_write_cache) {
 		current_cache->Insert(path, {length, last_modified, etag});
 	}

--- a/extension/httpfs/include/hffs.hpp
+++ b/extension/httpfs/include/hffs.hpp
@@ -45,7 +45,7 @@ public:
 	static void SetParams(HTTPParams &params, const string &path, optional_ptr<FileOpener> opener);
 
 protected:
-	duckdb::unique_ptr<HTTPFileHandle> CreateHandle(const string &path, FileOpenFlags flags,
+	duckdb::unique_ptr<HTTPFileHandle> CreateHandle(const OpenFileInfo &file, FileOpenFlags flags,
 	                                                optional_ptr<FileOpener> opener) override;
 
 	string ListHFRequest(ParsedHFUrl &url, HTTPParams &http_params, string &next_page_url,
@@ -56,9 +56,9 @@ class HFFileHandle : public HTTPFileHandle {
 	friend class HuggingFaceFileSystem;
 
 public:
-	HFFileHandle(FileSystem &fs, ParsedHFUrl hf_url, string http_url, FileOpenFlags flags,
+	HFFileHandle(FileSystem &fs, ParsedHFUrl hf_url, const OpenFileInfo &file, FileOpenFlags flags,
 	             const HTTPParams &http_params)
-	    : HTTPFileHandle(fs, std::move(http_url), flags, http_params), parsed_url(std::move(hf_url)) {
+	    : HTTPFileHandle(fs, file, flags, http_params), parsed_url(std::move(hf_url)) {
 	}
 	~HFFileHandle() override;
 

--- a/extension/httpfs/include/hffs.hpp
+++ b/extension/httpfs/include/hffs.hpp
@@ -22,7 +22,7 @@ class HuggingFaceFileSystem : public HTTPFileSystem {
 public:
 	~HuggingFaceFileSystem() override;
 
-	vector<string> Glob(const string &path, FileOpener *opener = nullptr) override;
+	vector<OpenFileInfo> Glob(const string &path, FileOpener *opener = nullptr) override;
 
 	duckdb::unique_ptr<ResponseWrapper> HeadRequest(FileHandle &handle, string hf_url, HeaderMap header_map) override;
 	duckdb::unique_ptr<ResponseWrapper> GetRequest(FileHandle &handle, string hf_url, HeaderMap header_map) override;

--- a/extension/httpfs/include/httpfs.hpp
+++ b/extension/httpfs/include/httpfs.hpp
@@ -151,10 +151,11 @@ public:
 	static void ParseUrl(string &url, string &path_out, string &proto_host_port_out);
 	duckdb::unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
 	                                        optional_ptr<FileOpener> opener = nullptr) final;
+	static bool TryParseLastModifiedTime(const string &timestamp, time_t &result);
 	static duckdb::unique_ptr<duckdb_httplib_openssl::Headers> InitializeHeaders(HeaderMap &header_map,
 	                                                                             const HTTPParams &http_params);
 
-	vector<string> Glob(const string &path, FileOpener *opener = nullptr) override {
+	vector<OpenFileInfo> Glob(const string &path, FileOpener *opener = nullptr) override {
 		return {path}; // FIXME
 	}
 

--- a/extension/httpfs/include/httpfs.hpp
+++ b/extension/httpfs/include/httpfs.hpp
@@ -87,7 +87,7 @@ class HTTPFileSystem;
 
 class HTTPFileHandle : public FileHandle {
 public:
-	HTTPFileHandle(FileSystem &fs, const string &path, FileOpenFlags flags, const HTTPParams &params);
+	HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags, const HTTPParams &params);
 	~HTTPFileHandle() override;
 	// This two-phase construction allows subclasses more flexible setup.
 	virtual void Initialize(optional_ptr<FileOpener> opener);
@@ -104,6 +104,7 @@ public:
 	idx_t length;
 	time_t last_modified;
 	string etag;
+	bool initialized = false;
 
 	// When using full file download, the full file will be written to a cached file handle
 	unique_ptr<CachedFileHandle> cached_file_handle;
@@ -138,6 +139,8 @@ public:
 protected:
 	//! Create a new Client
 	virtual unique_ptr<duckdb_httplib_openssl::Client> CreateClient(optional_ptr<ClientContext> client_context);
+	//! Perform a HEAD request to get the file info (if not yet loaded)
+	void LoadFileInfo();
 
 private:
 	//! Fully downloads a file
@@ -149,8 +152,6 @@ public:
 	static duckdb::unique_ptr<duckdb_httplib_openssl::Client>
 	GetClient(const HTTPParams &http_params, const char *proto_host_port, optional_ptr<HTTPFileHandle> hfs);
 	static void ParseUrl(string &url, string &path_out, string &proto_host_port_out);
-	duckdb::unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
-	                                        optional_ptr<FileOpener> opener = nullptr) final;
 	static bool TryParseLastModifiedTime(const string &timestamp, time_t &result);
 	static duckdb::unique_ptr<duckdb_httplib_openssl::Headers> InitializeHeaders(HeaderMap &header_map,
 	                                                                             const HTTPParams &http_params);
@@ -210,7 +211,13 @@ public:
 	optional_ptr<HTTPMetadataCache> GetGlobalCache();
 
 protected:
-	virtual duckdb::unique_ptr<HTTPFileHandle> CreateHandle(const string &path, FileOpenFlags flags,
+	unique_ptr<FileHandle> OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,
+															   optional_ptr<FileOpener> opener) override;
+	bool SupportsOpenFileExtended() const override {
+		return true;
+	}
+protected:
+	virtual duckdb::unique_ptr<HTTPFileHandle> CreateHandle(const OpenFileInfo &file, FileOpenFlags flags,
 	                                                        optional_ptr<FileOpener> opener);
 
 	static duckdb::unique_ptr<ResponseWrapper>

--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -111,9 +111,9 @@ class S3FileHandle : public HTTPFileHandle {
 	friend class S3FileSystem;
 
 public:
-	S3FileHandle(FileSystem &fs, string path_p, FileOpenFlags flags, const HTTPParams &http_params,
+	S3FileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags, const HTTPParams &http_params,
 	             const S3AuthParams &auth_params_p, const S3ConfigParams &config_params_p)
-	    : HTTPFileHandle(fs, std::move(path_p), flags, http_params), auth_params(auth_params_p),
+	    : HTTPFileHandle(fs, file, flags, http_params), auth_params(auth_params_p),
 	      config_params(config_params_p), uploads_in_progress(0), parts_uploaded(0), upload_finalized(false),
 	      uploader_has_error(false), upload_exception(nullptr) {
 		if (flags.OpenForReading() && flags.OpenForWriting()) {
@@ -232,7 +232,7 @@ public:
 
 protected:
 	static void NotifyUploadsInProgress(S3FileHandle &file_handle);
-	duckdb::unique_ptr<HTTPFileHandle> CreateHandle(const string &path, FileOpenFlags flags,
+	duckdb::unique_ptr<HTTPFileHandle> CreateHandle(const OpenFileInfo &file, FileOpenFlags flags,
 	                                                optional_ptr<FileOpener> opener) override;
 
 	void FlushBuffer(S3FileHandle &handle, shared_ptr<S3WriteBuffer> write_buffer);

--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -218,7 +218,7 @@ public:
 	// Note: caller is responsible to not call this method twice on the same buffer
 	static void UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer);
 
-	vector<string> Glob(const string &glob_pattern, FileOpener *opener = nullptr) override;
+	vector<OpenFileInfo> Glob(const string &glob_pattern, FileOpener *opener = nullptr) override;
 	bool ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
 	               FileOpener *opener = nullptr) override;
 
@@ -246,7 +246,7 @@ protected:
 struct AWSListObjectV2 {
 	static string Request(string &path, HTTPParams &http_params, S3AuthParams &s3_auth_params,
 	                      string &continuation_token, optional_ptr<HTTPState> state, bool use_delimiter = false);
-	static void ParseKey(string &aws_response, vector<string> &result);
+	static void ParseFileList(string &aws_response, vector<OpenFileInfo> &result);
 	static vector<string> ParseCommonPrefix(string &aws_response);
 	static string ParseContinuationToken(string &aws_response);
 };

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -973,7 +973,7 @@ static bool Match(vector<string>::const_iterator key, vector<string>::const_iter
 	return key == key_end && pattern == pattern_end;
 }
 
-vector<string> S3FileSystem::Glob(const string &glob_pattern, FileOpener *opener) {
+vector<OpenFileInfo> S3FileSystem::Glob(const string &glob_pattern, FileOpener *opener) {
 	if (opener == nullptr) {
 		throw InternalException("Cannot S3 Glob without FileOpener");
 	}
@@ -1003,7 +1003,7 @@ vector<string> S3FileSystem::Glob(const string &glob_pattern, FileOpener *opener
 	ReadQueryParams(parsed_s3_url.query_param, s3_auth_params);
 
 	// Do main listobjectsv2 request
-	vector<string> s3_keys;
+	vector<OpenFileInfo> s3_keys;
 	string main_continuation_token;
 
 	// Main paging loop
@@ -1012,7 +1012,7 @@ vector<string> S3FileSystem::Glob(const string &glob_pattern, FileOpener *opener
 		string response_str = AWSListObjectV2::Request(shared_path, http_params, s3_auth_params,
 		                                               main_continuation_token, HTTPState::TryGetState(opener).get());
 		main_continuation_token = AWSListObjectV2::ParseContinuationToken(response_str);
-		AWSListObjectV2::ParseKey(response_str, s3_keys);
+		AWSListObjectV2::ParseFileList(response_str, s3_keys);
 
 		// Repeat requests until the keys of all common prefixes are parsed.
 		auto common_prefixes = AWSListObjectV2::ParseCommonPrefix(response_str);
@@ -1027,7 +1027,7 @@ vector<string> S3FileSystem::Glob(const string &glob_pattern, FileOpener *opener
 				auto prefix_res =
 				    AWSListObjectV2::Request(prefix_path, http_params, s3_auth_params, common_prefix_continuation_token,
 				                             HTTPState::TryGetState(opener).get());
-				AWSListObjectV2::ParseKey(prefix_res, s3_keys);
+				AWSListObjectV2::ParseFileList(prefix_res, s3_keys);
 				auto more_prefixes = AWSListObjectV2::ParseCommonPrefix(prefix_res);
 				common_prefixes.insert(common_prefixes.end(), more_prefixes.begin(), more_prefixes.end());
 				common_prefix_continuation_token = AWSListObjectV2::ParseContinuationToken(prefix_res);
@@ -1036,19 +1036,20 @@ vector<string> S3FileSystem::Glob(const string &glob_pattern, FileOpener *opener
 	} while (!main_continuation_token.empty());
 
 	vector<string> pattern_splits = StringUtil::Split(parsed_s3_url.key, "/");
-	vector<string> result;
-	for (const auto &s3_key : s3_keys) {
+	vector<OpenFileInfo> result;
+	for (auto &s3_key : s3_keys) {
 
-		vector<string> key_splits = StringUtil::Split(s3_key, "/");
+		vector<string> key_splits = StringUtil::Split(s3_key.path, "/");
 		bool is_match = Match(key_splits.begin(), key_splits.end(), pattern_splits.begin(), pattern_splits.end());
 
 		if (is_match) {
-			auto result_full_url = parsed_s3_url.prefix + parsed_s3_url.bucket + "/" + s3_key;
+			auto result_full_url = parsed_s3_url.prefix + parsed_s3_url.bucket + "/" + s3_key.path;
 			// if a ? char was present, we re-add it here as the url parsing will have trimmed it.
 			if (!parsed_s3_url.query_param.empty()) {
 				result_full_url += '?' + parsed_s3_url.query_param;
 			}
-			result.push_back(result_full_url);
+			s3_key.path = std::move(result_full_url);
+			result.push_back(std::move(s3_key));
 		}
 	}
 	return result;
@@ -1069,7 +1070,7 @@ bool S3FileSystem::ListFiles(const string &directory, const std::function<void(c
 	}
 
 	for (const auto &file : glob_res) {
-		callback(file, false);
+		callback(file.path, false);
 	}
 
 	return true;
@@ -1128,24 +1129,74 @@ string AWSListObjectV2::Request(string &path, HTTPParams &http_params, S3AuthPar
 	return response.str();
 }
 
-void AWSListObjectV2::ParseKey(string &aws_response, vector<string> &result) {
+optional_idx FindTagContents(const string &response, const string &tag, idx_t cur_pos, string &result) {
+	string open_tag = "<" + tag + ">";
+	string close_tag = "</" + tag + ">";
+	auto open_tag_pos = response.find(open_tag, cur_pos);
+	if (open_tag_pos == string::npos) {
+		// tag not found
+		return optional_idx();
+	}
+	auto close_tag_pos = response.find(close_tag, open_tag_pos + open_tag.size());
+	if (close_tag_pos == string::npos) {
+		throw InternalException("Failed to parse S3 result: found open tag for %s but did not find matching close tag", tag);
+	}
+	result = response.substr(open_tag_pos + open_tag.size(), close_tag_pos - open_tag_pos - open_tag.size());
+	return close_tag_pos + close_tag.size();
+}
+
+
+void AWSListObjectV2::ParseFileList(string &aws_response, vector<OpenFileInfo> &result) {
+	// Example S3 response:
+	//	<Contents>
+	//		<Key>lineitem_sf10_partitioned_shipdate/l_shipdate%3D1997-03-28/data_0.parquet</Key>
+	//		<LastModified>2024-11-09T11:38:08.000Z</LastModified>
+	//		<ETag>&quot;bdf10f525f8355fb80d1ff2d8c62cc8b&quot;</ETag>
+	//		<Size>1127863</Size>
+	//		<StorageClass>STANDARD</StorageClass>
+	//	</Contents>
 	idx_t cur_pos = 0;
-	while (true) {
-		auto next_open_tag_pos = aws_response.find("<Key>", cur_pos);
-		if (next_open_tag_pos == string::npos) {
+	while(true) {
+		string contents;
+		auto next_pos = FindTagContents(aws_response, "Contents", cur_pos, contents);
+		if (!next_pos.IsValid()) {
+			// exhausted all contents
 			break;
-		} else {
-			auto next_close_tag_pos = aws_response.find("</Key>", next_open_tag_pos + 5);
-			if (next_close_tag_pos == string::npos) {
-				throw InternalException("Failed to parse S3 result");
-			}
-			auto parsed_path = S3FileSystem::UrlDecode(
-			    aws_response.substr(next_open_tag_pos + 5, next_close_tag_pos - next_open_tag_pos - 5));
-			if (parsed_path.back() != '/') {
-				result.push_back(parsed_path);
-			}
-			cur_pos = next_close_tag_pos + 6;
 		}
+		// move to the next position
+		cur_pos = next_pos.GetIndex();
+
+		// parse the contents
+		string key;
+		auto key_pos = FindTagContents(contents, "Key", 0, key);
+		if (!key_pos.IsValid()) {
+			throw InternalException("Key not found in S3 response: %s", contents);
+		}
+		auto parsed_path = S3FileSystem::UrlDecode(key);
+		if (parsed_path.back() == '/') {
+			// not a file but a directory
+			continue;
+		}
+		// construct the file
+		OpenFileInfo result_file(parsed_path);
+
+		auto extra_info = make_shared_ptr<ExtendedOpenFileInfo>();
+		// get file attributes
+		string last_modified, etag, size;
+		auto last_modified_pos = FindTagContents(contents, "LastModified", 0, last_modified);
+		if (last_modified_pos.IsValid()) {
+			extra_info->options["last_modified"] = Value(last_modified).DefaultCastAs(LogicalType::TIMESTAMP);
+		}
+		auto etag_pos = FindTagContents(contents, "ETag", 0, etag);
+		if (etag_pos.IsValid()) {
+			etag = StringUtil::Replace(etag, "&quot;", "\"");
+			extra_info->options["etag"] = Value(etag);
+		}
+		auto size_pos = FindTagContents(contents, "Size", 0, size);
+		if (size_pos.IsValid()) {
+			extra_info->options["file_size"] = Value(size).DefaultCastAs(LogicalType::UBIGINT);
+		}
+		result.push_back(std::move(result_file));
 	}
 }
 


### PR DESCRIPTION
This PR relies on https://github.com/duckdb/duckdb/pull/17102/ to actually work correctly

This PR extends the `S3FileSystem::Glob` method so that it reads additional metadata about the globbed files directly from the S3 response. The response is as follows:

```
<Contents>
	<Key>lineitem_sf10_partitioned_shipdate/l_shipdate%3D1997-03-28/data_0.parquet</Key>
	<LastModified>2024-11-09T11:38:08.000Z</LastModified>
	<ETag>&quot;bdf10f525f8355fb80d1ff2d8c62cc8b&quot;</ETag>
	<Size>1127863</Size>
	<StorageClass>STANDARD</StorageClass>
</Contents>
```

We previously only read the `Key` element. We now read the `LastModified`, `ETag` and `Size` elements as well. 

We pass these read elements onto the `HTTPFileHandle` that is created later on. This has the big benefit that we can avoid doing a `HEAD` request for these files in order to obtain this information later on. This can greatly speed up queries - in particular metadata-only queries - as we reduce the number of round-trips. For example:

```sql
select filename, last_modified from read_blob('s3://test-s3-lineitem/**/*.parquet');
-- previous: 900s, new: 3s
```

