### PR TITLE
Use curl as optional client v1.4

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       extension_name: httpfs
-      duckdb_version: v1.3.2
+      duckdb_version: main
       ci_tools_version: main
 
 
@@ -28,6 +28,6 @@ jobs:
     secrets: inherit
     with:
       extension_name: httpfs
-      duckdb_version: v1.3.2
+      duckdb_version: main
       ci_tools_version: main
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,8 +17,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       extension_name: httpfs
-      override_duckdb_repository: https://github.com/tmonster/duckdb.git
-      duckdb_version: 981f07e87f132eb3d46841e19d30a8b7e28c34b9
+      duckdb_version: v1.3.2
       ci_tools_version: main
 
 
@@ -29,6 +28,6 @@ jobs:
     secrets: inherit
     with:
       extension_name: httpfs
-      duckdb_version: main
+      duckdb_version: v1.3.2
       ci_tools_version: main
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,6 +17,8 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       extension_name: httpfs
+      override_repository: Tmonster/duckdb
+      override_ref: 8a495cef3c25f3d48223018f6b6f95b0bf83299e
       duckdb_version: main
       ci_tools_version: main
 

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       extension_name: httpfs
-      override_duckdb_repository: tmonster/duckdb-httpfs
+      override_duckdb_repository: https://github.com/tmonster/duckdb-httpfs.git
       set_caller_as_duckdb: true
       duckdb_version: 981f07e87f132eb3d46841e19d30a8b7e28c34b9
       ci_tools_version: main

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,8 +17,6 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       extension_name: httpfs
-      override_repository: Tmonster/duckdb
-      override_ref: 8a495cef3c25f3d48223018f6b6f95b0bf83299e
       duckdb_version: main
       ci_tools_version: main
 

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -19,7 +19,7 @@ jobs:
       extension_name: httpfs
       override_duckdb_repository: tmonster/duckdb-httpfs
       set_caller_as_duckdb: true
-      duckdb_version: d53321d994af5a6c9e26908faf60e82cd6c5410a
+      duckdb_version: 981f07e87f132eb3d46841e19d30a8b7e28c34b9
       ci_tools_version: main
 
 

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,9 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       extension_name: httpfs
-      duckdb_version: main
+      override_duckdb_repository: tmonster/duckdb-httpfs
+      set_caller_as_duckdb: true
+      duckdb_version: d53321d994af5a6c9e26908faf60e82cd6c5410a
       ci_tools_version: main
 
 

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -18,7 +18,6 @@ jobs:
     with:
       extension_name: httpfs
       override_duckdb_repository: https://github.com/tmonster/duckdb-httpfs.git
-      set_caller_as_duckdb: true
       duckdb_version: 981f07e87f132eb3d46841e19d30a8b7e28c34b9
       ci_tools_version: main
 

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       extension_name: httpfs
-      duckdb_version: v1.3.0
+      duckdb_version: v1.3.1
       ci_tools_version: main
 
   duckdb-stable-deploy:
@@ -27,6 +27,6 @@ jobs:
     secrets: inherit
     with:
       extension_name: httpfs
-      duckdb_version: v1.3.0
+      duckdb_version: v1.3.1
       ci_tools_version: main
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       extension_name: httpfs
-      override_duckdb_repository: https://github.com/tmonster/duckdb-httpfs.git
+      override_duckdb_repository: https://github.com/tmonster/duckdb.git
       duckdb_version: 981f07e87f132eb3d46841e19d30a8b7e28c34b9
       ci_tools_version: main
 

--- a/.github/workflows/MinioTests.yml
+++ b/.github/workflows/MinioTests.yml
@@ -18,6 +18,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: minio_duckdb_user_password
       DUCKDB_S3_ENDPOINT: duckdb-minio.com:9000
       DUCKDB_S3_USE_SSL: false
+      CORE_EXTENSIONS: 'parquet;json'
       GEN: ninja
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
       VCPKG_TARGET_TRIPLET: x64-linux

--- a/.github/workflows/MinioTests.yml
+++ b/.github/workflows/MinioTests.yml
@@ -33,7 +33,10 @@ jobs:
 
       - name: Install Ninja
         shell: bash
-        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y -qq software-properties-common
+          sudo apt-get install -y -qq libcurl4-gnutls-dev libcurl4-openssl-dev ninja-build
 
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main

--- a/.github/workflows/MinioTests.yml
+++ b/.github/workflows/MinioTests.yml
@@ -10,7 +10,7 @@ defaults:
 jobs:
   minio-tests:
     name: Minio Tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     env:
       S3_TEST_SERVER_AVAILABLE: 1
       AWS_DEFAULT_REGION: eu-west-1

--- a/.github/workflows/MinioTests.yml
+++ b/.github/workflows/MinioTests.yml
@@ -19,6 +19,7 @@ jobs:
       DUCKDB_S3_ENDPOINT: duckdb-minio.com:9000
       DUCKDB_S3_USE_SSL: false
       GEN: ninja
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
       VCPKG_TARGET_TRIPLET: x64-linux
 
     steps:
@@ -31,12 +32,9 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install Ninja
+      - name: Install libraries
         shell: bash
-        run: |
-          sudo apt-get update -y -qq
-          sudo apt-get install -y -qq software-properties-common
-          sudo apt-get install -y -qq libcurl4-gnutls-dev libcurl4-openssl-dev ninja-build
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
 
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main
@@ -49,9 +47,11 @@ jobs:
         with:
           vcpkgGitCommitId: 5e5d0e1cd7785623065e77eff011afdeec1a3574
 
-      - name: Build
-        shell: bash
-        run: make
+      - name: Build extension
+        env:
+          GEN: ninja
+        run: |
+          make release
 
       - name: Start S3/HTTP test server
         shell: bash

--- a/.github/workflows/MinioTests.yml
+++ b/.github/workflows/MinioTests.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install libraries
+      - name: Install Ninja
         shell: bash
         run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
 
@@ -48,11 +48,9 @@ jobs:
         with:
           vcpkgGitCommitId: 5e5d0e1cd7785623065e77eff011afdeec1a3574
 
-      - name: Build extension
-        env:
-          GEN: ninja
-        run: |
-          make release
+      - name: Build
+        shell: bash
+        run: make
 
       - name: Start S3/HTTP test server
         shell: bash

--- a/.github/workflows/MinioTests.yml
+++ b/.github/workflows/MinioTests.yml
@@ -10,7 +10,7 @@ defaults:
 jobs:
   minio-tests:
     name: Minio Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       S3_TEST_SERVER_AVAILABLE: 1
       AWS_DEFAULT_REGION: eu-west-1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ add_extension_definitions()
 include_directories(extension/httpfs/include
                     ${DUCKDB_MODULE_BASE_DIR}/third_party/httplib)
 
+
+
 build_static_extension(
   httpfs
   extension/httpfs/hffs.cpp
@@ -38,7 +40,9 @@ if(MINGW)
 endif()
 
 find_package(OpenSSL REQUIRED)
+find_package(CURL REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR})
+include_directories(${CURL_INCLUDE_DIRS})
 if(EMSCRIPTEN)
 
 else()
@@ -46,12 +50,18 @@ else()
                         ${OPENSSL_LIBRARIES})
   target_link_libraries(httpfs_extension duckdb_mbedtls ${OPENSSL_LIBRARIES})
 
+  # Link dependencies into extension
+  target_link_libraries(httpfs_loadable_extension ${CURL_LIBRARIES})
+  target_link_libraries(httpfs_extension ${CURL_LIBRARIES})
+
+
   if(MINGW)
     find_package(ZLIB)
     target_link_libraries(httpfs_loadable_extension ZLIB::ZLIB -lcrypt32)
     target_link_libraries(httpfs_extension ZLIB::ZLIB -lcrypt32)
   endif()
 endif()
