### PR TITLE
[chore] make format on cpp files

### DIFF
--- a/extension/httpfs/create_secret_functions.cpp
+++ b/extension/httpfs/create_secret_functions.cpp
@@ -111,7 +111,7 @@ unique_ptr<BaseSecret> CreateS3SecretFunctions::CreateSecretFunctionInternal(Cli
 		} else if (lower_name == "requester_pays") {
 			if (named_param.second.type() != LogicalType::BOOLEAN) {
 				throw InvalidInputException("Invalid type past to secret option: '%s', found '%s', expected: 'BOOLEAN'",
-											lower_name, named_param.second.type().ToString());
+				                            lower_name, named_param.second.type().ToString());
 			}
 			secret->secret_map["requester_pays"] = Value::BOOLEAN(named_param.second.GetValue<bool>());
 		} else if (lower_name == "bearer_token" && input.type == "gcs") {
@@ -195,7 +195,7 @@ void CreateS3SecretFunctions::SetBaseNamedParams(CreateSecretFunction &function,
 	function.named_parameters["use_ssl"] = LogicalType::BOOLEAN;
 	function.named_parameters["kms_key_id"] = LogicalType::VARCHAR;
 	function.named_parameters["url_compatibility_mode"] = LogicalType::BOOLEAN;
-    function.named_parameters["requester_pays"] = LogicalType::BOOLEAN;
+	function.named_parameters["requester_pays"] = LogicalType::BOOLEAN;
 
 	// Whether a secret refresh attempt should be made when the secret appears to be incorrect
 	function.named_parameters["refresh"] = LogicalType::VARCHAR;
@@ -214,7 +214,7 @@ void CreateS3SecretFunctions::SetBaseNamedParams(CreateSecretFunction &function,
 	if (type == "r2") {
 		function.named_parameters["account_id"] = LogicalType::VARCHAR;
 	}
-	
+
 	if (type == "gcs") {
 		function.named_parameters["bearer_token"] = LogicalType::VARCHAR;
 	}

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -275,7 +275,8 @@ void TimestampToTimeT(timestamp_t timestamp, time_t &result) {
 HTTPFileHandle::HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags,
                                unique_ptr<HTTPParams> params_p)
     : FileHandle(fs, file.path, flags), params(std::move(params_p)), http_params(params->Cast<HTTPFSParams>()),
-      flags(flags), length(0), force_full_download(false), buffer_available(0), buffer_idx(0), file_offset(0), buffer_start(0), buffer_end(0) {
+      flags(flags), length(0), force_full_download(false), buffer_available(0), buffer_idx(0), file_offset(0),
+      buffer_start(0), buffer_end(0) {
 	// check if the handle has extended properties that can be set directly in the handle
 	// if we have these properties we don't need to do a head request to obtain them later
 	if (file.extended_info) {

--- a/extension/httpfs/httpfs_client_wasm.cpp
+++ b/extension/httpfs/httpfs_client_wasm.cpp
@@ -9,7 +9,7 @@ unique_ptr<HTTPClient> HTTPFSUtil::InitializeClient(HTTPParams &http_params, con
 
 unordered_map<string, string> HTTPFSUtil::ParseGetParameters(const string &text) {
 	unordered_map<string, string> result;
-	//TODO: HTTPFSUtil::ParseGetParameters is currently not implemented
+	// TODO: HTTPFSUtil::ParseGetParameters is currently not implemented
 	return result;
 }
 

--- a/extension/httpfs/httpfs_extension.cpp
+++ b/extension/httpfs/httpfs_extension.cpp
@@ -13,23 +13,23 @@
 namespace duckdb {
 
 static void SetHttpfsClientImplementation(DBConfig &config, const string &value) {
-		if (config.http_util && config.http_util->GetName() == "WasmHTTPUtils") {
-			if (value == "wasm" || value == "default") {
-				// Already handled, do not override
-				return;
-			}
-			throw InvalidInputException("Unsupported option for httpfs_client_implementation, only `wasm` and "
-			                            "`default` are currently supported for duckdb-wasm");
-		}
-		if (value == "httplib" || value == "default") {
-			if (!config.http_util || config.http_util->GetName() != "HTTPFSUtil") {
-				config.http_util = make_shared_ptr<HTTPFSUtil>();
-			}
+	if (config.http_util && config.http_util->GetName() == "WasmHTTPUtils") {
+		if (value == "wasm" || value == "default") {
+			// Already handled, do not override
 			return;
 		}
-		throw InvalidInputException("Unsupported option for httpfs_client_implementation, only `curl`, `httplib` and "
-		                            "`default` are currently supported");
+		throw InvalidInputException("Unsupported option for httpfs_client_implementation, only `wasm` and "
+		                            "`default` are currently supported for duckdb-wasm");
 	}
+	if (value == "httplib" || value == "default") {
+		if (!config.http_util || config.http_util->GetName() != "HTTPFSUtil") {
+			config.http_util = make_shared_ptr<HTTPFSUtil>();
+		}
+		return;
+	}
+	throw InvalidInputException("Unsupported option for httpfs_client_implementation, only `curl`, `httplib` and "
+	                            "`default` are currently supported");
+}
 
 static void LoadInternal(DatabaseInstance &instance) {
 	auto &fs = instance.GetFileSystem();

--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -30,8 +30,8 @@ struct S3AuthParams {
 	string url_style;
 	bool use_ssl = true;
 	bool s3_url_compatibility_mode = false;
-    bool requester_pays = false;
-	string oauth2_bearer_token;  // OAuth2 bearer token for GCS
+	bool requester_pays = false;
+	string oauth2_bearer_token; // OAuth2 bearer token for GCS
 
 	static S3AuthParams ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info);
 };
@@ -46,7 +46,6 @@ struct AWSEnvironmentCredentialsProvider {
 	static constexpr const char *DUCKDB_USE_SSL_ENV_VAR = "DUCKDB_S3_USE_SSL";
 	static constexpr const char *DUCKDB_KMS_KEY_ID_ENV_VAR = "DUCKDB_S3_KMS_KEY_ID";
 	static constexpr const char *DUCKDB_REQUESTER_PAYS_ENV_VAR = "DUCKDB_S3_REQUESTER_PAYS";
-
 
 	explicit AWSEnvironmentCredentialsProvider(DBConfig &config) : config(config) {};
 

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -67,7 +67,7 @@ static HTTPHeaders create_s3_header(string url, string query, string host, strin
 		res["x-amz-request-payer"] = "requester";
 	}
 
-    string signed_headers = "";
+	string signed_headers = "";
 	hash_bytes canonical_request_hash;
 	hash_str canonical_request_hash_str;
 	if (content_type.length() > 0) {
@@ -83,7 +83,7 @@ static HTTPHeaders create_s3_header(string url, string query, string host, strin
 	if (use_requester_pays) {
 		signed_headers += ";x-amz-request-payer";
 	}
-    auto canonical_request = method + "\n" + S3FileSystem::UrlEncode(url) + "\n" + query;
+	auto canonical_request = method + "\n" + S3FileSystem::UrlEncode(url) + "\n" + query;
 	if (content_type.length() > 0) {
 		canonical_request += "\ncontent-type:" + content_type;
 	}
@@ -132,8 +132,7 @@ string S3FileSystem::UrlEncode(const string &input, bool encode_slash) {
 }
 
 static bool IsGCSRequest(const string &url) {
-	return StringUtil::StartsWith(url, "gcs://") || 
-	       StringUtil::StartsWith(url, "gs://");
+	return StringUtil::StartsWith(url, "gcs://") || StringUtil::StartsWith(url, "gs://");
 }
 
 void AWSEnvironmentCredentialsProvider::SetExtensionOptionValue(string key, const char *env_var_name) {
@@ -173,7 +172,7 @@ S3AuthParams AWSEnvironmentCredentialsProvider::CreateParams() {
 	params.endpoint = DUCKDB_ENDPOINT_ENV_VAR;
 	params.kms_key_id = DUCKDB_KMS_KEY_ID_ENV_VAR;
 	params.use_ssl = DUCKDB_USE_SSL_ENV_VAR;
-    params.requester_pays = DUCKDB_REQUESTER_PAYS_ENV_VAR;
+	params.requester_pays = DUCKDB_REQUESTER_PAYS_ENV_VAR;
 
 	return params;
 }
@@ -199,8 +198,7 @@ S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerI
 	secret_reader.TryGetSecretKeyOrSetting("kms_key_id", "s3_kms_key_id", result.kms_key_id);
 	secret_reader.TryGetSecretKeyOrSetting("s3_url_compatibility_mode", "s3_url_compatibility_mode",
 	                                       result.s3_url_compatibility_mode);
-	secret_reader.TryGetSecretKeyOrSetting("requester_pays", "s3_requester_pays",
-										   result.requester_pays);
+	secret_reader.TryGetSecretKeyOrSetting("requester_pays", "s3_requester_pays", result.requester_pays);
 
 	// Endpoint and url style are slightly more complex and require special handling for gcs and r2
 	auto endpoint_result = secret_reader.TryGetSecretKeyOrSetting("endpoint", "s3_endpoint", result.endpoint);
@@ -219,9 +217,9 @@ S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerI
 	}
 
 	if (!result.region.empty() && (result.endpoint.empty() || result.endpoint == "s3.amazonaws.com")) {
-	    result.endpoint = StringUtil::Format("s3.%s.amazonaws.com", result.region);
+		result.endpoint = StringUtil::Format("s3.%s.amazonaws.com", result.region);
 	} else if (result.endpoint.empty()) {
-	    result.endpoint = "s3.amazonaws.com";
+		result.endpoint = "s3.amazonaws.com";
 	}
 
 	return result;
@@ -572,7 +570,7 @@ void S3FileSystem::ReadQueryParams(const string &url_query_param, S3AuthParams &
 	if (!query_params.empty()) {
 		throw IOException("Invalid query parameters found. Supported parameters are:\n's3_region', 's3_access_key_id', "
 		                  "'s3_secret_access_key', 's3_session_token',\n's3_endpoint', 's3_url_style', 's3_use_ssl', "
-                          "'s3_requester_pays'");
+		                  "'s3_requester_pays'");
 	}
 }
 
@@ -683,7 +681,7 @@ unique_ptr<HTTPResponse> S3FileSystem::PostRequest(FileHandle &handle, string ur
 	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
 	auto parsed_s3_url = S3UrlParse(url, auth_params);
 	string http_url = parsed_s3_url.GetHTTPUrl(auth_params, http_params);
-	
+
 	HTTPHeaders headers;
 	if (IsGCSRequest(url) && !auth_params.oauth2_bearer_token.empty()) {
 		// Use bearer token for GCS
@@ -694,7 +692,7 @@ unique_ptr<HTTPResponse> S3FileSystem::PostRequest(FileHandle &handle, string ur
 		// Use existing S3 authentication
 		auto payload_hash = GetPayloadHash(buffer_in, buffer_in_len);
 		headers = create_s3_header(parsed_s3_url.path, http_params, parsed_s3_url.host, "s3", "POST", auth_params, "",
-		                          "", payload_hash, "application/octet-stream");
+		                           "", payload_hash, "application/octet-stream");
 	}
 
 	return HTTPFileSystem::PostRequest(handle, http_url, headers, result, buffer_in, buffer_in_len);
@@ -706,7 +704,7 @@ unique_ptr<HTTPResponse> S3FileSystem::PutRequest(FileHandle &handle, string url
 	auto parsed_s3_url = S3UrlParse(url, auth_params);
 	string http_url = parsed_s3_url.GetHTTPUrl(auth_params, http_params);
 	auto content_type = "application/octet-stream";
-	
+
 	HTTPHeaders headers;
 	if (IsGCSRequest(url) && !auth_params.oauth2_bearer_token.empty()) {
 		// Use bearer token for GCS
@@ -717,9 +715,9 @@ unique_ptr<HTTPResponse> S3FileSystem::PutRequest(FileHandle &handle, string url
 		// Use existing S3 authentication
 		auto payload_hash = GetPayloadHash(buffer_in, buffer_in_len);
 		headers = create_s3_header(parsed_s3_url.path, http_params, parsed_s3_url.host, "s3", "PUT", auth_params, "",
-		                          "", payload_hash, content_type);
+		                           "", payload_hash, content_type);
 	}
-	
+
 	return HTTPFileSystem::PutRequest(handle, http_url, headers, buffer_in, buffer_in_len);
 }
 
@@ -727,7 +725,7 @@ unique_ptr<HTTPResponse> S3FileSystem::HeadRequest(FileHandle &handle, string s3
 	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
 	auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
 	string http_url = parsed_s3_url.GetHTTPUrl(auth_params);
-	
+
 	HTTPHeaders headers;
 	if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
 		// Use bearer token for GCS
@@ -735,10 +733,10 @@ unique_ptr<HTTPResponse> S3FileSystem::HeadRequest(FileHandle &handle, string s3
 		headers["Host"] = parsed_s3_url.host;
 	} else {
 		// Use existing S3 authentication
-		headers = create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, 
-		                          "s3", "HEAD", auth_params, "", "", "", "");
+		headers =
+		    create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "HEAD", auth_params, "", "", "", "");
 	}
-	
+
 	return HTTPFileSystem::HeadRequest(handle, http_url, headers);
 }
 
@@ -746,7 +744,7 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_
 	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
 	auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
 	string http_url = parsed_s3_url.GetHTTPUrl(auth_params);
-	
+
 	HTTPHeaders headers;
 	if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
 		// Use bearer token for GCS
@@ -754,10 +752,10 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_
 		headers["Host"] = parsed_s3_url.host;
 	} else {
 		// Use existing S3 authentication
-		headers = create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, 
-		                          "s3", "GET", auth_params, "", "", "", "");
+		headers =
+		    create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "GET", auth_params, "", "", "", "");
 	}
-	
+
 	return HTTPFileSystem::GetRequest(handle, http_url, headers);
 }
 
@@ -766,7 +764,7 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, strin
 	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
 	auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
 	string http_url = parsed_s3_url.GetHTTPUrl(auth_params);
-	
+
 	HTTPHeaders headers;
 	if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
 		// Use bearer token for GCS
@@ -774,10 +772,10 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, strin
 		headers["Host"] = parsed_s3_url.host;
 	} else {
 		// Use existing S3 authentication
-		headers = create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, 
-		                          "s3", "GET", auth_params, "", "", "", "");
+		headers =
+		    create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "GET", auth_params, "", "", "", "");
 	}
-	
+
 	return HTTPFileSystem::GetRangeRequest(handle, http_url, headers, file_offset, buffer_out, buffer_out_len);
 }
 
@@ -785,7 +783,7 @@ unique_ptr<HTTPResponse> S3FileSystem::DeleteRequest(FileHandle &handle, string 
 	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
 	auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
 	string http_url = parsed_s3_url.GetHTTPUrl(auth_params);
-	
+
 	HTTPHeaders headers;
 	if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
 		// Use bearer token for GCS
@@ -793,10 +791,10 @@ unique_ptr<HTTPResponse> S3FileSystem::DeleteRequest(FileHandle &handle, string 
 		headers["Host"] = parsed_s3_url.host;
 	} else {
 		// Use existing S3 authentication
-		headers = create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, 
-		                          "s3", "DELETE", auth_params, "", "", "", "");
+		headers =
+		    create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "DELETE", auth_params, "", "", "", "");
 	}
-	
+
 	return HTTPFileSystem::DeleteRequest(handle, http_url, headers);
 }
 
