### PR TITLE
Automatic full file download fallback

### DIFF
--- a/.github/workflows/MinioTests.yml
+++ b/.github/workflows/MinioTests.yml
@@ -22,6 +22,8 @@ jobs:
       GEN: ninja
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
       VCPKG_TARGET_TRIPLET: x64-linux
+      PYTHON_HTTP_SERVER_URL: http://localhost:8008
+      PYTHON_HTTP_SERVER_DIR: /tmp/python_test_server
 
     steps:
       - uses: actions/checkout@v4
@@ -50,7 +52,9 @@ jobs:
 
       - name: Build
         shell: bash
-        run: make
+        run: |
+          echo -e "\nduckdb_extension_load(tpch)\n" >> extension_config.cmake
+          make
 
       - name: Start S3/HTTP test server
         shell: bash
@@ -61,6 +65,13 @@ jobs:
           sudo ./scripts/install_s3_test_server.sh
           source ./scripts/run_s3_test_server.sh
           sleep 30
+
+      - name: Run & Populate test server
+        shell: bash
+        run: |
+          mkdir -p $PYTHON_HTTP_SERVER_DIR
+          cd $PYTHON_HTTP_SERVER_DIR
+          python3 -m http.server 8008 &
 
       - name: Test
         shell: bash

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -254,7 +254,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
 		    return true;
 	    });
 
-	get_request.try_request = true;
+	get_request.try_request = hfh.auto_fallback_to_full_file_download;
 
 	auto response = http_util.Request(get_request, http_client);
 
@@ -360,8 +360,8 @@ bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders
 					return false;
 				}
 
-				error.Throw();
 			}
