### PR TITLE
Bugfix - header sort order for S3 Requester pays mode.

### DIFF
--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -74,29 +74,29 @@ static HTTPHeaders create_s3_header(string url, string query, string host, strin
 		signed_headers += "content-type;";
 	}
 	signed_headers += "host;x-amz-content-sha256;x-amz-date";
+	if (use_requester_pays) {
+		signed_headers += ";x-amz-request-payer";
+	}
 	if (auth_params.session_token.length() > 0) {
 		signed_headers += ";x-amz-security-token";
 	}
 	if (use_sse_kms) {
 		signed_headers += ";x-amz-server-side-encryption;x-amz-server-side-encryption-aws-kms-key-id";
 	}
-	if (use_requester_pays) {
-		signed_headers += ";x-amz-request-payer";
-	}
     auto canonical_request = method + "\n" + S3FileSystem::UrlEncode(url) + "\n" + query;
 	if (content_type.length() > 0) {
 		canonical_request += "\ncontent-type:" + content_type;
 	}
 	canonical_request += "\nhost:" + host + "\nx-amz-content-sha256:" + payload_hash + "\nx-amz-date:" + datetime_now;
+	if (use_requester_pays) {
+		canonical_request += "\nx-amz-request-payer:requester";
+	}
 	if (auth_params.session_token.length() > 0) {
 		canonical_request += "\nx-amz-security-token:" + auth_params.session_token;
 	}
 	if (use_sse_kms) {
 		canonical_request += "\nx-amz-server-side-encryption:aws:kms";
 		canonical_request += "\nx-amz-server-side-encryption-aws-kms-key-id:" + auth_params.kms_key_id;
-	}
-	if (use_requester_pays) {
-		canonical_request += "\nx-amz-request-payer:requester";
 	}
 
 	canonical_request += "\n\n" + signed_headers + "\n" + payload_hash;
