### PR TITLE
Revert "Allow multiple cases for ETag / etag"

### DIFF
--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -369,15 +369,10 @@ void S3FileSystem::UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuf
 			                    static_cast<int>(res->status));
 		}
 
-		if (!res->headers.HasHeader("ETag") && !res->headers.HasHeader("etag")) {
+		if (!res->headers.HasHeader("ETag")) {
 			throw IOException("Unexpected response when uploading part to S3");
 		}
-
-		if (res->headers.HasHeader("ETag")) {
-			etag = res->headers.GetHeaderValue("ETag");
-		} else if (res->headers.HasHeader("etag")) {
-			etag = res->headers.GetHeaderValue("etag");
-		}
+		etag = res->headers.GetHeaderValue("ETag");
 	} catch (std::exception &ex) {
 		ErrorData error(ex);
 		if (error.Type() != ExceptionType::IO && error.Type() != ExceptionType::HTTP) {


### PR DESCRIPTION
This reverts commit d54ddf3e16688b32040c22c47cccf7b4866d999e.

That was just unnecessary, already a case-insensitive map.