### PR TITLE
Only add Content-Type if not already present in the headers

### DIFF
--- a/extension/httpfs/httpfs_client.cpp
+++ b/extension/httpfs/httpfs_client.cpp
@@ -92,7 +92,9 @@ public:
 		req.method = "POST";
 		req.path = info.path;
 		req.headers = TransformHeaders(info.headers, info.params);
-		req.headers.emplace("Content-Type", "application/octet-stream");
+		if (req.headers.find("Content-Type") == req.headers.end()) {
+			req.headers.emplace("Content-Type", "application/octet-stream");
+		}
 		req.content_receiver = [&](const char *data, size_t data_length, uint64_t /*offset*/,
 		                           uint64_t /*total_length*/) {
 			if (state) {


### PR DESCRIPTION
Otherwise we can add to headers of "Content-Type". Some servers may prefer the last seen value, and if it doesn't match the content type for the url, the server may return an error.
This is happening currently with the cloudflare R2 iceberg catalog. The Iceberg client adds the header `Content-Type: application/json` then httpfs adds `Content-Type: application/octet-stream` and Cloudflare responds with 
"Expected request with `Content-Type: application/json`"