### PR TITLE
Wasm fixes: move Curl to separate header (so curl is not needed to be linked in)

### DIFF
--- a/extension/httpfs/httpfs_curl_client.cpp
+++ b/extension/httpfs/httpfs_curl_client.cpp
@@ -7,6 +7,10 @@
 #include <sys/stat.h>
 #include "duckdb/common/exception/http_exception.hpp"
 
+#ifndef EMSCRIPTEN
+#include "httpfs_curl_client.hpp"
+#endif
+
 namespace duckdb {
 
 // we statically compile in libcurl, which means the cert file location of the build machine is the

--- a/extension/httpfs/httpfs_extension.cpp
+++ b/extension/httpfs/httpfs_extension.cpp
@@ -98,6 +98,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 			throw InvalidInputException("Unsupported option for httpfs_client_implementation, only `wasm` and "
 			                            "`default` are currently supported for duckdb-wasm");
 		}
+#ifndef EMSCRIPTEN
 		if (value == "curl") {
 			if (!config.http_util || config.http_util->GetName() != "HTTPFSUtil-Curl") {
 				config.http_util = make_shared_ptr<HTTPFSCurlUtil>();
@@ -110,6 +111,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 			}
 			return;
 		}
+#endif
 		throw InvalidInputException("Unsupported option for httpfs_client_implementation, only `curl`, `httplib` and "
 		                            "`default` are currently supported");
 	};

--- a/extension/httpfs/httpfs_extension.cpp
+++ b/extension/httpfs/httpfs_extension.cpp
@@ -9,6 +9,10 @@
 #include "crypto.hpp"
 #endif // OVERRIDE_ENCRYPTION_UTILS
 
+#ifndef EMSCRIPTEN
+#include "httpfs_curl_client.hpp"
+#endif
+
 namespace duckdb {
 
 static void SetHttpfsClientImplementation(DBConfig &config, const string &value) {

--- a/extension/httpfs/include/httpfs_client.hpp
+++ b/extension/httpfs/include/httpfs_client.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "duckdb/common/http_util.hpp"
-#include <curl/curl.h>
 
 namespace duckdb {
 class HTTPLogger;
@@ -48,51 +47,6 @@ public:
 	static unordered_map<string, string> ParseGetParameters(const string &text);
 
 	string GetName() const override;
-};
-
-class CURLHandle {
-public:
-	CURLHandle(const string &token, const string &cert_path);
-	~CURLHandle();
-
-public:
-	operator CURL *() {
-		return curl;
-	}
-	CURLcode Execute() {
-		return curl_easy_perform(curl);
-	}
-
-private:
-	CURL *curl = NULL;
-};
-
-class CURLRequestHeaders {
-public:
-	CURLRequestHeaders(vector<std::string> &input) {
-		for (auto &header : input) {
-			Add(header);
-		}
-	}
-	CURLRequestHeaders() {}
-
-	~CURLRequestHeaders() {
-		if (headers) {
-			curl_slist_free_all(headers);
-		}
-		headers = NULL;
-	}
-	operator bool() const {
-		return headers != NULL;
-	}
-
-public:
-	void Add(const string &header) {
-		headers = curl_slist_append(headers, header.c_str());
-	}
-
-public:
-	curl_slist *headers = NULL;
 };
 
 struct HeaderCollector {

--- a/extension/httpfs/include/httpfs_curl_client.hpp
+++ b/extension/httpfs/include/httpfs_curl_client.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "duckdb/common/http_util.hpp"
+
+namespace duckdb {
+class HTTPLogger;
+class FileOpener;
+struct FileOpenerInfo;
+class HTTPState;
+
+#include <curl/curl.h>
+class CURLHandle {
+public:
+	CURLHandle(const string &token, const string &cert_path);
+	~CURLHandle();
+
+public:
+	operator CURL *() {
+		return curl;
+	}
+	CURLcode Execute() {
+		return curl_easy_perform(curl);
+	}
+
+private:
+	CURL *curl = NULL;
+};
+
+class CURLRequestHeaders {
+public:
+	CURLRequestHeaders(vector<std::string> &input) {
+		for (auto &header : input) {
+			Add(header);
+		}
+	}
+	CURLRequestHeaders() {}
+
+	~CURLRequestHeaders() {
+		if (headers) {
+			curl_slist_free_all(headers);
+		}
+		headers = NULL;
+	}
+	operator bool() const {
+		return headers != NULL;
+	}
+
+public:
+	void Add(const string &header) {
+		headers = curl_slist_append(headers, header.c_str());
+	}
+
+public:
+	curl_slist *headers = NULL;
+};
+
+} // namespace duckdb
+


### PR DESCRIPTION
Should be a NOP for native, while skipping compexity (and, if misused, crashes) on the Wasm side