+
 
 install(
   TARGETS httpfs_extension

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,8 @@ build_static_extension(
   extension/httpfs/hffs.cpp
   extension/httpfs/s3fs.cpp
   extension/httpfs/httpfs.cpp
-  extension/httpfs/httpfs_client.cpp
+  extension/httpfs/httpfs_httplib_client.cpp
+  extension/httpfs/httpfs_curl_client.cpp
   extension/httpfs/http_state.cpp
   extension/httpfs/crypto.cpp
   extension/httpfs/create_secret_functions.cpp
@@ -27,7 +28,8 @@ build_loadable_extension(
   extension/httpfs/hffs.cpp
   extension/httpfs/s3fs.cpp
   extension/httpfs/httpfs.cpp
-  extension/httpfs/httpfs_client.cpp
+  extension/httpfs/httpfs_httplib_client.cpp
+  extension/httpfs/httpfs_curl_client.cpp
   extension/httpfs/http_state.cpp
   extension/httpfs/crypto.cpp
   extension/httpfs/create_secret_functions.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,6 @@ add_extension_definitions()
 include_directories(extension/httpfs/include
                     ${DUCKDB_MODULE_BASE_DIR}/third_party/httplib)
 
-
-
 build_static_extension(
   httpfs
   extension/httpfs/hffs.cpp

--- a/extension/httpfs/crypto.cpp
+++ b/extension/httpfs/crypto.cpp
@@ -5,7 +5,16 @@
 #include <stdio.h>
 
 #define CPPHTTPLIB_OPENSSL_SUPPORT
-#include "httplib.hpp"
+
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/ssl.h>
+#include <openssl/x509v3.h>
+#include <openssl/rand.h>
+
+#if defined(_WIN32) && defined(OPENSSL_USE_APPLINK)
+#include <openssl/applink.c>
+#endif
 
 namespace duckdb {
 

--- a/extension/httpfs/httpfs_client.cpp
+++ b/extension/httpfs/httpfs_client.cpp
@@ -138,9 +138,6 @@ public:
 
 	}
 
-	void SetLogger(HTTPLogger &logger) {
-		client->set_logger(logger.GetLogger<duckdb_httplib_openssl::Request, duckdb_httplib_openssl::Response>());
-	}
 
 	unique_ptr<HTTPResponse> Get(GetRequestInfo &info) override {
 		if (state) {

--- a/extension/httpfs/httpfs_client.cpp
+++ b/extension/httpfs/httpfs_client.cpp
@@ -40,68 +40,67 @@ static std::string SelectCURLCertPath() {
 static std::string cert_path = SelectCURLCertPath();
 
 static size_t RequestWriteCallback(void *contents, size_t size, size_t nmemb, void *userp) {
-	((std::string *)userp)->append((char *)contents, size * nmemb);
-	return size * nmemb;
+	size_t totalSize = size * nmemb;
+	std::string* str = static_cast<std::string*>(userp);
+	str->append(static_cast<char*>(contents), totalSize);
+	return totalSize;
 }
 
-class CURLRequestHeaders {
-public:
-	CURLRequestHeaders(vector<std::string> &input) {
-		for (auto &header : input) {
-			Add(header);
+static size_t RequestHeaderCallback(void *contents, size_t size, size_t nmemb, void *userp) {
+	size_t totalSize = size * nmemb;
+	std::string header(static_cast<char*>(contents), totalSize);
+	HeaderCollector* header_collection = static_cast<HeaderCollector*>(userp);
+
+	// Trim trailing \r\n
+	if (!header.empty() && header.back() == '\n') {
+		header.pop_back();
+		if (!header.empty() && header.back() == '\r') {
+			header.pop_back();
 		}
 	}
-	CURLRequestHeaders() {}
-	~CURLRequestHeaders() {
-		if (headers) {
-			curl_slist_free_all(headers);
+
+	// If header starts with HTTP/... curl has followed a redirect and we have a new Header,
+	// so we clear all of the current header_collection
+	if (header.rfind("HTTP/", 0) == 0) {
+		header_collection->header_collection.push_back(HTTPHeaders());
+	}
+
+	size_t colonPos = header.find(':');
+
+	if (colonPos != std::string::npos) {
+		// Split the string into two parts
+		std::string part1 = header.substr(0, colonPos);
+		std::string part2 = header.substr(colonPos + 1);
+		if (part2.at(0) == ' ') {
+			part2.erase(0, 1);
 		}
-		headers = NULL;
-	}
-	operator bool() const {
-		return headers != NULL;
-	}
 
-public:
-	void Add(const string &header) {
-		headers = curl_slist_append(headers, header.c_str());
+		header_collection->header_collection.back().Insert(part1, part2);
 	}
+	// TODO: some headers may not follow standard response header formats.
+	//  what to do in this case? Invalid does not mean we should abort.
 
-public:
-	curl_slist *headers = NULL;
-};
+	return totalSize;
+}
 
-
-class CURLHandle {
-public:
-	CURLHandle(const string &token, const string &cert_path) {
-		curl = curl_easy_init();
-		if (!curl) {
-			throw InternalException("Failed to initialize curl");
-		}
-		if (!token.empty()) {
-			curl_easy_setopt(curl, CURLOPT_XOAUTH2_BEARER, token.c_str());
-			curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BEARER);
-		}
-		if (!cert_path.empty()) {
-			curl_easy_setopt(curl, CURLOPT_CAINFO, cert_path.c_str());
-		}
+ CURLHandle::CURLHandle(const string &token, const string &cert_path) {
+	curl = curl_easy_init();
+	if (!curl) {
+		throw InternalException("Failed to initialize curl");
 	}
-	~CURLHandle() {
-		curl_easy_cleanup(curl);
+	if (!token.empty()) {
+		curl_easy_setopt(curl, CURLOPT_XOAUTH2_BEARER, token.c_str());
+		curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BEARER);
 	}
+	if (!cert_path.empty()) {
+		curl_easy_setopt(curl, CURLOPT_CAINFO, cert_path.c_str());
+	}
+}
 
-public:
-	operator CURL *() {
-		return curl;
-	}
-	CURLcode Execute() {
-		return curl_easy_perform(curl);
-	}
+CURLHandle::~CURLHandle() {
+	curl_easy_cleanup(curl);
+}
 
-private:
-	CURL *curl = NULL;
-};
 
 class HTTPFSClient : public HTTPClient {
 public:
@@ -129,12 +128,14 @@ public:
 			}
 		}
 		state = http_params.state;
+
+		// initializing curl
 		auto bearer_token = "";
 		if (!http_params.bearer_token.empty()) {
 			bearer_token = http_params.bearer_token.c_str();
 		}
 		curl = make_uniq<CURLHandle>(bearer_token, SelectCURLCertPath());
-		state = http_params.state;
+
 	}
 
 	void SetLogger(HTTPLogger &logger) {
@@ -142,15 +143,46 @@ public:
 	}
 
 	unique_ptr<HTTPResponse> Get(GetRequestInfo &info) override {
-		auto headers = TransformHeadersForCurl(info.headers, info.params);
-		CURLRequestHeaders curl_headers(headers);
+		if (state) {
+			state->get_count++;
+		}
+
+		// auto headers = TransformHeaders(info.headers, info.params);
+		// if (!info.response_handler && !info.content_handler) {
+		// 	return TransformResult(client->Get(info.path, headers));
+		// } else {
+		// 	return TransformResult(client->Get(
+		// 		info.path.c_str(), headers,
+		// 		[&](const duckdb_httplib_openssl::Response &response) {
+		// 			auto http_response = TransformResponse(response);
+		// 			return info.response_handler(*http_response);
+		// 		},
+		// 		[&](const char *data, size_t data_length) {
+		// 			if (state) {
+		// 				state->total_bytes_received += data_length;
+		// 			}
+		// 			return info.content_handler(const_data_ptr_cast(data), data_length);
+		// 		}));
+		// }
+
+		auto curl_headers = TransformHeadersForCurl(info.headers, info.params);
 
 		CURLcode res;
-		string result;
+		std::string result;
+		HeaderCollector response_header_collection;
 		{
+			// If the same handle served a HEAD request, we must set NOBODY back to 0L to request content again
+			curl_easy_setopt(*curl, CURLOPT_NOBODY, 0L);
+
+			// follow redirects
+			curl_easy_setopt(*curl, CURLOPT_FOLLOWLOCATION, 1L);
 			curl_easy_setopt(*curl, CURLOPT_URL, info.url.c_str());
+			// write response data
 			curl_easy_setopt(*curl, CURLOPT_WRITEFUNCTION, RequestWriteCallback);
 			curl_easy_setopt(*curl, CURLOPT_WRITEDATA, &result);
+			// write response headers (different header collection for each redirect)
+			curl_easy_setopt(*curl, CURLOPT_HEADERFUNCTION, RequestHeaderCallback);
+			curl_easy_setopt(*curl, CURLOPT_HEADERDATA, &response_header_collection);
 
 			if (curl_headers) {
 				curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers.headers);
@@ -165,17 +197,28 @@ public:
 			throw HTTPException(StringUtil::Format("Curl GET Request to '%s' failed with error: '%s'", info.url, error));
 		}
 		uint16_t response_code = 0;
-		curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, response_code);
+		curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, &response_code);
 
-		// TODO: replace this with better bytes received provided by curl.
+		idx_t bytes_received = 0;
+		if (response_header_collection.header_collection.back().HasHeader("content-length")) {
+			bytes_received = std::stoi(response_header_collection.header_collection.back().GetHeaderValue("content-length"));
+			D_ASSERT(bytes_received == result.size());
+		} else {
+			bytes_received = result.size();
+		}
 		if (state) {
-			state->total_bytes_received += sizeof(result);
+			state->total_bytes_received += bytes_received;
 		}
 
-		// get the response code
+		const char* data = result.c_str();
+		info.content_handler(const_data_ptr_cast(data), bytes_received);
+
+		// Construct HTTPResponse
 		auto status_code = HTTPStatusCode(response_code);
 		auto return_result = make_uniq<HTTPResponse>(status_code);
 		return_result->body = result;
+		return_result->headers = response_header_collection.header_collection.back();
+		return_result->url = info.url;
 		return return_result;
 	}
 
@@ -184,25 +227,170 @@ public:
 			state->put_count++;
 			state->total_bytes_sent += info.buffer_in_len;
 		}
-		auto headers = TransformHeaders(info.headers, info.params);
-		return TransformResult(client->Put(info.path, headers, const_char_ptr_cast(info.buffer_in), info.buffer_in_len,
-		                                   info.content_type));
+		// auto headers = TransformHeaders(info.headers, info.params);
+		// return TransformResult(client->Put(info.path, headers, const_char_ptr_cast(info.buffer_in), info.buffer_in_len,
+		//                                    info.content_type));
+
+		auto curl_headers = TransformHeadersForCurl(info.headers, info.params);
+		// Optionally add headers directly
+		curl_headers.headers = curl_slist_append(curl_headers.headers, "Content-Type: application/json");
+
+		CURLcode res;
+		std::string result;
+		HeaderCollector response_header_collection;
+
+		{
+			curl_easy_setopt(*curl, CURLOPT_URL, info.url.c_str());
+
+			// Perform PUT
+			curl_easy_setopt(*curl, CURLOPT_CUSTOMREQUEST, "PUT");
+
+			// Include PUT body
+			curl_easy_setopt(*curl, CURLOPT_POSTFIELDS, const_char_ptr_cast(info.buffer_in));
+			curl_easy_setopt(*curl, CURLOPT_POSTFIELDSIZE, info.buffer_in_len);
+
+			// Follow redirects if needed
+			curl_easy_setopt(*curl, CURLOPT_FOLLOWLOCATION, 1L);
+
+			// Capture response body
+			curl_easy_setopt(*curl, CURLOPT_WRITEFUNCTION, RequestWriteCallback);
+			curl_easy_setopt(*curl, CURLOPT_WRITEDATA, &result);
+
+			// Capture response headers
+			curl_easy_setopt(*curl, CURLOPT_HEADERFUNCTION, RequestHeaderCallback);
+			curl_easy_setopt(*curl, CURLOPT_HEADERDATA, &response_header_collection);
+
+			// Apply headers
+			if (curl_headers) {
+				curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers.headers);
+			}
+
+			// Execute the request
+			res = curl->Execute();
+		}
+
+		// Check response
+		if (res != CURLcode::CURLE_OK) {
+			std::string error = curl_easy_strerror(res);
+			throw HTTPException(StringUtil::Format("Curl PUT Request to '%s' failed with error: '%s'", info.url, error));
+		}
+
+		uint16_t response_code = 0;
+		curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, &response_code);
+
+		// Construct HTTPResponse
+		auto status_code = HTTPStatusCode(response_code);
+		auto return_result = make_uniq<HTTPResponse>(status_code);
+		return_result->body = "";
+		return_result->headers = response_header_collection.header_collection.back();
+		return_result->url = info.url;
+		return return_result;
 	}
 
 	unique_ptr<HTTPResponse> Head(HeadRequestInfo &info) override {
-		if (state) {
-			state->head_count++;
-		}
-		auto headers = TransformHeaders(info.headers, info.params);
-		return TransformResult(client->Head(info.path, headers));
+
+		 auto curl_headers = TransformHeadersForCurl(info.headers, info.params);
+
+		 CURLcode res;
+		 std::string result;
+		 HeaderCollector response_header_collection;
+
+		 {
+		 	// Set URL
+		 	curl_easy_setopt(*curl, CURLOPT_URL, info.url.c_str());
+			// curl_easy_setopt(*curl, CURLOPT_VERBOSE, 1L);
+
+		 	// Perform HEAD request instead of GET
+		 	curl_easy_setopt(*curl, CURLOPT_NOBODY, 1L);
+		 	curl_easy_setopt(*curl, CURLOPT_HTTPGET, 0L);
+
+		 	// Follow redirects
+		 	curl_easy_setopt(*curl, CURLOPT_FOLLOWLOCATION, 1L);
+
+		 	//  set write function to collect body — no body expected, so safe to omit
+		 	curl_easy_setopt(*curl, CURLOPT_WRITEFUNCTION, RequestWriteCallback);
+		 	curl_easy_setopt(*curl, CURLOPT_WRITEDATA, &result);
+
+		 	// Collect response headers (multiple header blocks for redirects)
+		 	curl_easy_setopt(*curl, CURLOPT_HEADERFUNCTION, RequestHeaderCallback);
+		 	curl_easy_setopt(*curl, CURLOPT_HEADERDATA, &response_header_collection);
+
+		 	// Add headers if any
+		 	if (curl_headers) {
+		 		curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers.headers);
+		 	}
+
+		 	// Execute HEAD request
+		 	res = curl->Execute();
+		 }
+
+		 // Handle result
+		 if (res != CURLcode::CURLE_OK) {
+		 	string error = curl_easy_strerror(res);
+		 	throw HTTPException(StringUtil::Format("Curl HEAD Request to '%s' failed with error: '%s'", info.url, error));
+		 }
+		 uint16_t response_code = 0;
+		 curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, &response_code);
+		 // Construct HTTPResponse
+		 auto status_code = HTTPStatusCode(response_code);
+		 auto return_result = make_uniq<HTTPResponse>(status_code);
+		 return_result->body = "";
+		 return_result->headers = response_header_collection.header_collection.back();
+		 return_result->url = info.url;
+		 return return_result;
 	}
 
 	unique_ptr<HTTPResponse> Delete(DeleteRequestInfo &info) override {
-		if (state) {
-			state->delete_count++;
+		auto curl_headers = TransformHeadersForCurl(info.headers, info.params);
+
+		CURLcode res;
+		std::string result;
+		HeaderCollector response_header_collection;
+
+		// TODO: some delete requests require a BODY
+		{
+			// Set URL
+			curl_easy_setopt(*curl, CURLOPT_URL, info.url.c_str());
+
+			// Set DELETE request method
+			curl_easy_setopt(*curl, CURLOPT_CUSTOMREQUEST, "DELETE");
+
+			// Follow redirects
+			curl_easy_setopt(*curl, CURLOPT_FOLLOWLOCATION, 1L);
+
+			// Set write function to collect response body
+			curl_easy_setopt(*curl, CURLOPT_WRITEFUNCTION, RequestWriteCallback);
+			curl_easy_setopt(*curl, CURLOPT_WRITEDATA, &result);
+
+			// Collect response headers (multiple header blocks for redirects)
+			curl_easy_setopt(*curl, CURLOPT_HEADERFUNCTION, RequestHeaderCallback);
+			curl_easy_setopt(*curl, CURLOPT_HEADERDATA, &response_header_collection);
+
+			// Add headers if any
+			if (curl_headers) {
+				curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers.headers);
+			}
+
+			// Execute DELETE request
+			res = curl->Execute();
 		}
-		auto headers = TransformHeaders(info.headers, info.params);
-		return TransformResult(client->Delete(info.path, headers));
+
+		// Handle result
+		if (res != CURLcode::CURLE_OK) {
+			std::string error = curl_easy_strerror(res);
+			throw HTTPException(StringUtil::Format("Curl DELETE Request to '%s' failed with error: '%s'", info.url, error));
+		}
+
+		// Get HTTP response status code
+		uint16_t response_code = 0;
+		curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, &response_code);
+		// Construct HTTPResponse
+		auto status_code = HTTPStatusCode(response_code);
+		auto return_result = make_uniq<HTTPResponse>(status_code);
+		return_result->headers = response_header_collection.header_collection.back();
+		return_result->url = info.url;
+		return return_result;
+
 	}
 
 	unique_ptr<HTTPResponse> Post(PostRequestInfo &info) override {
@@ -210,22 +398,75 @@ public:
 			state->post_count++;
 			state->total_bytes_sent += info.buffer_in_len;
 		}
