### PR TITLE
Better S3 authentication errors

### DIFF
--- a/extension/httpfs/include/httpfs.hpp
+++ b/extension/httpfs/include/httpfs.hpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/exception/http_exception.hpp"
 #include "http_state.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/unordered_map.hpp"
@@ -215,6 +216,8 @@ protected:
 	static duckdb::unique_ptr<ResponseWrapper>
 	RunRequestWithRetry(const std::function<duckdb_httplib_openssl::Result(void)> &request, string &url, string method,
 	                    const HTTPParams &params, const std::function<void(void)> &retry_cb = {});
+
+	virtual HTTPException GetHTTPError(FileHandle &handle, const duckdb_httplib_openssl::Response &response, const string &url);
 
 private:
 	// Global cache

--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -230,6 +230,8 @@ public:
 		return true;
 	}
 
+	static HTTPException GetS3Error(S3AuthParams &s3_auth_params, const duckdb_httplib_openssl::Response &response, const string &url);
+
 protected:
 	static void NotifyUploadsInProgress(S3FileHandle &file_handle);
 	duckdb::unique_ptr<HTTPFileHandle> CreateHandle(const string &path, FileOpenFlags flags,
@@ -240,6 +242,8 @@ protected:
 
 	// helper for ReadQueryParams
 	void GetQueryParam(const string &key, string &param, CPPHTTPLIB_NAMESPACE::Params &query_params);
+
+	HTTPException GetHTTPError(FileHandle &, const duckdb_httplib_openssl::Response &response, const string &url) override;
 };
 
 // Helper class to do s3 ListObjectV2 api call https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html


### PR DESCRIPTION
This PR improves the errors when S3 authentication fails.

For example:

```sql
select filename from read_parquet('s3://test-s3-lineitem/lineitem_sf10_partitioned_shipdate/l_shipdate=1992-01-02/data_0.parquet');
```
```
HTTP Error:
HTTP GET error reading 'https://test-s3-lineitem.s3.amazonaws.com/lineitem_sf10_partitioned_shipdate/l_shipdate%3D1992-01-02/data_0.parquet' in region 'us-east-1' (HTTP 403 Forbidden)

Authentication Failure - this is usually caused by invalid or missing credentials.
* No credentials are provided.
* See https://duckdb.org/docs/stable/extensions/httpfs/s3api.html
```



```sql
D select filename from read_parquet('s3://test-s3-lineitem/**');
```
```
HTTP Error:
HTTP GET error reading 's3://test-s3-lineitem/?encoding-type=url&list-type=2&prefix=' in region 'us-east-1' (HTTP 403 Forbidden)

Authentication Failure - this is usually caused by invalid or missing credentials.
* No credentials are provided.
* See https://duckdb.org/docs/stable/extensions/httpfs/s3api.html
```