### PR TITLE
Explicitly link mbedtls for wasm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ if (NOT EMSCRIPTEN)
   add_definitions(-DOVERRIDE_ENCRYPTION_UTILS=1)
 else()
   set(EXTRA_SOURCES extension/httpfs/httpfs_client_wasm.cpp)
+  set (DUCKDB_EXTENSION_HTTPFS_LINKED_LIBS "../../third_party/mbedtls/libduckdb_mbedtls.a")
 endif()
 
 build_static_extension(


### PR DESCRIPTION
Not very clean, but currently required due to changes in duckdb-wasm linking stage. This can/should be cleaned up, possibly for 1.4.0

Given this has no real changes for non-wasm targets, should be on the easy side.