-		// We use a custom Request method here, because there is no Post call with a contentreceiver in httplib
-		duckdb_httplib_openssl::Request req;
-		req.method = "POST";
-		req.path = info.path;
-		req.headers = TransformHeaders(info.headers, info.params);
-		req.headers.emplace("Content-Type", "application/octet-stream");
-		req.content_receiver = [&](const char *data, size_t data_length, uint64_t /*offset*/,
-		                           uint64_t /*total_length*/) {
-			if (state) {
-				state->total_bytes_received += data_length;
+
+		// // We use a custom Request method here, because there is no Post call with a contentreceiver in httplib
+		// duckdb_httplib_openssl::Request req;
+		// req.method = "POST";
+		// req.path = info.path;
+		// req.headers = TransformHeaders(info.headers, info.params);
+		// req.headers.emplace("Content-Type", "application/octet-stream");
+		// req.content_receiver = [&](const char *data, size_t data_length, uint64_t /*offset*/,
+		//                            uint64_t /*total_length*/) {
+		// 	if (state) {
+		// 		state->total_bytes_received += data_length;
+		// 	}
+		// 	info.buffer_out += string(data, data_length);
+		// 	return true;
+		// };
+		// req.body.assign(const_char_ptr_cast(info.buffer_in), info.buffer_in_len);
+		// return TransformResult(client->send(req));
+
+		auto curl_headers = TransformHeadersForCurl(info.headers, info.params);
+		curl_headers.Add("Content-Type: application/octet-stream");
+
+		CURLcode res;
+		std::string result;
+		HeaderCollector response_header_collection;
+
+		{
+			curl_easy_setopt(*curl, CURLOPT_URL, info.url.c_str());
+			curl_easy_setopt(*curl, CURLOPT_POST, 1L);
+
+			// Set POST body
+			curl_easy_setopt(*curl, CURLOPT_POSTFIELDS, const_char_ptr_cast(info.buffer_in));
+			curl_easy_setopt(*curl, CURLOPT_POSTFIELDSIZE, info.buffer_in_len);
+
+			// Follow redirects
+			// TODO: follow redirects for POST?
+			curl_easy_setopt(*curl, CURLOPT_FOLLOWLOCATION, 1L);
+
+			// Set write function to collect response body
+			curl_easy_setopt(*curl, CURLOPT_WRITEFUNCTION, RequestWriteCallback);
+			curl_easy_setopt(*curl, CURLOPT_WRITEDATA, &result);
+
+			// Collect response headers (multiple header blocks for redirects)
+			curl_easy_setopt(*curl, CURLOPT_HEADERFUNCTION, RequestHeaderCallback);
+			curl_easy_setopt(*curl, CURLOPT_HEADERDATA, &response_header_collection);
+
+			// Add headers if any
+			if (curl_headers) {
+				curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers.headers);
 			}
-			info.buffer_out += string(data, data_length);
-			return true;
-		};
-		req.body.assign(const_char_ptr_cast(info.buffer_in), info.buffer_in_len);
-		return TransformResult(client->send(req));
+
+			// Execute POST request
+			res = curl->Execute();
+		}
+
+		// Handle result
+		if (res != CURLcode::CURLE_OK) {
+			string error = curl_easy_strerror(res);
+			throw HTTPException(StringUtil::Format("Curl POST Request to '%s' failed with error: '%s'", info.url, error));
+		}
+		uint16_t response_code = 0;
+		curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, &response_code);
+
+		info.buffer_out = result;
+		// Construct HTTPResponse
+		auto status_code = HTTPStatusCode(response_code);
+		auto return_result = make_uniq<HTTPResponse>(status_code);
+		return_result->headers = response_header_collection.header_collection.back();
+		return_result->url = info.url;
+		return return_result;
 	}
 
 private:
@@ -243,11 +484,11 @@ private:
 	CURLRequestHeaders TransformHeadersForCurl(const HTTPHeaders &header_map, const HTTPParams &params) {
 		std::vector<std::string> headers;
 		for (auto &entry : header_map) {
-			const std::string new_header = entry.first + "=" + entry.second;
+			const std::string new_header = entry.first + ": " + entry.second;
 			headers.push_back(new_header);
 		}
 		for (auto &entry : params.extra_headers) {
-			const std::string new_header = entry.first + "=" + entry.second;
+			const std::string new_header = entry.first + ": " + entry.second;
 			headers.push_back(new_header);
 		}
 		CURLRequestHeaders curl_headers;
@@ -255,7 +496,6 @@ private:
 			curl_headers.Add(header);
 		}
 		return curl_headers;
-		// return CURLRequestHeaders(headers);
 	}
 
 	unique_ptr<HTTPResponse> TransformResponse(const duckdb_httplib_openssl::Response &response) {
@@ -283,6 +523,7 @@ private:
 private:
 	unique_ptr<duckdb_httplib_openssl::Client> client;
 	unique_ptr<CURLHandle> curl;
+	CURLRequestHeaders request_headers;
 	optional_ptr<HTTPState> state;
 };
 

