### PR TITLE
Continue in S3FileHandle::Initialize on secret refresh

### DIFF
--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -737,7 +737,7 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 				// We have succesfully refreshed a secret: retry initializing with new credentials
 				FileOpenerInfo info = {path};
 				auth_params = S3AuthParams::ReadFrom(opener, info);
-				HTTPFileHandle::Initialize(opener);
+				S3FileHandle::Initialize(opener);
 				return;
 			}
 		}


### PR DESCRIPTION
The intention here is to re-run the same method using the refreshed credentials. Currently we are calling only the base-class method again and then returning. This skips a bunch of code related to uploading - which could potentially cause issues. This PR inverts the condition to instead throw if there is no secret refresh - and otherwise refresh and continue.