+			error.Throw();
 		}
 		throw HTTPException(*res, "Request returned HTTP %d for HTTP %s to '%s'",
 									static_cast<int>(res->status), EnumUtil::ToString(RequestType::GET_REQUEST), res->url);

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -344,8 +344,8 @@ bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders
 	auto res = GetRangeRequest(handle, url, header_map, file_offset, buffer_out, buffer_out_len);
 
 	if (res) {
-		// Request succeeded
-		if (res->Success()) {
+		// Request succeeded TODO: fix upstream that 206 is not considered success
+		if (res->Success() || res->status == HTTPStatusCode::PartialContent_206 || res->status == HTTPStatusCode::Accepted_202) {
 			return true;
 		}
 

--- a/extension/httpfs/httpfs_extension.cpp
+++ b/extension/httpfs/httpfs_extension.cpp
@@ -47,6 +47,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("http_retries", "HTTP retries on I/O error", LogicalType::UBIGINT, Value(3));
 	config.AddExtensionOption("http_retry_wait_ms", "Time between retries", LogicalType::UBIGINT, Value(100));
 	config.AddExtensionOption("force_download", "Forces upfront download of file", LogicalType::BOOLEAN, Value(false));
+	config.AddExtensionOption("auto_fallback_to_full_download", "Allows automatically falling back to full file downloads when possible.", LogicalType::BOOLEAN, Value(true));
 	// Reduces the number of requests made while waiting, for example retry_wait_ms of 50 and backoff factor of 2 will
 	// result in wait times of  0 50 100 200 400...etc.
 	config.AddExtensionOption("http_retry_backoff", "Backoff factor for exponentially increasing retry wait time",

--- a/extension/httpfs/include/httpfs_client.hpp
+++ b/extension/httpfs/include/httpfs_client.hpp
@@ -16,8 +16,10 @@ struct HTTPFSParams : public HTTPParams {
 	static constexpr bool DEFAULT_ENABLE_SERVER_CERT_VERIFICATION = false;
 	static constexpr uint64_t DEFAULT_HF_MAX_PER_PAGE = 0;
 	static constexpr bool DEFAULT_FORCE_DOWNLOAD = false;
+	static constexpr bool AUTO_FALLBACK_TO_FULL_DOWNLOAD = true;
 
 	bool force_download = DEFAULT_FORCE_DOWNLOAD;
+	bool auto_fallback_to_full_download = AUTO_FALLBACK_TO_FULL_DOWNLOAD;
 	bool enable_server_cert_verification = DEFAULT_ENABLE_SERVER_CERT_VERIFICATION;
 	idx_t hf_max_per_page = DEFAULT_HF_MAX_PER_PAGE;
 	string ca_cert_file;

--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -116,6 +116,7 @@ public:
 	    : HTTPFileHandle(fs, file, flags, std::move(http_params_p)), auth_params(auth_params_p),
 	      config_params(config_params_p), uploads_in_progress(0), parts_uploaded(0), upload_finalized(false),
 	      uploader_has_error(false), upload_exception(nullptr) {
+		auto_fallback_to_full_file_download = false;
 		if (flags.OpenForReading() && flags.OpenForWriting()) {
 			throw NotImplementedException("Cannot open an HTTP file for both reading and writing");
 		} else if (flags.OpenForAppending()) {

--- a/test/sql/full_file_download_fallback.test
+++ b/test/sql/full_file_download_fallback.test
@@ -12,7 +12,7 @@ require-env PYTHON_HTTP_SERVER_URL
 require-env PYTHON_HTTP_SERVER_DIR
 
 statement ok
-pragma enable_logging;
+CALL enable_logging();
 
 statement ok
 call dbgen(sf=1);

--- a/test/sql/full_file_download_fallback.test
+++ b/test/sql/full_file_download_fallback.test
@@ -1,0 +1,46 @@
+# name: test/sql/full_file_download_fallback.test
+# group: [full_file_download]
+
+require parquet
+
+require httpfs
+
+require tpch
+
+require-env PYTHON_HTTP_SERVER_URL
+
+require-env PYTHON_HTTP_SERVER_DIR
+
+statement ok
+pragma enable_logging;
+
+statement ok
+call dbgen(sf=1);
+
+statement ok
+copy lineitem to '${PYTHON_HTTP_SERVER_DIR}/lineitem.csv'
+
+statement ok
+drop table lineitem;
+
+statement ok
+CREATE view lineitem AS FROM '${PYTHON_HTTP_SERVER_URL}/lineitem.csv';
+
+query I
+pragma tpch(6);
+----
+123141078.22829981
+
+query I
+select count(*) from duckdb_logs where log_level='WARN' and message like '%Falling back to full%'
+----
+2
+
+statement ok
+set auto_fallback_to_full_download=false
+
+statement error
+pragma tpch(6);
+----
+HTTP Error: Content-Length from server mismatches requested range, server may not support range requests. You can try to resolve this by enabling `SET force_download=true`
+

--- a/test/sql/secret/secret_aws.test
+++ b/test/sql/secret/secret_aws.test
@@ -14,6 +14,8 @@ require-env DUCKDB_S3_ENDPOINT
 
 require-env DUCKDB_S3_USE_SSL
 
+set ignore_error_messages
+
 require httpfs
 
 require parquet

--- a/test/sql/secret/secret_refresh.test
+++ b/test/sql/secret/secret_refresh.test
@@ -84,7 +84,7 @@ CREATE SECRET s1 (
 statement error
 FROM "s3://test-bucket/test-file.parquet"
 ----
-HTTP Error: HTTP GET error on 'http://test-bucket.duckdb-minio.com:9000/test-file.parquet' (HTTP 403)
+403
 
 query I
 SELECT message[0:46] FROM duckdb_logs WHERE message like '%Successfully refreshed secret%'
@@ -125,7 +125,7 @@ set s3_access_key_id='bogus'
 statement error
 FROM "s3://test-bucket/test-file.parquet"
 ----
-HTTP Error: HTTP GET error on 'http://test-bucket.duckdb-minio.com:9000/test-file.parquet' (HTTP 403)
+403
 
 # -> log empty
 query II

--- a/test/sql/secret/secret_refresh.test
+++ b/test/sql/secret/secret_refresh.test
@@ -14,6 +14,8 @@ require-env DUCKDB_S3_ENDPOINT
 
 require-env DUCKDB_S3_USE_SSL
 
+set ignore_error_messages
+
 require httpfs
 
 require parquet

--- a/test/sql/secret/secret_refresh.test
+++ b/test/sql/secret/secret_refresh.test
@@ -84,7 +84,7 @@ CREATE SECRET s1 (
 statement error
 FROM "s3://test-bucket/test-file.parquet"
 ----
-403
+HTTP Error: HTTP GET error on 'http://test-bucket.duckdb-minio.com:9000/test-file.parquet' (HTTP 403)
 
 query I
 SELECT message[0:46] FROM duckdb_logs WHERE message like '%Successfully refreshed secret%'
@@ -125,7 +125,7 @@ set s3_access_key_id='bogus'
 statement error
 FROM "s3://test-bucket/test-file.parquet"
 ----
-403
+HTTP Error: HTTP GET error on 'http://test-bucket.duckdb-minio.com:9000/test-file.parquet' (HTTP 403)
 
 # -> log empty
 query II

--- a/test/sql/secret/secret_refresh_attach.test
+++ b/test/sql/secret/secret_refresh_attach.test
@@ -16,6 +16,8 @@ require-env DUCKDB_S3_USE_SSL
 
 require-env S3_ATTACH_DB
 
+set ignore_error_messages
+
 require httpfs
 
 require parquet


### PR DESCRIPTION
This PR adds a new (default enabled) feature that will attempt to automatically fall back to full file downloads when HTTP range requests are not supported.

@pdet