--- a/extension/httpfs/httpfs_client.cpp
+++ b/extension/httpfs/httpfs_client.cpp
@@ -94,8 +94,6 @@ static size_t RequestHeaderCallback(void *contents, size_t size, size_t nmemb, v
 	}
 	if (!cert_path.empty()) {
 		curl_easy_setopt(curl, CURLOPT_CAINFO, cert_path.c_str());
-	} else {
-		throw InternalException("Could not set certificate authority");
 	}
 }
 

--- a/extension/httpfs/httpfs_client.cpp
+++ b/extension/httpfs/httpfs_client.cpp
@@ -294,8 +294,6 @@ public:
 			curl_easy_setopt(*curl, CURLOPT_NOBODY, 1L);
 			curl_easy_setopt(*curl, CURLOPT_HTTPGET, 0L);
 
-			curl_easy_setopt(*curl, CURLOPT_VERBOSE, 1L);
-
 			// Follow redirects
 			curl_easy_setopt(*curl, CURLOPT_FOLLOWLOCATION, 1L);
 

--- a/extension/httpfs/httpfs_client.cpp
+++ b/extension/httpfs/httpfs_client.cpp
@@ -118,7 +118,7 @@ public:
 		}
 		state = http_params.state;
 		// init curl globally,
-		// curl_global_init(CURL_GLOBAL_DEFAULT);
+		curl_global_init(CURL_GLOBAL_DEFAULT);
 		curl = make_uniq<CURLHandle>(bearer_token, SelectCURLCertPath());
 
 		// set curl options
@@ -159,8 +159,7 @@ public:
 	}
 
 	~HTTPFSClient() {
-		// init curl globally,
-		 // curl_global_cleanup();
+		curl_global_cleanup();
 	}
 
 	unique_ptr<HTTPResponse> Get(GetRequestInfo &info) override {

--- a/extension/httpfs/httpfs_client.cpp
+++ b/extension/httpfs/httpfs_client.cpp
@@ -110,6 +110,7 @@ public:
 		if (!http_params.bearer_token.empty()) {
 			bearer_token = http_params.bearer_token.c_str();
 		}
+		state = http_params.state;
 		curl = make_uniq<CURLHandle>(bearer_token, SelectCURLCertPath());
 	}
 
@@ -234,17 +235,12 @@ public:
 		curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, &response_code);
 
 		return TransformResponseCurl(response_code, response_header_collection, result, res, url);
-
-		// Construct HTTPResponse
-		// auto status_code = HTTPStatusCode(response_code);
-		// auto return_result = make_uniq<HTTPResponse>(status_code);
-		// return_result->body = "";
-		// return_result->headers = response_header_collection.header_collection.back();
-		// return_result->url = info.url;
-		// return return_result;
 	}
 
 	unique_ptr<HTTPResponse> Head(HeadRequestInfo &info) override {
+		if (state) {
+			state->head_count++;
+		}
 
 		auto curl_headers = TransformHeadersForCurl(info.headers);
 		// transform parameters
@@ -298,6 +294,10 @@ public:
 	}
 
 	unique_ptr<HTTPResponse> Delete(DeleteRequestInfo &info) override {
+		if (state) {
+			state->delete_count++;
+		}
+
 		auto curl_headers = TransformHeadersForCurl(info.headers);
 		// transform parameters
 		auto url = info.url;

--- a/extension/httpfs/httpfs_curl_client.cpp
+++ b/extension/httpfs/httpfs_curl_client.cpp
@@ -77,8 +77,7 @@ static size_t RequestHeaderCallback(void *contents, size_t size, size_t nmemb, v
 
 		header_collection->header_collection.back().Insert(part1, part2);
 	}
-	// TODO: some headers may not follow standard response header formats.
-	//  what to do in this case? Invalid does not mean we should abort.
+	// TODO: log headers that don't follow the header format
 
 	return totalSize;
 }
@@ -141,11 +140,6 @@ public:
 			curl_easy_setopt(*curl, CURLOPT_SSL_VERIFYPEER, 1L);   // Verify the cert
 			curl_easy_setopt(*curl, CURLOPT_SSL_VERIFYHOST, 2L);   // Verify that the cert matches the hostname
 		}
-
-		// TODO: no global write timeout option, but you could put customize a timeout in the write functions
-		//  or handle use CURLOPT_XFERINFOFUNCTION (progress callback) with CURLOPT_TIMEOUT_MS
-		//  we could also set CURLOPT_LOW_SPEED_LIMIT and timeout if the speed is too low for
-		//  too long.
 
 		// set read timeout
 		curl_easy_setopt(*curl, CURLOPT_TIMEOUT, http_params.timeout);

--- a/extension/httpfs/httpfs_curl_client.cpp
+++ b/extension/httpfs/httpfs_curl_client.cpp
@@ -206,7 +206,10 @@ public:
 		}
 
 		const char* data = request_info->body.c_str();
-		info.content_handler(const_data_ptr_cast(data), bytes_received);
+		if (info.content_handler) {
+			 info.content_handler(const_data_ptr_cast(data), bytes_received);
+		}
+
 		return TransformResponseCurl(res);
 	}
 

