### PR TITLE
Add httpfs_client_implementation option, currently only `default` and `httplib` are valid

### DIFF
--- a/test/sql/httpfs_client/httpfs_client_implementation.test
+++ b/test/sql/httpfs_client/httpfs_client_implementation.test
@@ -1,0 +1,16 @@
+# name: test/sql/htpfs_client/httpfs_client_implementation.test
+# description: Tests basic valus for httpfs_client_implementation
+# group: [httpfs_client]
+
+require httpfs
+
+statement ok
+set httpfs_client_implementation = 'default';
+
+statement ok
+set httpfs_client_implementation = 'httplib';
+
+statement error
+set httpfs_client_implementation = 'something else';
+----
+Unsupported option for httpfs_client_implementation


### PR DESCRIPTION
Idea of this is allowing, in future versions of `httpfs` to offer a different version, namely `curl`, and possibly move the default.

Infrastructure would allow to register already in duckdb the option.