@@ -129,11 +129,6 @@ string S3FileSystem::UrlDecode(string input) {
 
 string S3FileSystem::UrlEncode(const string &input, bool encode_slash) {
 	return StringUtil::URLEncode(input, encode_slash);
-}
-
-static bool IsGCSRequest(const string &url) {
-	return StringUtil::StartsWith(url, "gcs://") || 
-	       StringUtil::StartsWith(url, "gs://");
 }
 
 void AWSEnvironmentCredentialsProvider::SetExtensionOptionValue(string key, const char *env_var_name) {
@@ -214,8 +209,6 @@ S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerI
 		if (result.url_style.empty() || url_style_result.GetScope() != SettingScope::SECRET) {
 			result.url_style = "path";
 		}
-		// Read bearer token for GCS
-		secret_reader.TryGetSecretKey("bearer_token", result.oauth2_bearer_token);
 	}
 
 	if (!result.region.empty() && (result.endpoint.empty() || result.endpoint == "s3.amazonaws.com")) {
@@ -242,13 +235,9 @@ unique_ptr<KeyValueSecret> CreateSecret(vector<string> &prefix_paths_p, string &
 	return_value->secret_map["kms_key_id"] = params.kms_key_id;
 	return_value->secret_map["s3_url_compatibility_mode"] = params.s3_url_compatibility_mode;
 	return_value->secret_map["requester_pays"] = params.requester_pays;
-	return_value->secret_map["bearer_token"] = params.oauth2_bearer_token;
 
 	//! Set redact keys
 	return_value->redact_keys = {"secret", "session_token"};
-	if (!params.oauth2_bearer_token.empty()) {
-		return_value->redact_keys.insert("bearer_token");
-	}
 
 	return return_value;
 }
@@ -683,19 +672,9 @@ unique_ptr<HTTPResponse> S3FileSystem::PostRequest(FileHandle &handle, string ur
 	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
 	auto parsed_s3_url = S3UrlParse(url, auth_params);
 	string http_url = parsed_s3_url.GetHTTPUrl(auth_params, http_params);
-	
-	HTTPHeaders headers;
-	if (IsGCSRequest(url) && !auth_params.oauth2_bearer_token.empty()) {
-		// Use bearer token for GCS
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_s3_url.host;
-		headers["Content-Type"] = "application/octet-stream";
-	} else {
-		// Use existing S3 authentication
-		auto payload_hash = GetPayloadHash(buffer_in, buffer_in_len);
-		headers = create_s3_header(parsed_s3_url.path, http_params, parsed_s3_url.host, "s3", "POST", auth_params, "",
-		                          "", payload_hash, "application/octet-stream");
-	}
+	auto payload_hash = GetPayloadHash(buffer_in, buffer_in_len);
+	auto headers = create_s3_header(parsed_s3_url.path, http_params, parsed_s3_url.host, "s3", "POST", auth_params, "",
+	                                "", payload_hash, "application/octet-stream");
 
 	return HTTPFileSystem::PostRequest(handle, http_url, headers, result, buffer_in, buffer_in_len);
 }
@@ -706,20 +685,10 @@ unique_ptr<HTTPResponse> S3FileSystem::PutRequest(FileHandle &handle, string url
 	auto parsed_s3_url = S3UrlParse(url, auth_params);
 	string http_url = parsed_s3_url.GetHTTPUrl(auth_params, http_params);
 	auto content_type = "application/octet-stream";
-	
-	HTTPHeaders headers;
-	if (IsGCSRequest(url) && !auth_params.oauth2_bearer_token.empty()) {
-		// Use bearer token for GCS
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_s3_url.host;
-		headers["Content-Type"] = content_type;
-	} else {
-		// Use existing S3 authentication
-		auto payload_hash = GetPayloadHash(buffer_in, buffer_in_len);
-		headers = create_s3_header(parsed_s3_url.path, http_params, parsed_s3_url.host, "s3", "PUT", auth_params, "",
-		                          "", payload_hash, content_type);
-	}
-	
+	auto payload_hash = GetPayloadHash(buffer_in, buffer_in_len);
+
+	auto headers = create_s3_header(parsed_s3_url.path, http_params, parsed_s3_url.host, "s3", "PUT", auth_params, "",
+	                                "", payload_hash, content_type);
 	return HTTPFileSystem::PutRequest(handle, http_url, headers, buffer_in, buffer_in_len);
 }
 
@@ -727,18 +696,8 @@ unique_ptr<HTTPResponse> S3FileSystem::HeadRequest(FileHandle &handle, string s3
 	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
 	auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
 	string http_url = parsed_s3_url.GetHTTPUrl(auth_params);
-	
-	HTTPHeaders headers;
-	if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
-		// Use bearer token for GCS
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_s3_url.host;
-	} else {
-		// Use existing S3 authentication
-		headers = create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, 
-		                          "s3", "HEAD", auth_params, "", "", "", "");
-	}
-	
+	auto headers =
+	    create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "HEAD", auth_params, "", "", "", "");
 	return HTTPFileSystem::HeadRequest(handle, http_url, headers);
 }
 
@@ -746,18 +705,8 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_
 	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
 	auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
 	string http_url = parsed_s3_url.GetHTTPUrl(auth_params);
-	
-	HTTPHeaders headers;
-	if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
-		// Use bearer token for GCS
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_s3_url.host;
-	} else {
-		// Use existing S3 authentication
-		headers = create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, 
-		                          "s3", "GET", auth_params, "", "", "", "");
-	}
-	
+	auto headers =
+	    create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "GET", auth_params, "", "", "", "");
 	return HTTPFileSystem::GetRequest(handle, http_url, headers);
 }
 
@@ -766,18 +715,8 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, strin
 	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
 	auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
 	string http_url = parsed_s3_url.GetHTTPUrl(auth_params);
-	
-	HTTPHeaders headers;
-	if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
-		// Use bearer token for GCS
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_s3_url.host;
-	} else {
-		// Use existing S3 authentication
-		headers = create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, 
-		                          "s3", "GET", auth_params, "", "", "", "");
-	}
-	
+	auto headers =
+	    create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "GET", auth_params, "", "", "", "");
 	return HTTPFileSystem::GetRangeRequest(handle, http_url, headers, file_offset, buffer_out, buffer_out_len);
 }
 
