### PR TITLE
[WIP] HTTPMetadataCache should also store OpenFileExtendedInfo

### DIFF
--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -279,7 +279,7 @@ void TimestampToTimeT(timestamp_t timestamp, time_t &result) {
 HTTPFileHandle::HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags,
                                unique_ptr<HTTPParams> params_p)
     : FileHandle(fs, file.path, flags), params(std::move(params_p)), http_params(params->Cast<HTTPFSParams>()),
-      flags(flags), buffer_available(0), buffer_idx(0), file_offset(0), buffer_start(0), buffer_end(0) {
+      flags(flags), length(0), buffer_available(0), buffer_idx(0), file_offset(0), buffer_start(0), buffer_end(0) {
 	// check if the handle has extended properties that can be set directly in the handle
 	// if we have these properties we don't need to do a head request to obtain them later
 	if (file.extended_info) {

--- a/extension/httpfs/include/http_metadata_cache.hpp
+++ b/extension/httpfs/include/http_metadata_cache.hpp
@@ -19,6 +19,7 @@ struct HTTPMetadataCacheEntry {
 	idx_t length;
 	time_t last_modified;
 	string etag;
+	shared_ptr<ExtendedOpenFileInfo> extended_info;
 };
 
 // Simple cache with a max age for an entry to be valid

--- a/extension/httpfs/include/httpfs.hpp
+++ b/extension/httpfs/include/httpfs.hpp
@@ -48,6 +48,7 @@ public:
 	idx_t length;
 	time_t last_modified;
 	string etag;
+	shared_ptr<ExtendedOpenFileInfo> extended_info;
 	bool initialized = false;
 
 	// When using full file download, the full file will be written to a cached file handle


### PR DESCRIPTION
If there is extended info, options like "validate_external_cache" can be read from any thread. 

This is WIP because the extended_info is still a shared pointer between the HTTPMetadataCache and HTTPFileHandle etc. It's still possible to have two handles reading from the same memory. The problem with that is what happens if the extended_options object becomes very big? (We will probably deal with that later then).

Eventually there may be extra options, one I can see is a "direct_get" option, which will translate to not executing a head request and executing a GET request. This will help with Lakehouse formats (i.e Iceberg) where we don't want to execute a HEAD request if we KNOW we are still going to execute a GET request.