### PR TITLE
When a HTTPFIleHandle has an Etag, and that changes over time, throw an error

### DIFF
--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -232,9 +232,11 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
                                 string responseEtag = response.GetHeaderValue("ETag");
 
                                 if (!responseEtag.empty() && responseEtag != hfh.etag) {
-                                    throw HTTPException(response, "ETag was initially %s and now it returned %s, this likely means the remote file has changed.\nTry restart the read / close file-handle and restart (e.g. `DETACH` in case of database file).\nYou can disable this behaviour via `SET unsafe_disable_etag_checks = true;`", hfh.etag, response.GetHeaderValue("ETag"));
+                                    throw HTTPException(response, "ETag was initially %s and now it returned %s, this likely means the remote file has changed.\nTry to restart the read or close the file-handle and read the file again (e.g. `DETACH` in the file is a database file).\nYou can disable checking etags via `SET unsafe_disable_etag_checks = true;`", hfh.etag, response.GetHeaderValue("ETag"));
 				}
                             }
+
+
 
 			    if (response.HasHeader("Content-Length")) {
 				    auto content_length = stoll(response.GetHeaderValue("Content-Length"));

--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -226,6 +226,11 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
 		    }
 		    if (static_cast<int>(response.status) < 300) { // done redirecting
 			    out_offset = 0;
+
+				if (response.HasHeader("ETag") && !hfh.etag.empty() && response.GetHeaderValue("ETag") != hfh.etag) {
+					throw HTTPException(response, "ETag was initially %s and now it returned %s, this likely means the remote file has changed.\nTry restart the read / close file-handle and restart (e.g. `DETACH` in case of database file).", hfh.etag, response.GetHeaderValue("ETag"));
+				}
+
 			    if (response.HasHeader("Content-Length")) {
 				    auto content_length = stoll(response.GetHeaderValue("Content-Length"));
 				    if ((idx_t)content_length != buffer_out_len) {

--- a/extension/httpfs/httpfs_extension.cpp
+++ b/extension/httpfs/httpfs_extension.cpp
@@ -79,6 +79,8 @@ static void LoadInternal(DatabaseInstance &instance) {
 	                          LogicalType::UBIGINT, Value(10000));
 	config.AddExtensionOption("s3_uploader_thread_limit", "S3 Uploader global thread limit", LogicalType::UBIGINT,
 	                          Value(50));
+	config.AddExtensionOption("unsafe_disable_etag_checks", "Disable checks on ETag consistency",
+	                          LogicalType::BOOLEAN, Value(false));
 
 	// HuggingFace options
 	config.AddExtensionOption("hf_max_per_page", "Debug option to limit number of items returned in list requests",

--- a/extension/httpfs/include/httpfs_client.hpp
+++ b/extension/httpfs/include/httpfs_client.hpp
@@ -21,6 +21,7 @@ struct HTTPFSParams : public HTTPParams {
 	idx_t hf_max_per_page = DEFAULT_HF_MAX_PER_PAGE;
 	string ca_cert_file;
 	string bearer_token;
+	bool unsafe_disable_etag_checks {false};
 	shared_ptr<HTTPState> state;
 };
 


### PR DESCRIPTION
Basically same as https://github.com/duckdb/duckdb-httpfs/pull/111, adding an option to disable the behaviour.
```
SET unsafe_disable_etag_checks = true;
```
Brings back current default, that is not checking, to avoid some yet unknown relevant workflow that will start failing due to this change.