@@ -785,18 +724,8 @@ unique_ptr<HTTPResponse> S3FileSystem::DeleteRequest(FileHandle &handle, string 
 	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
 	auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
 	string http_url = parsed_s3_url.GetHTTPUrl(auth_params);
-	
-	HTTPHeaders headers;
-	if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
-		// Use bearer token for GCS
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_s3_url.host;
-	} else {
-		// Use existing S3 authentication
-		headers = create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, 
-		                          "s3", "DELETE", auth_params, "", "", "", "");
-	}
-	
+	auto headers =
+	    create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "DELETE", auth_params, "", "", "", "");
 	return HTTPFileSystem::DeleteRequest(handle, http_url, headers);
 }
 
@@ -845,12 +774,7 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 				}
 				if (entry->second == "403") {
 					// 403: FORBIDDEN
-					string extra_text;
-					if (IsGCSRequest(path)) {
-						extra_text = S3FileSystem::GetGCSAuthError(auth_params);
-					} else {
-						extra_text = S3FileSystem::GetS3AuthError(auth_params);
-					}
+					auto extra_text = S3FileSystem::GetS3AuthError(auth_params);
 					throw Exception(error.Type(), error.RawMessage() + extra_text, extra_info);
 				}
 			}
@@ -1112,24 +1036,6 @@ string S3FileSystem::GetS3AuthError(S3AuthParams &s3_auth_params) {
 	return extra_text;
 }
 
-string S3FileSystem::GetGCSAuthError(S3AuthParams &s3_auth_params) {
-	string extra_text = "\n\nAuthentication Failure - GCS authentication failed.";
-	if (s3_auth_params.oauth2_bearer_token.empty() && 
-	    s3_auth_params.secret_access_key.empty() && 
-	    s3_auth_params.access_key_id.empty()) {
-		extra_text += "\n* No credentials provided.";
-		extra_text += "\n* For OAuth2: CREATE SECRET (TYPE GCS, bearer_token 'your-token')";
-		extra_text += "\n* For HMAC: CREATE SECRET (TYPE GCS, key_id 'key', secret 'secret')";
-	} else if (!s3_auth_params.oauth2_bearer_token.empty()) {
-		extra_text += "\n* Bearer token was provided but authentication failed.";
-		extra_text += "\n* Ensure your OAuth2 token is valid and not expired.";
-	} else {
-		extra_text += "\n* HMAC credentials were provided but authentication failed.";
-		extra_text += "\n* Ensure your HMAC key_id and secret are correct.";
-	}
-	return extra_text;
-}
-
 HTTPException S3FileSystem::GetS3Error(S3AuthParams &s3_auth_params, const HTTPResponse &response, const string &url) {
 	string extra_text;
 	if (response.status == HTTPStatusCode::BadRequest_400) {
@@ -1145,15 +1051,6 @@ HTTPException S3FileSystem::GetS3Error(S3AuthParams &s3_auth_params, const HTTPR
 
 HTTPException S3FileSystem::GetHTTPError(FileHandle &handle, const HTTPResponse &response, const string &url) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
-	
-	// Use GCS-specific error for GCS URLs
-	if (IsGCSRequest(url) && response.status == HTTPStatusCode::Forbidden_403) {
-		string extra_text = GetGCSAuthError(s3_handle.auth_params);
-		auto status_message = HTTPFSUtil::GetStatusMessage(response.status);
-		throw HTTPException(response, "HTTP error on '%s' (HTTP %d %s)%s", url,
-		                    response.status, status_message, extra_text);
-	}
-	
 	return GetS3Error(s3_handle.auth_params, response, url);
 }
 string AWSListObjectV2::Request(string &path, HTTPParams &http_params, S3AuthParams &s3_auth_params,


### PR DESCRIPTION
This is to fix a bug found by: 

Per [AWS documentation](https://www.linkedin.com/safety/go?url=https%3A%2F%2Fdocs.aws.amazon.com%2FAmazonS3%2Flatest%2FAPI%2Fsig-v4-header-based-auth.html&trk=flagship-messaging-web&messageThreadUrn=urn%3Ali%3AmessagingThread%3A2-ZTFlMDkzNzQtODc4Yi00NDA0LWIxMjUtMWNiYzNhOTIyZTVhXzEwMA%3D%3D&lipi=urn%3Ali%3Apage%3Ad_flagship3_messaging_conversation_detail%3B7A5oOnzqSv6z1V9Zs5FXwQ%3D%3D) - the headers must be sorted.  We did not test when the session token was present - so this bug was not caught before.

Thanks to: @wiamsuri for finding and reporting this issue!