--- a/extension/httpfs/httpfs_curl_client.cpp
+++ b/extension/httpfs/httpfs_curl_client.cpp
@@ -112,9 +112,9 @@ struct RequestInfo {
 
 static idx_t httpfs_client_count = 0;
 
-class HTTPFSClient : public HTTPClient {
+class HTTPFSCurlClient : public HTTPClient {
 public:
-	HTTPFSClient(HTTPFSParams &http_params, const string &proto_host_port) {
+	HTTPFSCurlClient(HTTPFSParams &http_params, const string &proto_host_port) {
 		auto bearer_token = "";
 		if (!http_params.bearer_token.empty()) {
 			bearer_token = http_params.bearer_token.c_str();
@@ -173,7 +173,7 @@ public:
 		}
 	}
 
-	~HTTPFSClient() {
+	~HTTPFSCurlClient() {
 		DestroyCurlGlobal();
 	}
 
@@ -453,12 +453,12 @@ private:
 	}
 };
 
-unique_ptr<HTTPClient> HTTPFSUtil::InitializeClient(HTTPParams &http_params, const string &proto_host_port) {
-	auto client = make_uniq<HTTPFSClient>(http_params.Cast<HTTPFSParams>(), proto_host_port);
+unique_ptr<HTTPClient> HTTPFSCurlUtil::InitializeClient(HTTPParams &http_params, const string &proto_host_port) {
+	auto client = make_uniq<HTTPFSCurlClient>(http_params.Cast<HTTPFSParams>(), proto_host_port);
 	return std::move(client);
 }
 
-unordered_map<string, string> HTTPFSUtil::ParseGetParameters(const string &text) {
+unordered_map<string, string> HTTPFSCurlUtil::ParseGetParameters(const string &text) {
 	unordered_map<std::string, std::string> params;
 
 	auto pos = text.find('?');
@@ -482,8 +482,8 @@ unordered_map<string, string> HTTPFSUtil::ParseGetParameters(const string &text)
 	return params;
 }
 
-string HTTPFSUtil::GetName() const {
-	return "HTTPFS";
+string HTTPFSCurlUtil::GetName() const {
+	return "HTTPFS-Curl";
 }
 
 } // namespace duckdb

--- a/extension/httpfs/httpfs_httplib_client.cpp
+++ b/extension/httpfs/httpfs_httplib_client.cpp
@@ -1,9 +1,6 @@
 #include "httpfs_client.hpp"
 #include "http_state.hpp"
 #define CPPHTTPLIB_OPENSSL_SUPPORT
-#if defined(_WIN32)
-#include "duckdb/common/windows.hpp"
-#endif
 #include "httplib.hpp"
 
 

--- a/extension/httpfs/httpfs_httplib_client.cpp
+++ b/extension/httpfs/httpfs_httplib_client.cpp
@@ -1,0 +1,167 @@
+#include "httpfs_client.hpp"
+#include "http_state.hpp"
+
+#define CPPHTTPLIB_OPENSSL_SUPPORT
+#include "httplib.hpp"
+
+namespace duckdb {
+
+class HTTPFSClient : public HTTPClient {
+public:
+	HTTPFSClient(HTTPFSParams &http_params, const string &proto_host_port) {
+		client = make_uniq<duckdb_httplib_openssl::Client>(proto_host_port);
+		client->set_follow_location(http_params.follow_location);
+		client->set_keep_alive(http_params.keep_alive);
+		if (!http_params.ca_cert_file.empty()) {
+			client->set_ca_cert_path(http_params.ca_cert_file.c_str());
+		}
+		client->enable_server_certificate_verification(http_params.enable_server_cert_verification);
+		client->set_write_timeout(http_params.timeout, http_params.timeout_usec);
+		client->set_read_timeout(http_params.timeout, http_params.timeout_usec);
+		client->set_connection_timeout(http_params.timeout, http_params.timeout_usec);
+		client->set_decompress(false);
+		if (!http_params.bearer_token.empty()) {
+			client->set_bearer_token_auth(http_params.bearer_token.c_str());
+		}
+
+		if (!http_params.http_proxy.empty()) {
+			client->set_proxy(http_params.http_proxy, http_params.http_proxy_port);
+
+			if (!http_params.http_proxy_username.empty()) {
+				client->set_proxy_basic_auth(http_params.http_proxy_username, http_params.http_proxy_password);
+			}
+		}
+		state = http_params.state;
+	}
+
+	unique_ptr<HTTPResponse> Get(GetRequestInfo &info) override {
+		if (state) {
+			state->get_count++;
+		}
+		auto headers = TransformHeaders(info.headers, info.params);
+		if (!info.response_handler && !info.content_handler) {
+			return TransformResult(client->Get(info.path, headers));
+		} else {
+			return TransformResult(client->Get(
+			    info.path.c_str(), headers,
+			    [&](const duckdb_httplib_openssl::Response &response) {
+				    auto http_response = TransformResponse(response);
+				    return info.response_handler(*http_response);
+			    },
+			    [&](const char *data, size_t data_length) {
+				    if (state) {
+					    state->total_bytes_received += data_length;
+				    }
+				    return info.content_handler(const_data_ptr_cast(data), data_length);
+			    }));
+		}
+	}
+	unique_ptr<HTTPResponse> Put(PutRequestInfo &info) override {
+		if (state) {
+			state->put_count++;
+			state->total_bytes_sent += info.buffer_in_len;
+		}
+		auto headers = TransformHeaders(info.headers, info.params);
+		return TransformResult(client->Put(info.path, headers, const_char_ptr_cast(info.buffer_in), info.buffer_in_len,
+		                                   info.content_type));
+	}
+
+	unique_ptr<HTTPResponse> Head(HeadRequestInfo &info) override {
+		if (state) {
+			state->head_count++;
+		}
+		auto headers = TransformHeaders(info.headers, info.params);
+		return TransformResult(client->Head(info.path, headers));
+	}
+
+	unique_ptr<HTTPResponse> Delete(DeleteRequestInfo &info) override {
+		if (state) {
+			state->delete_count++;
+		}
+		auto headers = TransformHeaders(info.headers, info.params);
+		return TransformResult(client->Delete(info.path, headers));
+	}
+
+	unique_ptr<HTTPResponse> Post(PostRequestInfo &info) override {
+		if (state) {
+			state->post_count++;
+			state->total_bytes_sent += info.buffer_in_len;
+		}
+		// We use a custom Request method here, because there is no Post call with a contentreceiver in httplib
+		duckdb_httplib_openssl::Request req;
+		req.method = "POST";
+		req.path = info.path;
+		req.headers = TransformHeaders(info.headers, info.params);
+		req.headers.emplace("Content-Type", "application/octet-stream");
+		req.content_receiver = [&](const char *data, size_t data_length, uint64_t /*offset*/,
+		                           uint64_t /*total_length*/) {
+			if (state) {
+				state->total_bytes_received += data_length;
+			}
+			info.buffer_out += string(data, data_length);
+			return true;
+		};
+		req.body.assign(const_char_ptr_cast(info.buffer_in), info.buffer_in_len);
+		return TransformResult(client->send(req));
+	}
+
+private:
+	duckdb_httplib_openssl::Headers TransformHeaders(const HTTPHeaders &header_map, const HTTPParams &params) {
+		duckdb_httplib_openssl::Headers headers;
+		for (auto &entry : header_map) {
+			headers.insert(entry);
+		}
+		for (auto &entry : params.extra_headers) {
+			headers.insert(entry);
+		}
+		return headers;
+	}
+
+	unique_ptr<HTTPResponse> TransformResponse(const duckdb_httplib_openssl::Response &response) {
+		auto status_code = HTTPUtil::ToStatusCode(response.status);
+		auto result = make_uniq<HTTPResponse>(status_code);
+		result->body = response.body;
+		result->reason = response.reason;
+		for (auto &entry : response.headers) {
+			result->headers.Insert(entry.first, entry.second);
+		}
+		return result;
+	}
+
+	unique_ptr<HTTPResponse> TransformResult(duckdb_httplib_openssl::Result &&res) {
+		if (res.error() == duckdb_httplib_openssl::Error::Success) {
+			auto &response = res.value();
+			return TransformResponse(response);
+		} else {
+			auto result = make_uniq<HTTPResponse>(HTTPStatusCode::INVALID);
+			result->request_error = to_string(res.error());
+			return result;
+		}
+	}
+
+private:
+	unique_ptr<duckdb_httplib_openssl::Client> client;
+	optional_ptr<HTTPState> state;
+};
+
+unique_ptr<HTTPClient> HTTPFSUtil::InitializeClient(HTTPParams &http_params, const string &proto_host_port) {
+	auto client = make_uniq<HTTPFSClient>(http_params.Cast<HTTPFSParams>(), proto_host_port);
+	return std::move(client);
+}
+
+unordered_map<string, string> HTTPFSUtil::ParseGetParameters(const string &text) {
+	duckdb_httplib_openssl::Params query_params;
+	duckdb_httplib_openssl::detail::parse_query_text(text, query_params);
+
+	unordered_map<string, string> result;
+	for (auto &entry : query_params) {
+		result.emplace(std::move(entry.first), std::move(entry.second));
+	}
+	return result;
+}
+
+string HTTPFSUtil::GetName() const {
+	return "HTTPFS";
+}
+
+} // namespace duckdb

--- a/extension/httpfs/httpfs_httplib_client.cpp
+++ b/extension/httpfs/httpfs_httplib_client.cpp
@@ -1,10 +1,11 @@
 #include "httpfs_client.hpp"
 #include "http_state.hpp"
+#define CPPHTTPLIB_OPENSSL_SUPPORT
 #if defined(_WIN32)
 #include "duckdb/common/windows.hpp"
 #endif
 #include "httplib.hpp"
-#define CPPHTTPLIB_OPENSSL_SUPPORT
+
 
 
 namespace duckdb {

--- a/extension/httpfs/httpfs_httplib_client.cpp
+++ b/extension/httpfs/httpfs_httplib_client.cpp
@@ -1,8 +1,11 @@
 #include "httpfs_client.hpp"
 #include "http_state.hpp"
-
-#define CPPHTTPLIB_OPENSSL_SUPPORT
+#if defined(_WIN32)
+#include "duckdb/common/windows.hpp"
+#endif
 #include "httplib.hpp"
+#define CPPHTTPLIB_OPENSSL_SUPPORT
+
 
 namespace duckdb {
 

--- a/extension/httpfs/include/httpfs_client.hpp
+++ b/extension/httpfs/include/httpfs_client.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb/common/http_util.hpp"
+#include <curl/curl.h>
 
 namespace duckdb {
 class HTTPLogger;
@@ -35,5 +36,55 @@ public:
 
 	string GetName() const override;
 };
+
+class CURLHandle {
+public:
+	CURLHandle(const string &token, const string &cert_path);
+	~CURLHandle();
+
+public:
+	operator CURL *() {
+		return curl;
+	}
+	CURLcode Execute() {
+		return curl_easy_perform(curl);
+	}
+
+private:
+	CURL *curl = NULL;
+};
+
+class CURLRequestHeaders {
+public:
+	CURLRequestHeaders(vector<std::string> &input) {
+		for (auto &header : input) {
+			Add(header);
+		}
+	}
+	CURLRequestHeaders() {}
+
+	~CURLRequestHeaders() {
+		if (headers) {
+			curl_slist_free_all(headers);
+		}
+		headers = NULL;
+	}
+	operator bool() const {
+		return headers != NULL;
+	}
+
+public:
+	void Add(const string &header) {
+		headers = curl_slist_append(headers, header.c_str());
+	}
+
+public:
+	curl_slist *headers = NULL;
+};
+
+struct HeaderCollector {
+	std::vector<HTTPHeaders> header_collection;
+};
+
 
 } // namespace duckdb

--- a/extension/httpfs/include/httpfs_client.hpp
+++ b/extension/httpfs/include/httpfs_client.hpp
@@ -37,6 +37,15 @@ public:
 	string GetName() const override;
 };
 
+class HTTPFSCurlUtil : public HTTPFSUtil {
+public:
+	unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
+
+	static unordered_map<string, string> ParseGetParameters(const string &text);
+
+	string GetName() const override;
+};
+
 class CURLHandle {
 public:
 	CURLHandle(const string &token, const string &cert_path);

--- a/test/sql/copy/csv/test_csv_httpfs.test
+++ b/test/sql/copy/csv/test_csv_httpfs.test
@@ -28,8 +28,6 @@ select * from 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_
 11	production designer
 12	guest
 
-pragma enable_logging('HTTP');
-
 query IIIIIIIIIIIIIIIIII
 select * from 'https://github.com/duckdb/duckdb/raw/9cf66f950dde0173e1a863a7659b3ecf11bf3978/data/csv/customer.csv';
 ----

--- a/test/sql/copy/csv/test_csv_httpfs.test
+++ b/test/sql/copy/csv/test_csv_httpfs.test
@@ -12,6 +12,11 @@ PRAGMA enable_verification
 statement ok
 pragma enable_logging('HTTP');
 
+foreach httpfs_implementation curl httplib
+
+statement ok
+SET httpfs_client_implementation='${httpfs_implementation}';
+
 query II
 select * from 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_role_type.parquet' order by all;
 ----
@@ -298,6 +303,12 @@ select * from read_csv_auto('https://csvbase.com/meripaterson/stock-exchanges');
 250	Africa	Zimbabwe	Victoria Falls Stock Exchange	NULL	2020-11-01
 251	Asia	China	Beijing Stock Exchange	NULL	2021-12-27
 
+endloop
+
+statement error
+SET httpfs_client_implementation='unkown';
+----
+<REGEX>:.*Unsupported option for httpfs_client_implementation.*
 
 #FIXME this test fails: file is nonexistent
 mode skip

--- a/test/sql/copy/csv/test_csv_httpfs.test
+++ b/test/sql/copy/csv/test_csv_httpfs.test
@@ -9,99 +9,35 @@ require parquet
 statement ok
 PRAGMA enable_verification
 
-statement ok
-select * from 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_role_type.parquet';
-
-
-#FIXME this test fails: file is nonexistent
-mode skip
-
-query IIIIII rowsort
-SELECT * from read_csv_auto('https://www.data.gouv.fr/fr/datasets/r/6d186965-f41b-41f3-9b23-88241cc6890c');
+query II
+select * from 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_role_type.parquet' order by all;
 ----
-2020	Allemagne	Germany	26.1	53196.069	200601.2
-2020	Autriche	Austria	18.0	4723.5	26215.8
-2020	Belgique	Belgium	28.999999999999996	9436.1	32553.0
-2020	Bulgarie	Bulgaria	11.600000000000001	1124.1	9698.7
-2020	Chypre	Cyprus	0.0	0.0	1627.6
-2020	Croatie	Croatia	16.3	1094.8	6726.3
-2020	Danemark	Denmark	11.600000000000001	1579.0	13601.4
-2020	Espagne	Spain	17.4	14211.7	81512.9
-2020	Estonie	Estonia	8.5	241.1	2827.3
-2020	Finlande	Finland	2.8000000000000003	692.3	24674.4
-2020	France	France	20.3	28278.9	139375.8
-2020	Grèce	Greece	5.800000000000001	896.5	15401.9
-2020	Hongrie	Hungary	30.5	5486.7	17872.4
-2020	Irlande	Ireland	17.4	1968.477	11296.601
-2020	Italie	Italy	29.2	33042.585	113119.475
-2020	Lettonie	Latvia	8.200000000000001	323.605	3926.131
-2020	Lituanie	Lithuania	10.7	584.104	5457.728
-2020	Luxembourg	Luxembourg	16.5	623.165	3786.785
-2020	Malte	Malta	0.0	0.0	547.5
-2020	Pays-Bas	Netherlands	37.1	16588.314	44682.656
-2020	Pologne	Poland	13.5	9323.205	69135.018
-2020	Portugal	Portugal	11.1	1814.878	16354.725
-2020	Roumanie	Romania	23.7	5626.161	23712.653
-2020	Royaume-Uni	United Kingdom	32.4	39311.416	121414.483
-2020	République tchèque	Czech Republic	21.4	5187.282	24263.896
-2020	Slovaquie	Slovakia	25.0	2564.876	10248.401
-2020	Slovénie	Slovenia	12.1	590.243	4861.315
-2020	Suède	Sweden	1.5	475.195	31311.413
-2020	UE 28	Europe 28	22.5	238152.4	1056907.5
-2021	Allemagne	Germany	26.760345686044435	51812.567	193616.957
-2021	Autriche	Austria	18.720006775926056	4645.795	24817.272
-2021	Belgique	Belgium	29.279402721103864	9088.083	31039.168
-2021	Bulgarie	Bulgaria	12.368015142641884	1176.537	9512.739
-2021	Chypre	Cyprus	0.0	0.0	1528.558
-2021	Croatie	Croatia	17.10389029082304	1100.12	6431.987
-2021	Danemark	Denmark	11.485631727184947	1508.152	13130.771
-2021	Espagne	Spain	19.10173955663722	13815.0	72323.256
-2021	Estonie	Estonia	8.988278645659518	245.094	2726.818
-2021	Finlande	Finland	2.9937725178230212	694.288	23191.074
-2021	France	France	20.649030024470434	26465.646	128168.955
-2021	Grèce	Greece	7.580480506088059	1097.87	14482.855
-2021	Hongrie	Hungary	32.344729318831554	5693.164	17601.52
-2021	Irlande	Ireland	18.020604987495144	1953.468	10840.191
-2021	Italie	Italy	30.86368769746751	31807.236	103057.147
-2021	Lettonie	Latvia	8.502139837843602	322.927	3798.185
-2021	Lituanie	Lithuania	11.029023816606903	582.797	5284.212
-2021	Luxembourg	Luxembourg	17.282784281000467	564.365	3265.475
-2021	Malte	Malta	0.0	0.0	499.875
-2021	Pays-Bas	Netherlands	37.61392206122467	15896.316	42261.788
-2021	Pologne	Poland	13.146720200313602	9235.656	70250.647
-2021	Portugal	Portugal	11.437926753365227	1740.3	15215.17
-2021	Roumanie	Romania	24.909638477223016	5846.885	23472.38
-2021	République tchèque	Czech Republic	21.716683280446812	5158.445	23753.374
-2021	Slovaquie	Slovakia	25.253930010417324	2427.134	9610.916
-2021	Slovénie	Slovenia	13.141683407321874	582.024	4428.839
-2021	Suède	Sweden	1.497679952802663	471.085	31454.317
-2021	UE 27	UE 27	21.894190365821018	193930.95399999994	885764.4460000001
+1	actor
+2	actress
+3	producer
+4	writer
+5	cinematographer
+6	composer
+7	costume designer
+8	director
+9	editor
+10	miscellaneous crew
+11	production designer
+12	guest
 
-query IIIIII rowsort res
-SELECT * from read_csv('https://www.data.gouv.fr/fr/datasets/r/6d186965-f41b-41f3-9b23-88241cc6890c',DELIM=';',Columns={'annee_de_reference':'VARCHAR','pays':'VARCHAR','label_en':'VARCHAR','part_du_gaz_naturel_dans_la_consommation_finale_d_energie0':'VARCHAR','consommation_finale_de_gaz_naturel_mtep':'VARCHAR','consommation_finale_d_energie_totale_mtep':'VARCHAR'});
-
-
-query IIIIII rowsort res
-SELECT * from read_csv('https://www.data.gouv.fr/fr/datasets/r/6d186965-f41b-41f3-9b23-88241cc6890c',DELIM=';',Columns={'annee_de_reference':'VARCHAR','pays':'VARCHAR','label_en':'VARCHAR','part_du_gaz_naturel_dans_la_consommation_finale_d_energie0':'VARCHAR','consommation_finale_de_gaz_naturel_mtep':'VARCHAR','consommation_finale_d_energie_totale_mtep':'VARCHAR'});
-
-
-# Give it a try to a request that returns length 0
-query I
-SELECT count(*) from read_csv_auto('https://query1.finance.yahoo.com/v7/finance/download/^GSPC?period1=1512086400&period2=1670630400&interval=1d&events=history')
+query IIIIIIIIIIIIIIIIII
+select * from 'https://github.com/duckdb/duckdb/raw/9cf66f950dde0173e1a863a7659b3ecf11bf3978/data/csv/customer.csv';
 ----
-1265
-
-# Give it a try to a request that returns length 0
-query I
-SELECT count(*) from read_csv_auto('https://query1.finance.yahoo.com/v7/finance/download/^GSPC?period1=1512086400&period2=1670630400&interval=1d&events=history')
-----
-1265
-
-# Give it a try to a request that returns length 0
-query I
-SELECT count(*) from read_csv_auto('https://query1.finance.yahoo.com/v7/finance/download/^GSPC?period1=1512086400&period2=1670630400&interval=1d&events=history')
-----
-1265
+1	AAAAAAAABAAAAAAA	980124	7135	32946	2452238	2452208	Mr.	Javier	Lewis	Y	9	12	1936	CHILE	NULL	Javier.Lewis@VFAxlnZEvOx.org	2452508
+2	AAAAAAAACAAAAAAA	819667	1461	31655	2452318	2452288	Dr.	Amy	Moses	Y	9	4	1966	TOGO	NULL	Amy.Moses@Ovk9KjHH.com	2452318
+3	AAAAAAAADAAAAAAA	1473522	6247	48572	2449130	2449100	Miss	Latisha	Hamilton	Y	18	9	1979	NIUE	NULL	Latisha.Hamilton@V.com	2452313
+4	AAAAAAAAEAAAAAAA	1703214	3986	39558	2450030	2450000	Dr.	Michael	White	Y	7	6	1983	MEXICO	NULL	Michael.White@i.org	2452361
+5	AAAAAAAAFAAAAAAA	953372	4470	36368	2449438	2449408	Sir	Robert	Moran	N	8	5	1956	FIJI	NULL	Robert.Moran@Hh.edu	2452469
+6	AAAAAAAAGAAAAAAA	213219	6374	27082	2451883	2451853	Ms.	Brunilda	Sharp	Y	4	12	1925	SURINAME	NULL	Brunilda.Sharp@T3pylZEUQjm.org	2452430
+7	AAAAAAAAHAAAAAAA	68377	3219	44814	2451438	2451408	Ms.	Fonda	Wiles	N	24	4	1985	GAMBIA	NULL	Fonda.Wiles@S9KnyEtz9hv.org	2452360
+8	AAAAAAAAIAAAAAAA	1215897	2471	16598	2449406	2449376	Sir	Ollie	Shipman	N	26	12	1938	KOREA, REPUBLIC OF	NULL	Ollie.Shipman@be.org	2452334
+9	AAAAAAAAJAAAAAAA	1168667	1404	49388	2452275	2452245	Sir	Karl	Gilbert	N	26	10	1966	MONTSERRAT	NULL	Karl.Gilbert@Crg5KyP2IxX9C4d6.edu	2452454
+10	AAAAAAAAKAAAAAAA	1207553	5143	19580	2451353	2451323	Ms.	Albert	Brunson	N	15	10	1973	JORDAN	NULL	Albert.Brunson@62.com	2452641
 
 #Add test for 5924
 query IIIIII
@@ -358,3 +294,94 @@ select * from read_csv_auto('https://csvbase.com/meripaterson/stock-exchanges');
 249	North America	United States of America	Members' Exchange	NULL	2020-09-24
 250	Africa	Zimbabwe	Victoria Falls Stock Exchange	NULL	2020-11-01
 251	Asia	China	Beijing Stock Exchange	NULL	2021-12-27
+
+
+#FIXME this test fails: file is nonexistent
+mode skip
+
+query IIIIII rowsort
+SELECT * from read_csv_auto('https://github.com/duckdb/duckdb/raw/9cf66f950dde0173e1a863a7659b3ecf11bf3978/data/csv/customer.csv');
+----
+2020	Allemagne	Germany	26.1	53196.069	200601.2
+2020	Autriche	Austria	18.0	4723.5	26215.8
+2020	Belgique	Belgium	28.999999999999996	9436.1	32553.0
+2020	Bulgarie	Bulgaria	11.600000000000001	1124.1	9698.7
+2020	Chypre	Cyprus	0.0	0.0	1627.6
+2020	Croatie	Croatia	16.3	1094.8	6726.3
+2020	Danemark	Denmark	11.600000000000001	1579.0	13601.4
+2020	Espagne	Spain	17.4	14211.7	81512.9
+2020	Estonie	Estonia	8.5	241.1	2827.3
+2020	Finlande	Finland	2.8000000000000003	692.3	24674.4
+2020	France	France	20.3	28278.9	139375.8
+2020	Grèce	Greece	5.800000000000001	896.5	15401.9
+2020	Hongrie	Hungary	30.5	5486.7	17872.4
+2020	Irlande	Ireland	17.4	1968.477	11296.601
+2020	Italie	Italy	29.2	33042.585	113119.475
+2020	Lettonie	Latvia	8.200000000000001	323.605	3926.131
+2020	Lituanie	Lithuania	10.7	584.104	5457.728
+2020	Luxembourg	Luxembourg	16.5	623.165	3786.785
+2020	Malte	Malta	0.0	0.0	547.5
+2020	Pays-Bas	Netherlands	37.1	16588.314	44682.656
+2020	Pologne	Poland	13.5	9323.205	69135.018
+2020	Portugal	Portugal	11.1	1814.878	16354.725
+2020	Roumanie	Romania	23.7	5626.161	23712.653
+2020	Royaume-Uni	United Kingdom	32.4	39311.416	121414.483
+2020	République tchèque	Czech Republic	21.4	5187.282	24263.896
+2020	Slovaquie	Slovakia	25.0	2564.876	10248.401
+2020	Slovénie	Slovenia	12.1	590.243	4861.315
+2020	Suède	Sweden	1.5	475.195	31311.413
+2020	UE 28	Europe 28	22.5	238152.4	1056907.5
+2021	Allemagne	Germany	26.760345686044435	51812.567	193616.957
+2021	Autriche	Austria	18.720006775926056	4645.795	24817.272
+2021	Belgique	Belgium	29.279402721103864	9088.083	31039.168
+2021	Bulgarie	Bulgaria	12.368015142641884	1176.537	9512.739
+2021	Chypre	Cyprus	0.0	0.0	1528.558
+2021	Croatie	Croatia	17.10389029082304	1100.12	6431.987
+2021	Danemark	Denmark	11.485631727184947	1508.152	13130.771
+2021	Espagne	Spain	19.10173955663722	13815.0	72323.256
+2021	Estonie	Estonia	8.988278645659518	245.094	2726.818
+2021	Finlande	Finland	2.9937725178230212	694.288	23191.074
+2021	France	France	20.649030024470434	26465.646	128168.955
+2021	Grèce	Greece	7.580480506088059	1097.87	14482.855
+2021	Hongrie	Hungary	32.344729318831554	5693.164	17601.52
+2021	Irlande	Ireland	18.020604987495144	1953.468	10840.191
+2021	Italie	Italy	30.86368769746751	31807.236	103057.147
+2021	Lettonie	Latvia	8.502139837843602	322.927	3798.185
+2021	Lituanie	Lithuania	11.029023816606903	582.797	5284.212
+2021	Luxembourg	Luxembourg	17.282784281000467	564.365	3265.475
+2021	Malte	Malta	0.0	0.0	499.875
+2021	Pays-Bas	Netherlands	37.61392206122467	15896.316	42261.788
+2021	Pologne	Poland	13.146720200313602	9235.656	70250.647
+2021	Portugal	Portugal	11.437926753365227	1740.3	15215.17
+2021	Roumanie	Romania	24.909638477223016	5846.885	23472.38
+2021	République tchèque	Czech Republic	21.716683280446812	5158.445	23753.374
+2021	Slovaquie	Slovakia	25.253930010417324	2427.134	9610.916
+2021	Slovénie	Slovenia	13.141683407321874	582.024	4428.839
+2021	Suède	Sweden	1.497679952802663	471.085	31454.317
+2021	UE 27	UE 27	21.894190365821018	193930.95399999994	885764.4460000001
+
+query IIIIII rowsort res
+SELECT * from read_csv('https://www.data.gouv.fr/fr/datasets/r/6d186965-f41b-41f3-9b23-88241cc6890c',DELIM=';',Columns={'annee_de_reference':'VARCHAR','pays':'VARCHAR','label_en':'VARCHAR','part_du_gaz_naturel_dans_la_consommation_finale_d_energie0':'VARCHAR','consommation_finale_de_gaz_naturel_mtep':'VARCHAR','consommation_finale_d_energie_totale_mtep':'VARCHAR'});
+
+
+query IIIIII rowsort res
+SELECT * from read_csv('https://www.data.gouv.fr/fr/datasets/r/6d186965-f41b-41f3-9b23-88241cc6890c',DELIM=';',Columns={'annee_de_reference':'VARCHAR','pays':'VARCHAR','label_en':'VARCHAR','part_du_gaz_naturel_dans_la_consommation_finale_d_energie0':'VARCHAR','consommation_finale_de_gaz_naturel_mtep':'VARCHAR','consommation_finale_d_energie_totale_mtep':'VARCHAR'});
+
+
+# Give it a try to a request that returns length 0
+query I
+SELECT count(*) from read_csv_auto('https://query1.finance.yahoo.com/v7/finance/download/^GSPC?period1=1512086400&period2=1670630400&interval=1d&events=history')
+----
+1265
+
+# Give it a try to a request that returns length 0
+query I
+SELECT count(*) from read_csv_auto('https://query1.finance.yahoo.com/v7/finance/download/^GSPC?period1=1512086400&period2=1670630400&interval=1d&events=history')
+----
+1265
+
+# Give it a try to a request that returns length 0
+query I
+SELECT count(*) from read_csv_auto('https://query1.finance.yahoo.com/v7/finance/download/^GSPC?period1=1512086400&period2=1670630400&interval=1d&events=history')
+----
+1265

--- a/test/sql/copy/csv/test_csv_httpfs.test
+++ b/test/sql/copy/csv/test_csv_httpfs.test
@@ -9,6 +9,9 @@ require parquet
 statement ok
 PRAGMA enable_verification
 
+statement ok
+pragma enable_logging('HTTP');
+
 query II
 select * from 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_role_type.parquet' order by all;
 ----
@@ -24,6 +27,8 @@ select * from 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_
 10	miscellaneous crew
 11	production designer
 12	guest
+
+pragma enable_logging('HTTP');
 
 query IIIIIIIIIIIIIIIIII
 select * from 'https://github.com/duckdb/duckdb/raw/9cf66f950dde0173e1a863a7659b3ecf11bf3978/data/csv/customer.csv';

--- a/test/sql/copy/csv/test_csv_httpfs.test
+++ b/test/sql/copy/csv/test_csv_httpfs.test
@@ -4,8 +4,13 @@
 
 require httpfs
 
+require parquet
+
 statement ok
 PRAGMA enable_verification
+
+statement ok
+select * from 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_role_type.parquet';
 
 
 #FIXME this test fails: file is nonexistent

--- a/test/sql/curl_client/test_load_other_extensions.test
+++ b/test/sql/curl_client/test_load_other_extensions.test
@@ -13,5 +13,4 @@ SET httpfs_client_implementation='curl';
 statement error
 INSTALL non_existent_extension;
 ----
-<REGEX>:.*HTTP Error: Failed to download extension "non_existent_extension" at URL.*
-    
+<REGEX>:.*HTTP Error: Failed to download extension.*

--- a/test/sql/curl_client/test_load_other_extensions.test
+++ b/test/sql/curl_client/test_load_other_extensions.test
@@ -1,0 +1,17 @@
+# name: test/sql/curl_client/test_load_other_extensions.test
+# description: when using the curl client, test loading other extensions
+# group: [httpfs_client]
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+SET httpfs_client_implementation='curl';
+
+statement error
+INSTALL non_existent_extension;
+----
+<REGEX>:.*HTTP Error: Failed to download extension "non_existent_extension" at URL.*
+    

--- a/test/sql/metadata_stats.test
+++ b/test/sql/metadata_stats.test
@@ -9,8 +9,6 @@ require httpfs
 statement ok
 SET force_download=false;
 
-mode output_result
-
 query II
 explain analyze SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://raw.githubusercontent.com/duckdb/duckdb/main/data/parquet-testing/userdata1.parquet')
 ----

--- a/test/sql/metadata_stats.test
+++ b/test/sql/metadata_stats.test
@@ -6,6 +6,12 @@ require parquet
 
 require httpfs
 
+require json
+
+# Test Force download with server that doesn't want to give us the head
+statement ok
+FROM read_json('https://api.spring.io/projects/spring-boot/generations')
+
 statement ok
 SET force_download=false;
 

--- a/test/sql/metadata_stats.test
+++ b/test/sql/metadata_stats.test
@@ -1,0 +1,17 @@
+# name: test/sql/metadata_stats.test
+# description: Test getting metadata stats
+# group: []
+
+require parquet
+
+require httpfs
+
+statement ok
+SET force_download=false;
+
+mode output_result
+
+query II
+explain analyze SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://raw.githubusercontent.com/duckdb/duckdb/main/data/parquet-testing/userdata1.parquet')
+----
+analyzed_plan	<REGEX>:.*GET: 2.*

--- a/test/sql/secret/secret_aws.test
+++ b/test/sql/secret/secret_aws.test
@@ -18,6 +18,11 @@ require httpfs
 
 require parquet
 
+foreach httpfs_implementation curl httplib
+
+statement ok
+SET httpfs_client_implementation='${httpfs_implementation}';
+
 statement ok
 SET enable_logging=true
 
@@ -32,7 +37,7 @@ set s3_region='${AWS_DEFAULT_REGION}'
 
 # Create some test data
 statement ok
-CREATE SECRET s1 (
+CREATE or replace SECRET s1 (
     TYPE AWS,
     KEY_ID '${AWS_ACCESS_KEY_ID}',
     SECRET '${AWS_SECRET_ACCESS_KEY}'
@@ -45,3 +50,5 @@ query I
 FROM "s3://test-bucket/test-file.parquet"
 ----
 1
+
+endloop

--- a/test/sql/secret/secret_refresh.test
+++ b/test/sql/secret/secret_refresh.test
@@ -78,10 +78,11 @@ CREATE SECRET s1 (
     REFRESH 1
 )
 
+# TODO: add FORBIDDEN back in once enum util for http status codes is merged into httpfs
 statement error
 FROM "s3://test-bucket/test-file.parquet"
 ----
-IO Error: HTTP/1.1 403 Forbidden
+HTTP Error: Unable to connect to URL "s3://test-bucket/test-file.parquet": 403 ()
 
 query I
 SELECT message[0:46] FROM duckdb_logs WHERE message like '%Successfully refreshed secret%'
@@ -118,10 +119,11 @@ statement ok
 set s3_access_key_id='bogus'
 
 # Without secret this query will fail, but since there are no suitable secrets, no refresh attempt will be made
+# TODO: add FORBIDDEN in once enum util for http status codes is merged into httpfs
 statement error
 FROM "s3://test-bucket/test-file.parquet"
 ----
-IO Error: HTTP/1.1 403 Forbidden
+HTTP Error: Unable to connect to URL "s3://test-bucket/test-file.parquet": 403 ()
 
 # -> log empty
 query II

--- a/test/sql/secret/secret_refresh.test
+++ b/test/sql/secret/secret_refresh.test
@@ -82,7 +82,7 @@ CREATE SECRET s1 (
 statement error
 FROM "s3://test-bucket/test-file.parquet"
 ----
-HTTP Error: Unable to connect to URL "s3://test-bucket/test-file.parquet": 403 ()
+HTTP Error: HTTP GET error on 'http://test-bucket.duckdb-minio.com:9000/test-file.parquet' (HTTP 403)
 
 query I
 SELECT message[0:46] FROM duckdb_logs WHERE message like '%Successfully refreshed secret%'
@@ -123,7 +123,7 @@ set s3_access_key_id='bogus'
 statement error
 FROM "s3://test-bucket/test-file.parquet"
 ----
-HTTP Error: Unable to connect to URL "s3://test-bucket/test-file.parquet": 403 ()
+HTTP Error: HTTP GET error on 'http://test-bucket.duckdb-minio.com:9000/test-file.parquet' (HTTP 403)
 
 # -> log empty
 query II

--- a/test/sql/secret/secret_refresh.test
+++ b/test/sql/secret/secret_refresh.test
@@ -81,7 +81,7 @@ CREATE SECRET s1 (
 statement error
 FROM "s3://test-bucket/test-file.parquet"
 ----
-HTTP 403
+IO Error: HTTP/1.1 403 Forbidden
 
 query I
 SELECT message[0:46] FROM duckdb_logs WHERE message like '%Successfully refreshed secret%'
@@ -121,7 +121,7 @@ set s3_access_key_id='bogus'
 statement error
 FROM "s3://test-bucket/test-file.parquet"
 ----
-HTTP 403
+IO Error: HTTP/1.1 403 Forbidden
 
 # -> log empty
 query II

--- a/test/sql/test_headers_parsed.test
+++ b/test/sql/test_headers_parsed.test
@@ -25,7 +25,7 @@ select * from 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_
 11	production designer
 12	guest
 
-query II
+query I
 select response.status from duckdb_logs_parsed('HTTP') order by all;
 ----
 OK_200

--- a/test/sql/test_headers_parsed.test
+++ b/test/sql/test_headers_parsed.test
@@ -31,8 +31,16 @@ select response.status from duckdb_logs_parsed('HTTP') order by all;
 OK_200
 PartialContent_206
 
-query II
-select response.headers['__RESPONSE_STATUS__'] from duckdb_logs_parsed('HTTP') order by all;
+
+# response status is either
+# HTTP/2 200
+# HTTP/2 206
+# OR
+# HTTP/1.1 200 OK
+# HTTP/1.1 206 Partial Content
+# depending on OS and CA (I think)
+query I
+select response.headers['__RESPONSE_STATUS__'] LIKE 'HTTP%20%' from duckdb_logs_parsed('HTTP') order by all;
 ----
-HTTP/2 200
-HTTP/2 206
+true
+true

--- a/test/sql/test_headers_parsed.test
+++ b/test/sql/test_headers_parsed.test
@@ -7,6 +7,9 @@ require httpfs
 require parquet
 
 statement ok
+SET httpfs_client_implementation='curl';
+
+statement ok
 pragma enable_logging('HTTP');
 
 query II
@@ -30,7 +33,6 @@ select response.status from duckdb_logs_parsed('HTTP') order by all;
 ----
 OK_200
 PartialContent_206
-
 
 # response status is either
 # HTTP/2 200

--- a/test/sql/test_headers_parsed.test
+++ b/test/sql/test_headers_parsed.test
@@ -1,0 +1,38 @@
+# name: test/sql/copy/csv/test_headers_parsed.test
+# description: This test triggers the http prefetch mechanism.
+# group: [csv]
+
+require httpfs
+
+require parquet
+
+statement ok
+pragma enable_logging('HTTP');
+
+query II
+select * from 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_role_type.parquet' order by all;
+----
+1	actor
+2	actress
+3	producer
+4	writer
+5	cinematographer
+6	composer
+7	costume designer
+8	director
+9	editor
+10	miscellaneous crew
+11	production designer
+12	guest
+
+query II
+select response.status from duckdb_logs_parsed('HTTP') order by all;
+----
+OK_200
+PartialContent_206
+
+query II
+select response.headers['__RESPONSE_STATUS__'] from duckdb_logs_parsed('HTTP') order by all;
+----
+HTTP/2 200
+HTTP/2 206

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,6 @@
 {
   "dependencies": [
-    "openssl"
+    "openssl",
+    "curl"
   ]
 }


### PR DESCRIPTION

After https://github.com/duckdb/duckdb/pull/18107 landed in duckdb/duckdb, and moving the duckdb submodule to a recent commit on v1.4-andium, this PR allows to switch at runtime based on the newly added httpfs config option httpfs_client_implementation:
```
D SET logging_storage=stdout;
D PRAGMA enable_logging('HTTP');
D SET httpfs_client_implementation='default';
D select count(*)
  FROM 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/event_baserunning_advance_attempt.parquet';
[LOG] 2025-07-03 10:06:18.479, HTTP, DEBUG, {'request': {'type': HEAD, 'url': 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/event_baserunning_advance_attempt.parquet', 'headers': {}}, 'response': {'status': OK_200, 'reason': OK, 'headers': {X-Timer='S1751537178.169255,VS0,VE1', x-ms-request-id=91401b99-a01e-000c-7caa-dd765d000000, X-Served-By='cache-iad-kcgs7200132-IAD, cache-rtm-ehrd2290029-RTM', Fastly-Restarts=1, x-ms-lease-status=unlocked, x-ms-creation-time='Tue, 17 Jan 2023 21:28:40 GMT', x-ms-blob-type=BlockBlob, x-ms-blob-content-md5='0OgVgULsCWfa1mU4BlFEbg==', X-Cache-Hits='3730, 1', Via='1.1 varnish, 1.1 varnish', Server=Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0, x-ms-version=2025-05-05, X-Cache='HIT, HIT', ETag='"0x8DAF8D1CD43CA79"', Connection=keep-alive, x-ms-lease-state=available, Last-Modified='Tue, 17 Jan 2023 21:28:40 GMT', Date='Thu, 03 Jul 2025 10:06:18 GMT', Content-Length=21916382, Content-Type=application/octet-stream, Content-Disposition='attachment; filename=event_baserunning_advance_attempt.parquet', x-ms-server-encrypted=true, Age=806, Accept-Ranges=bytes}}}, CONNECTION, 2, 11, NULL
┌────────────────┐
│  count_star()  │
│     int64      │
├────────────────┤
│    9388600     │
│ (9.39 million) │
└────────────────┘
D SET httpfs_client_implementation='curl';
D select count(*)
  FROM 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/event_baserunning_advance_attempt.parquet';
[LOG] 2025-07-03 10:06:30.247, HTTP, DEBUG, {'request': {'type': HEAD, 'url': 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/event_baserunning_advance_attempt.parquet', 'headers': {}}, 'response': {'status': OK_200, 'reason': '', 'headers': {content-type=application/octet-stream, x-ms-lease-state=available, last-modified='Tue, 17 Jan 2023 21:28:40 GMT', x-ms-request-id=91401b99-a01e-000c-7caa-dd765d000000, accept-ranges=bytes, x-ms-version=2025-05-05, server=Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0, x-ms-creation-time='Tue, 17 Jan 2023 21:28:40 GMT', x-ms-blob-content-md5='0OgVgULsCWfa1mU4BlFEbg==', x-cache='HIT, HIT', __RESPONSE_STATUS__='HTTP/2 200 ', etag='"0x8DAF8D1CD43CA79"', x-ms-blob-type=BlockBlob, x-ms-server-encrypted=true, age=818, x-ms-lease-status=unlocked, x-served-by='cache-iad-kcgs7200132-IAD, cache-rtm-ehrd2290021-RTM', fastly-restarts=1, via='1.1 varnish, 1.1 varnish', date='Thu, 03 Jul 2025 10:06:30 GMT', x-cache-hits='3730, 1', content-disposition='attachment; filename=event_baserunning_advance_attempt.parquet', x-timer='S1751537190.940711,VS0,VE1', content-length=21916382}}}, CONNECTION, 2, 13, NULL
┌────────────────┐
│  count_star()  │
│     int64      │
├────────────────┤
│    9388600     │
│ (9.39 million) │
└────────────────┘
D SET httpfs_client_implementation='httplib';
D select count(*)
  FROM 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/event_baserunning_advance_attempt.parquet';
[LOG] 2025-07-03 10:07:45.552, HTTP, DEBUG, {'request': {'type': HEAD, 'url': 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/event_baserunning_advance_attempt.parquet', 'headers': {}}, 'response': {'status': OK_200, 'reason': OK, 'headers': {X-Timer='S1751537265.144944,VS0,VE0', x-ms-request-id=91401b99-a01e-000c-7caa-dd765d000000, X-Served-By='cache-iad-kcgs7200132-IAD, cache-rtm-ehrd2290047-RTM', Fastly-Restarts=1, x-ms-lease-status=unlocked, x-ms-creation-time='Tue, 17 Jan 2023 21:28:40 GMT', x-ms-blob-type=BlockBlob, x-ms-blob-content-md5='0OgVgULsCWfa1mU4BlFEbg==', X-Cache-Hits='3730, 0', Via='1.1 varnish, 1.1 varnish', Server=Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0, x-ms-version=2025-05-05, X-Cache='HIT, HIT', ETag='"0x8DAF8D1CD43CA79"', Connection=keep-alive, x-ms-lease-state=available, Last-Modified='Tue, 17 Jan 2023 21:28:40 GMT', Date='Thu, 03 Jul 2025 10:07:45 GMT', Content-Length=21916382, Content-Type=application/octet-stream, Content-Disposition='attachment; filename=event_baserunning_advance_attempt.parquet', x-ms-server-encrypted=true, Age=893, Accept-Ranges=bytes}}}, CONNECTION, 2, 15, NULL
┌────────────────┐
│  count_star()  │
│     int64      │
├────────────────┤
│    9388600     │
│ (9.39 million) │
└────────────────┘
D SET httpfs_client_implementation='something_else';
Invalid Input Error:
Unsupported option for httpfs_client_implementation, only `curl`, `httplib` and `default` are currently supported
It can be checked from the headers that slightly different implementations are used, given for example different styling for Etag vs etag or similar implementation details.
```
