### PR TITLE
Improve S3 error messages - suggest incorrect region when status code is 400

### DIFF
--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -223,6 +223,8 @@ public:
 		return true;
 	}
 
+	static string GetS3BadRequestError(S3AuthParams &s3_auth_params);
+	static string GetS3AuthError(S3AuthParams &s3_auth_params);
 	static HTTPException GetS3Error(S3AuthParams &s3_auth_params, const HTTPResponse &response, const string &url);
 
 protected:


### PR DESCRIPTION
S3 returns [status code 400](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/http-400-bad-request.html) when the region is set incorrectly. This PR improves the error message shown in case of a 400 error to signify that we might be using the wrong region.