### PR TITLE
Append content-type only on DuckDB-Wasm

### DIFF
--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -75,7 +75,9 @@ static HTTPHeaders create_s3_header(string url, string query, string host, strin
 	hash_str canonical_request_hash_str;
 	if (content_type.length() > 0) {
 		signed_headers += "content-type;";
+#ifdef EMSCRIPTEN
 		res["content-type"] = content_type;
+#endif
 	}
 	signed_headers += "host;x-amz-content-sha256;x-amz-date";
 	if (auth_params.session_token.length() > 0) {


### PR DESCRIPTION
I feel this is not the right solution, BUT reverting https://github.com/duckdb/duckdb-httpfs/pull/101/commits/7dfdcf05df3e46c9d3cf595daff7824732ae797d is the right first step, given otherwise it broke signing to S3