### PR TITLE
Include region in s3 endpoints

### DIFF
--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -200,6 +200,10 @@ S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerI
 		result.endpoint = "s3.amazonaws.com";
 	}
 
+	if (result.endpoint == "s3.amazonaws.com" && !result.region.empty()) {
+		result.endpoint = StringUtil::Format("s3.%s.amazonaws.com", result.region);
+	}
+
 	return result;
 }
 

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -196,12 +196,10 @@ S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerI
 		}
 	}
 
-	if (result.endpoint.empty()) {
-		result.endpoint = "s3.amazonaws.com";
-	}
-
-	if (result.endpoint == "s3.amazonaws.com" && !result.region.empty()) {
-		result.endpoint = StringUtil::Format("s3.%s.amazonaws.com", result.region);
+	if (!result.region.empty() && (result.endpoint.empty() || result.endpoint == "s3.amazonaws.com")) {
+	    result.endpoint = StringUtil::Format("s3.%s.amazonaws.com", result.region);
+	} else if (result.endpoint.empty()) {
+	    result.endpoint = "s3.amazonaws.com";
 	}
 
 	return result;


### PR DESCRIPTION
I've been encountering a number of issues where iceberg writes/reads are failing because the endpoint url is incorrect. I think what is happening is if you hit the regular `s3.amazonaws.com` endpoint you will get redirected to `s3.{region}.amazonaws.com`. For s3tables, however, this is not the case, and instead you just directly get an error.

Opening this PR to try an squash many of these issues. See AWS documentation here https://docs.aws.amazon.com/general/latest/gr/s3.html