### PR TITLE
Fixup syntax error + temporary skip wasm targets

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -19,6 +19,8 @@ jobs:
       extension_name: httpfs
       duckdb_version: v1.3.1
       ci_tools_version: main
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads'
+
 
   duckdb-stable-deploy:
     name: Deploy extension binaries
@@ -30,3 +32,4 @@ jobs:
       duckdb_version: v1.3.1
       ci_tools_version: main
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads'

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -536,7 +536,7 @@ void HTTPFileHandle::FullDownload(HTTPFileSystem &hfs, bool &should_write_cache)
 		// Try to fully download the file first
 		const auto full_download_result = hfs.GetRequest(*this, path, {});
 		if (full_download_result->status != HTTPStatusCode::OK_200) {
-			throw HTTPException(*full_download_result, "Full download failed to to URL \"%s\": %s (%s)",
+			throw HTTPException(*full_download_result, "Full download failed to to URL \"%s\": %d (%s)",
 			                    full_download_result->url, static_cast<int>(full_download_result->status),
 			                    full_download_result->GetError());
 		}


### PR DESCRIPTION
Workflow changes is since wasm work is currently carried forward in the `wasm` branch, and it's not clear yet how to reconcile the different set of dependencies.

Formatting error fix is that otherwise on formatting the exception message that would turn into an more heavy InternalException.