### PR TITLE
Use target_link_libraries instead of LINKED_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ endif()
 find_package(OpenSSL REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR})
 if(EMSCRIPTEN)
-
+  target_link_libraries(httpfs_loadable_extension duckdb_mbedtls)
 else()
   target_link_libraries(httpfs_loadable_extension duckdb_mbedtls
                         ${OPENSSL_LIBRARIES})

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -15,5 +15,4 @@ duckdb_extension_load(httpfs
 	SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
 	INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/extension/httpfs/include
 	${LOAD_HTTPFS_TESTS}
-	LINKED_LIBS "../../third_party/mbedtls/libduckdb_mbedtls.a"
 )


### PR DESCRIPTION
Proper fix, moving to CMake logic instead of hacking this later in the process.

This is a Wasm-only fix, so should be pretty safe.