### PR TITLE
Refactor S3 Multi part upload to separate class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,10 @@ build_static_extension(
   extension/httpfs/http_state.cpp
   extension/httpfs/crypto.cpp
   extension/httpfs/hash_functions.cpp
+  extension/httpfs/s3_multi_part_upload.cpp
   extension/httpfs/create_secret_functions.cpp
   extension/httpfs/httpfs_extension.cpp
-  ${EXTRA_SOURCES} )
+  ${EXTRA_SOURCES})
 
 set(PARAMETERS "-warnings")
 build_loadable_extension(

--- a/extension/httpfs/include/s3_multi_part_upload.hpp
+++ b/extension/httpfs/include/s3_multi_part_upload.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "s3fs.hpp"
+#include "duckdb/execution/task_error_manager.hpp"
+
+namespace duckdb {
+
+// Holds the buffered data for 1 part of an S3 Multipart upload
+class S3WriteBuffer {
+public:
+	explicit S3WriteBuffer(idx_t buffer_start, size_t buffer_size, BufferHandle buffer_p)
+	    : idx(0), buffer_start(buffer_start), buffer(std::move(buffer_p)) {
+		buffer_end = buffer_start + buffer_size;
+		part_no = buffer_start / buffer_size;
+		uploading = false;
+	}
+
+	void *Ptr() {
+		return buffer.Ptr();
+	}
+
+	// The S3 multipart part number. Note that internally we start at 0 but AWS S3 starts at 1
+	idx_t part_no;
+
+	idx_t idx;
+	idx_t buffer_start;
+	idx_t buffer_end;
+	BufferHandle buffer;
+	atomic<bool> uploading;
+};
+
+class S3MultiPartUpload : public enable_shared_from_this<S3MultiPartUpload> {
+public:
+	S3MultiPartUpload(S3FileSystem &s3fs_p, S3FileHandle &file_handle_p);
+
+public:
+	static shared_ptr<S3MultiPartUpload> Initialize(S3FileHandle &file_handle);
+
+	idx_t GetPartSize() const {
+		return part_size;
+	}
+
+	shared_ptr<S3WriteBuffer> GetBuffer(idx_t write_buffer_idx);
+	static void FlushBuffer(shared_ptr<S3MultiPartUpload> upload_state, shared_ptr<S3WriteBuffer> write_buffer);
+	static void UploadBuffer(shared_ptr<S3MultiPartUpload> upload_state, shared_ptr<S3WriteBuffer> write_buffer);
+	void Finalize();
+
+private:
+	string InitializeMultipartUpload();
+	void NotifyUploadsInProgress();
+	void FlushAllBuffers();
+	void FinalizeMultipartUpload();
+
+private:
+	S3FileSystem &s3fs;
+	S3FileHandle &file_handle;
+	string path;
+	S3ConfigParams config_params;
+	string multipart_upload_id;
+	idx_t part_size;
+
+	//! Write buffers for this file
+	mutex write_buffers_lock;
+	unordered_map<idx_t, shared_ptr<S3WriteBuffer>> write_buffers;
+
+	//! Synchronization for upload threads
+	mutex uploads_in_progress_lock;
+	std::condition_variable uploads_in_progress_cv;
+	std::condition_variable final_flush_cv;
+	uint16_t uploads_in_progress;
+
+	//! Etags are stored for each part
+	mutex part_etags_lock;
+	unordered_map<idx_t, string> part_etags;
+
+	//! Info for upload
+	atomic<uint16_t> parts_uploaded;
+	atomic<bool> upload_finalized;
+
+	//! Error handling in upload threads
+	TaskErrorManager error_manager;
+};
+
+} // namespace duckdb

--- a/extension/httpfs/include/s3_multi_part_upload.hpp
+++ b/extension/httpfs/include/s3_multi_part_upload.hpp
@@ -53,7 +53,7 @@ private:
 
 private:
 	S3FileSystem &s3fs;
-	S3FileHandle &file_handle;
+	shared_ptr<HTTPInput> http_input;
 	string path;
 	S3ConfigParams config_params;
 	string multipart_upload_id;

--- a/extension/httpfs/s3_multi_part_upload.cpp
+++ b/extension/httpfs/s3_multi_part_upload.cpp
@@ -1,0 +1,238 @@
+#include "s3_multi_part_upload.hpp"
+#include "duckdb/common/thread.hpp"
+
+namespace duckdb {
+
+S3MultiPartUpload::S3MultiPartUpload(S3FileSystem &s3fs_p, S3FileHandle &file_handle_p)
+    : s3fs(s3fs_p), file_handle(file_handle_p), path(file_handle.path), config_params(file_handle.config_params),
+      uploads_in_progress(0), parts_uploaded(0), upload_finalized(false) {
+}
+
+shared_ptr<S3MultiPartUpload> S3MultiPartUpload::Initialize(S3FileHandle &file_handle) {
+	auto &config_params = file_handle.config_params;
+
+	auto aws_minimum_part_size = 5242880; // 5 MiB https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
+	auto max_part_count = config_params.max_parts_per_file;
+	auto required_part_size = config_params.max_file_size / max_part_count;
+	auto minimum_part_size = MaxValue<idx_t>(aws_minimum_part_size, required_part_size);
+
+	auto &s3fs = file_handle.file_system.Cast<S3FileSystem>();
+
+	auto upload_state = make_shared_ptr<S3MultiPartUpload>(s3fs, file_handle);
+	// Round part size up to multiple of Storage::DEFAULT_BLOCK_SIZE
+	upload_state->part_size = ((minimum_part_size + Storage::DEFAULT_BLOCK_SIZE - 1) / Storage::DEFAULT_BLOCK_SIZE) *
+	                          Storage::DEFAULT_BLOCK_SIZE;
+	D_ASSERT(upload_state->part_size * max_part_count >= config_params.max_file_size);
+
+	upload_state->multipart_upload_id = upload_state->InitializeMultipartUpload();
+	return upload_state;
+}
+
+// Opens the multipart upload and returns the ID
+string S3MultiPartUpload::InitializeMultipartUpload() {
+	string result;
+	string query_param = "uploads=";
+	auto res = s3fs.PostRequest(file_handle, path, {}, result, nullptr, 0, query_param);
+
+	if (res->status != HTTPStatusCode::OK_200) {
+		throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", res->url, res->GetError(),
+		                    static_cast<int>(res->status));
+	}
+
+	auto open_tag_pos = result.find("<UploadId>", 0);
+	auto close_tag_pos = result.find("</UploadId>", open_tag_pos);
+
+	if (open_tag_pos == string::npos || close_tag_pos == string::npos) {
+		throw HTTPException("Unexpected response while initializing S3 multipart upload");
+	}
+
+	open_tag_pos += 10; // Skip open tag
+
+	return result.substr(open_tag_pos, close_tag_pos - open_tag_pos);
+}
+
+shared_ptr<S3WriteBuffer> S3MultiPartUpload::GetBuffer(idx_t write_buffer_idx) {
+	// Check if write buffer already exists
+	{
+		lock_guard<mutex> lck(write_buffers_lock);
+		auto lookup_result = write_buffers.find(write_buffer_idx);
+		if (lookup_result != write_buffers.end()) {
+			return lookup_result->second;
+		}
+	}
+
+	auto buffer_handle = s3fs.Allocate(part_size, config_params.max_upload_threads);
+	auto new_write_buffer =
+	    make_shared_ptr<S3WriteBuffer>(write_buffer_idx * part_size, part_size, std::move(buffer_handle));
+	{
+		lock_guard<mutex> lck(write_buffers_lock);
+		auto lookup_result = write_buffers.find(write_buffer_idx);
+
+		// Check if other thread has created the same buffer, if so we return theirs and drop ours.
+		if (lookup_result != write_buffers.end()) {
+			// write_buffer_idx << std::endl;
+			return lookup_result->second;
+		}
+		write_buffers.emplace(write_buffer_idx, new_write_buffer);
+	}
+
+	return new_write_buffer;
+}
+
+void S3MultiPartUpload::NotifyUploadsInProgress() {
+	{
+		unique_lock<mutex> lck(uploads_in_progress_lock);
+		uploads_in_progress--;
+	}
+	// Note that there are 2 cv's because otherwise we might deadlock when the final flushing thread is notified while
+	// another thread is still waiting for an upload thread
+	uploads_in_progress_cv.notify_one();
+	final_flush_cv.notify_one();
+}
+
+void S3MultiPartUpload::UploadBuffer(shared_ptr<S3MultiPartUpload> upload_state,
+                                     shared_ptr<S3WriteBuffer> write_buffer) {
+	auto &s3fs = upload_state->s3fs;
+
+	string query_param = "partNumber=" + to_string(write_buffer->part_no + 1) + "&" +
+	                     "uploadId=" + S3FileSystem::UrlEncode(upload_state->multipart_upload_id, true);
+	unique_ptr<HTTPResponse> res;
+	string etag;
+
+	try {
+		res = s3fs.PutRequest(upload_state->file_handle, upload_state->path, {}, (char *)write_buffer->Ptr(),
+		                      write_buffer->idx, query_param);
+
+		if (res->status != HTTPStatusCode::OK_200) {
+			throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", res->url, res->GetError(),
+			                    static_cast<int>(res->status));
+		}
+
+		if (!res->headers.HasHeader("ETag")) {
+			throw IOException("Unexpected response when uploading part to S3");
+		}
+		etag = res->headers.GetHeaderValue("ETag");
+	} catch (std::exception &ex) {
+		ErrorData error(ex);
+		if (error.Type() != ExceptionType::IO && error.Type() != ExceptionType::HTTP) {
+			throw;
+		}
+		upload_state->error_manager.PushError(std::move(error));
+
+		upload_state->NotifyUploadsInProgress();
+		return;
+	}
+
+	// Insert etag
+	{
+		unique_lock<mutex> lck(upload_state->part_etags_lock);
+		upload_state->part_etags.insert(std::pair<uint16_t, string>(write_buffer->part_no, etag));
+	}
+
+	upload_state->parts_uploaded++;
+
+	// Free up space for another thread to acquire an S3WriteBuffer
+	write_buffer.reset();
+
+	upload_state->NotifyUploadsInProgress();
+}
+
+void S3MultiPartUpload::FlushBuffer(shared_ptr<S3MultiPartUpload> upload_state,
+                                    shared_ptr<S3WriteBuffer> write_buffer) {
+	auto uploading = write_buffer->uploading.load();
+	if (uploading) {
+		return;
+	}
+	bool can_upload = write_buffer->uploading.compare_exchange_strong(uploading, true);
+	if (!can_upload) {
+		return;
+	}
+
+	if (upload_state->error_manager.HasError()) {
+		upload_state->error_manager.ThrowException();
+	}
+
+	{
+		unique_lock<mutex> lck(upload_state->write_buffers_lock);
+		upload_state->write_buffers.erase(write_buffer->part_no);
+	}
+
+	{
+		unique_lock<mutex> lck(upload_state->uploads_in_progress_lock);
+		// check if there are upload threads available
+		if (upload_state->uploads_in_progress >= upload_state->config_params.max_upload_threads) {
+			// there are not - wait for one to become available
+			upload_state->uploads_in_progress_cv.wait(lck, [&] {
+				return upload_state->uploads_in_progress < upload_state->config_params.max_upload_threads;
+			});
+		}
+		upload_state->uploads_in_progress++;
+	}
+
+	thread upload_thread(UploadBuffer, upload_state, write_buffer);
+	upload_thread.detach();
+}
+
+// Note that FlushAll currently does not allow to continue writing afterwards. Therefore, FinalizeMultipartUpload should
+// be called right after it!
+// TODO: we can fix this by keeping the last partially written buffer in memory and allow reuploading it with new data.
+void S3MultiPartUpload::FlushAllBuffers() {
+	//  Collect references to all buffers to check
+	vector<shared_ptr<S3WriteBuffer>> to_flush;
+	write_buffers_lock.lock();
+	for (auto &item : write_buffers) {
+		to_flush.push_back(item.second);
+	}
+	write_buffers_lock.unlock();
+
+	// Flush all buffers that aren't already uploading
+	for (auto &write_buffer : to_flush) {
+		if (!write_buffer->uploading) {
+			FlushBuffer(shared_from_this(), write_buffer);
+		}
+	}
+	unique_lock<mutex> lck(uploads_in_progress_lock);
+	final_flush_cv.wait(lck, [&] { return uploads_in_progress == 0; });
+
+	if (error_manager.HasError()) {
+		error_manager.ThrowException();
+	}
+}
+
+void S3MultiPartUpload::FinalizeMultipartUpload() {
+	upload_finalized = true;
+
+	std::stringstream ss;
+	ss << "<CompleteMultipartUpload xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">";
+
+	auto parts = parts_uploaded.load();
+	for (auto i = 0; i < parts; i++) {
+		auto etag_lookup = part_etags.find(i);
+		if (etag_lookup == part_etags.end()) {
+			throw IOException("Unknown part number");
+		}
+		ss << "<Part><ETag>" << etag_lookup->second << "</ETag><PartNumber>" << i + 1 << "</PartNumber></Part>";
+	}
+	ss << "</CompleteMultipartUpload>";
+	string body = ss.str();
+
+	string result;
+
+	string query_param = "uploadId=" + S3FileSystem::UrlEncode(multipart_upload_id, true);
+	auto res =
+	    s3fs.PostRequest(file_handle, file_handle.path, {}, result, (char *)body.c_str(), body.length(), query_param);
+	auto open_tag_pos = result.find("<CompleteMultipartUploadResult", 0);
+	if (open_tag_pos == string::npos) {
+		throw HTTPException(*res, "Unexpected response during S3 multipart upload finalization: %d\n\n%s",
+		                    static_cast<int>(res->status), result);
+	}
+}
+
+void S3MultiPartUpload::Finalize() {
+	FlushAllBuffers();
+	if (parts_uploaded) {
+		FinalizeMultipartUpload();
+	}
+}
+
+} // namespace duckdb

--- a/extension/httpfs/s3_multi_part_upload.cpp
+++ b/extension/httpfs/s3_multi_part_upload.cpp
@@ -229,6 +229,10 @@ void S3MultiPartUpload::FinalizeMultipartUpload() {
 }
 
 void S3MultiPartUpload::Finalize() {
+	if (upload_finalized) {
+		// already finalized
+		return;
+	}
 	FlushAllBuffers();
 	if (parts_uploaded) {
 		FinalizeMultipartUpload();


### PR DESCRIPTION
This PR refactors the S3 multi part upload code into a separate class from the S3FileHandle. It is kept alive separately and performs the Put/Post requests separately from the S3FileHandle. This greatly simplifies reasoning about lifetimes as we are no longer launching background threads that are dependent on external state (the file handle) being kept alive. This likely fixes some edge case issues around writes in particular when dealing with exceptions.

This shouldn't change behavior - but given this is a relatively sizeable refactor I would not include this for the v1.3.2 release.