@@ -1114,8 +1112,7 @@ string S3FileSystem::GetS3AuthError(S3AuthParams &s3_auth_params) {
 
 string S3FileSystem::GetGCSAuthError(S3AuthParams &s3_auth_params) {
 	string extra_text = "\n\nAuthentication Failure - GCS authentication failed.";
-	if (s3_auth_params.oauth2_bearer_token.empty() && 
-	    s3_auth_params.secret_access_key.empty() && 
+	if (s3_auth_params.oauth2_bearer_token.empty() && s3_auth_params.secret_access_key.empty() &&
 	    s3_auth_params.access_key_id.empty()) {
 		extra_text += "\n* No credentials provided.";
 		extra_text += "\n* For OAuth2: CREATE SECRET (TYPE GCS, bearer_token 'your-token')";
@@ -1145,15 +1142,15 @@ HTTPException S3FileSystem::GetS3Error(S3AuthParams &s3_auth_params, const HTTPR
 
 HTTPException S3FileSystem::GetHTTPError(FileHandle &handle, const HTTPResponse &response, const string &url) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
-	
+
 	// Use GCS-specific error for GCS URLs
 	if (IsGCSRequest(url) && response.status == HTTPStatusCode::Forbidden_403) {
 		string extra_text = GetGCSAuthError(s3_handle.auth_params);
 		auto status_message = HTTPFSUtil::GetStatusMessage(response.status);
-		throw HTTPException(response, "HTTP error on '%s' (HTTP %d %s)%s", url,
-		                    response.status, status_message, extra_text);
+		throw HTTPException(response, "HTTP error on '%s' (HTTP %d %s)%s", url, response.status, status_message,
+		                    extra_text);
 	}
-	
+
 	return GetS3Error(s3_handle.auth_params, response, url);
 }
 string AWSListObjectV2::Request(string &path, HTTPParams &http_params, S3AuthParams &s3_auth_params,


### PR DESCRIPTION
Equivalent to https://github.com/duckdb/duckdb-httpfs/pull/102, `mv extension/httpfs src && make format && mv src extension/httpfs`.

My plan would be first to land this, https://github.com/duckdb/duckdb-httpfs/pull/101 and https://github.com/duckdb/duckdb-httpfs/pull/102, and then moving to `andium`, and then committing `mv extension/httpfs src` and formatting checks.