### PR TITLE
Remove s3 region default, check error message for Unknown Error to HTTP HEAD

### DIFF
--- a/extension/httpfs/httpfs_extension.cpp
+++ b/extension/httpfs/httpfs_extension.cpp
@@ -62,7 +62,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("ca_cert_file", "Path to a custom certificate file for self-signed certificates.",
 	                          LogicalType::VARCHAR, Value(""));
 	// Global S3 config
-	config.AddExtensionOption("s3_region", "S3 Region", LogicalType::VARCHAR, Value("us-east-1"));
+	config.AddExtensionOption("s3_region", "S3 Region", LogicalType::VARCHAR);
 	config.AddExtensionOption("s3_access_key_id", "S3 Access Key ID", LogicalType::VARCHAR);
 	config.AddExtensionOption("s3_secret_access_key", "S3 Access Key", LogicalType::VARCHAR);
 	config.AddExtensionOption("s3_session_token", "S3 Session Token", LogicalType::VARCHAR);

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -74,29 +74,29 @@ static HTTPHeaders create_s3_header(string url, string query, string host, strin
 		signed_headers += "content-type;";
 	}
 	signed_headers += "host;x-amz-content-sha256;x-amz-date";
+	if (use_requester_pays) {
+		signed_headers += ";x-amz-request-payer";
+	}
 	if (auth_params.session_token.length() > 0) {
 		signed_headers += ";x-amz-security-token";
 	}
 	if (use_sse_kms) {
 		signed_headers += ";x-amz-server-side-encryption;x-amz-server-side-encryption-aws-kms-key-id";
 	}
-	if (use_requester_pays) {
-		signed_headers += ";x-amz-request-payer";
-	}
     auto canonical_request = method + "\n" + S3FileSystem::UrlEncode(url) + "\n" + query;
 	if (content_type.length() > 0) {
 		canonical_request += "\ncontent-type:" + content_type;
 	}
 	canonical_request += "\nhost:" + host + "\nx-amz-content-sha256:" + payload_hash + "\nx-amz-date:" + datetime_now;
+	if (use_requester_pays) {
+		canonical_request += "\nx-amz-request-payer:requester";
+	}
 	if (auth_params.session_token.length() > 0) {
 		canonical_request += "\nx-amz-security-token:" + auth_params.session_token;
 	}
 	if (use_sse_kms) {
 		canonical_request += "\nx-amz-server-side-encryption:aws:kms";
 		canonical_request += "\nx-amz-server-side-encryption-aws-kms-key-id:" + auth_params.kms_key_id;
-	}
-	if (use_requester_pays) {
-		canonical_request += "\nx-amz-request-payer:requester";
 	}
 
 	canonical_request += "\n\n" + signed_headers + "\n" + payload_hash;
@@ -129,11 +129,6 @@ string S3FileSystem::UrlDecode(string input) {
 
 string S3FileSystem::UrlEncode(const string &input, bool encode_slash) {
 	return StringUtil::URLEncode(input, encode_slash);
-}
-
-static bool IsGCSRequest(const string &url) {
-	return StringUtil::StartsWith(url, "gcs://") || 
-	       StringUtil::StartsWith(url, "gs://");
 }
 
 void AWSEnvironmentCredentialsProvider::SetExtensionOptionValue(string key, const char *env_var_name) {
@@ -214,8 +209,6 @@ S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerI
 		if (result.url_style.empty() || url_style_result.GetScope() != SettingScope::SECRET) {
 			result.url_style = "path";
 		}
-		// Read bearer token for GCS
-		secret_reader.TryGetSecretKey("bearer_token", result.oauth2_bearer_token);
 	}
 
 	if (!result.region.empty() && (result.endpoint.empty() || result.endpoint == "s3.amazonaws.com")) {
@@ -242,13 +235,9 @@ unique_ptr<KeyValueSecret> CreateSecret(vector<string> &prefix_paths_p, string &
 	return_value->secret_map["kms_key_id"] = params.kms_key_id;
 	return_value->secret_map["s3_url_compatibility_mode"] = params.s3_url_compatibility_mode;
 	return_value->secret_map["requester_pays"] = params.requester_pays;
-	return_value->secret_map["bearer_token"] = params.oauth2_bearer_token;
 
 	//! Set redact keys
 	return_value->redact_keys = {"secret", "session_token"};
-	if (!params.oauth2_bearer_token.empty()) {
-		return_value->redact_keys.insert("bearer_token");
-	}
 
 	return return_value;
 }
@@ -683,19 +672,9 @@ unique_ptr<HTTPResponse> S3FileSystem::PostRequest(FileHandle &handle, string ur
 	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
 	auto parsed_s3_url = S3UrlParse(url, auth_params);
 	string http_url = parsed_s3_url.GetHTTPUrl(auth_params, http_params);
-	
-	HTTPHeaders headers;
-	if (IsGCSRequest(url) && !auth_params.oauth2_bearer_token.empty()) {
-		// Use bearer token for GCS
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_s3_url.host;
-		headers["Content-Type"] = "application/octet-stream";
-	} else {
-		// Use existing S3 authentication
-		auto payload_hash = GetPayloadHash(buffer_in, buffer_in_len);
-		headers = create_s3_header(parsed_s3_url.path, http_params, parsed_s3_url.host, "s3", "POST", auth_params, "",
-		                          "", payload_hash, "application/octet-stream");
-	}
+	auto payload_hash = GetPayloadHash(buffer_in, buffer_in_len);
+	auto headers = create_s3_header(parsed_s3_url.path, http_params, parsed_s3_url.host, "s3", "POST", auth_params, "",
+	                                "", payload_hash, "application/octet-stream");
 
 	return HTTPFileSystem::PostRequest(handle, http_url, headers, result, buffer_in, buffer_in_len);
 }
@@ -706,20 +685,10 @@ unique_ptr<HTTPResponse> S3FileSystem::PutRequest(FileHandle &handle, string url
 	auto parsed_s3_url = S3UrlParse(url, auth_params);
 	string http_url = parsed_s3_url.GetHTTPUrl(auth_params, http_params);
 	auto content_type = "application/octet-stream";
-	
-	HTTPHeaders headers;
-	if (IsGCSRequest(url) && !auth_params.oauth2_bearer_token.empty()) {
-		// Use bearer token for GCS
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_s3_url.host;
-		headers["Content-Type"] = content_type;
-	} else {
-		// Use existing S3 authentication
-		auto payload_hash = GetPayloadHash(buffer_in, buffer_in_len);
-		headers = create_s3_header(parsed_s3_url.path, http_params, parsed_s3_url.host, "s3", "PUT", auth_params, "",
-		                          "", payload_hash, content_type);
-	}
-	
+	auto payload_hash = GetPayloadHash(buffer_in, buffer_in_len);
+
+	auto headers = create_s3_header(parsed_s3_url.path, http_params, parsed_s3_url.host, "s3", "PUT", auth_params, "",
+	                                "", payload_hash, content_type);
 	return HTTPFileSystem::PutRequest(handle, http_url, headers, buffer_in, buffer_in_len);
 }
 
@@ -727,18 +696,8 @@ unique_ptr<HTTPResponse> S3FileSystem::HeadRequest(FileHandle &handle, string s3
 	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
 	auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
 	string http_url = parsed_s3_url.GetHTTPUrl(auth_params);
-	
-	HTTPHeaders headers;
-	if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
-		// Use bearer token for GCS
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_s3_url.host;
-	} else {
-		// Use existing S3 authentication
-		headers = create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, 
-		                          "s3", "HEAD", auth_params, "", "", "", "");
-	}
-	
+	auto headers =
+	    create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "HEAD", auth_params, "", "", "", "");
 	return HTTPFileSystem::HeadRequest(handle, http_url, headers);
 }
 
@@ -746,18 +705,8 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_
 	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
 	auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
 	string http_url = parsed_s3_url.GetHTTPUrl(auth_params);
-	
-	HTTPHeaders headers;
-	if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
-		// Use bearer token for GCS
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_s3_url.host;
-	} else {
-		// Use existing S3 authentication
-		headers = create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, 
-		                          "s3", "GET", auth_params, "", "", "", "");
-	}
-	
+	auto headers =
+	    create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "GET", auth_params, "", "", "", "");
 	return HTTPFileSystem::GetRequest(handle, http_url, headers);
 }
 
@@ -766,18 +715,8 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, strin
 	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
 	auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
 	string http_url = parsed_s3_url.GetHTTPUrl(auth_params);
-	
-	HTTPHeaders headers;
-	if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
-		// Use bearer token for GCS
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_s3_url.host;
-	} else {
-		// Use existing S3 authentication
-		headers = create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, 
-		                          "s3", "GET", auth_params, "", "", "", "");
-	}
-	
+	auto headers =
+	    create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "GET", auth_params, "", "", "", "");
 	return HTTPFileSystem::GetRangeRequest(handle, http_url, headers, file_offset, buffer_out, buffer_out_len);
 }
 
@@ -785,18 +724,8 @@ unique_ptr<HTTPResponse> S3FileSystem::DeleteRequest(FileHandle &handle, string 
 	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
 	auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
 	string http_url = parsed_s3_url.GetHTTPUrl(auth_params);
-	
-	HTTPHeaders headers;
-	if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
-		// Use bearer token for GCS
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_s3_url.host;
-	} else {
-		// Use existing S3 authentication
-		headers = create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, 
-		                          "s3", "DELETE", auth_params, "", "", "", "");
-	}
-	
+	auto headers =
+	    create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "DELETE", auth_params, "", "", "", "");
 	return HTTPFileSystem::DeleteRequest(handle, http_url, headers);
 }
 
@@ -845,12 +774,7 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 				}
 				if (entry->second == "403") {
 					// 403: FORBIDDEN
-					string extra_text;
-					if (IsGCSRequest(path)) {
-						extra_text = S3FileSystem::GetGCSAuthError(auth_params);
-					} else {
-						extra_text = S3FileSystem::GetS3AuthError(auth_params);
-					}
+					auto extra_text = S3FileSystem::GetS3AuthError(auth_params);
 					throw Exception(error.Type(), error.RawMessage() + extra_text, extra_info);
 				}
 			}
@@ -1112,24 +1036,6 @@ string S3FileSystem::GetS3AuthError(S3AuthParams &s3_auth_params) {
 	return extra_text;
 }
 
-string S3FileSystem::GetGCSAuthError(S3AuthParams &s3_auth_params) {
-	string extra_text = "\n\nAuthentication Failure - GCS authentication failed.";
-	if (s3_auth_params.oauth2_bearer_token.empty() && 
-	    s3_auth_params.secret_access_key.empty() && 
-	    s3_auth_params.access_key_id.empty()) {
-		extra_text += "\n* No credentials provided.";
-		extra_text += "\n* For OAuth2: CREATE SECRET (TYPE GCS, bearer_token 'your-token')";
-		extra_text += "\n* For HMAC: CREATE SECRET (TYPE GCS, key_id 'key', secret 'secret')";
-	} else if (!s3_auth_params.oauth2_bearer_token.empty()) {
-		extra_text += "\n* Bearer token was provided but authentication failed.";
-		extra_text += "\n* Ensure your OAuth2 token is valid and not expired.";
-	} else {
-		extra_text += "\n* HMAC credentials were provided but authentication failed.";
-		extra_text += "\n* Ensure your HMAC key_id and secret are correct.";
-	}
-	return extra_text;
-}
-
 HTTPException S3FileSystem::GetS3Error(S3AuthParams &s3_auth_params, const HTTPResponse &response, const string &url) {
 	string extra_text;
 	if (response.status == HTTPStatusCode::BadRequest_400) {
@@ -1145,15 +1051,6 @@ HTTPException S3FileSystem::GetS3Error(S3AuthParams &s3_auth_params, const HTTPR
 
 HTTPException S3FileSystem::GetHTTPError(FileHandle &handle, const HTTPResponse &response, const string &url) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
-	
-	// Use GCS-specific error for GCS URLs
-	if (IsGCSRequest(url) && response.status == HTTPStatusCode::Forbidden_403) {
-		string extra_text = GetGCSAuthError(s3_handle.auth_params);
-		auto status_message = HTTPFSUtil::GetStatusMessage(response.status);
-		throw HTTPException(response, "HTTP error on '%s' (HTTP %d %s)%s", url,
-		                    response.status, status_message, extra_text);
-	}
-	
 	return GetS3Error(s3_handle.auth_params, response, url);
 }
 string AWSListObjectV2::Request(string &path, HTTPParams &http_params, S3AuthParams &s3_auth_params,

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -868,6 +868,12 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 					}
 					throw Exception(error.Type(), error.RawMessage() + extra_text, extra_info);
 				}
+			} else if (error.Message().find("Unknown error for HTTP HEAD to") != string::npos) {
+				// FIXME: Potentially a request to a bucket with an incorrect region. This returns a 301 Permanently Moved
+				//        http_util thinks this is a failed request, and ignores all response information
+				//        see: duckdblabs/duckdb-internal/issues/5905
+				auto extra_text = S3FileSystem::GetS3BadRequestError(auth_params);
+				throw Exception(error.Type(), error.RawMessage() + extra_text, extra_info);
 			}
 			throw;
 		}

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -74,29 +74,29 @@ static HTTPHeaders create_s3_header(string url, string query, string host, strin
 		signed_headers += "content-type;";
 	}
 	signed_headers += "host;x-amz-content-sha256;x-amz-date";
+	if (use_requester_pays) {
+		signed_headers += ";x-amz-request-payer";
+	}
 	if (auth_params.session_token.length() > 0) {
 		signed_headers += ";x-amz-security-token";
 	}
 	if (use_sse_kms) {
 		signed_headers += ";x-amz-server-side-encryption;x-amz-server-side-encryption-aws-kms-key-id";
 	}
-	if (use_requester_pays) {
-		signed_headers += ";x-amz-request-payer";
-	}
     auto canonical_request = method + "\n" + S3FileSystem::UrlEncode(url) + "\n" + query;
 	if (content_type.length() > 0) {
 		canonical_request += "\ncontent-type:" + content_type;
 	}
 	canonical_request += "\nhost:" + host + "\nx-amz-content-sha256:" + payload_hash + "\nx-amz-date:" + datetime_now;
+	if (use_requester_pays) {
+		canonical_request += "\nx-amz-request-payer:requester";
+	}
 	if (auth_params.session_token.length() > 0) {
 		canonical_request += "\nx-amz-security-token:" + auth_params.session_token;
 	}
 	if (use_sse_kms) {
 		canonical_request += "\nx-amz-server-side-encryption:aws:kms";
 		canonical_request += "\nx-amz-server-side-encryption-aws-kms-key-id:" + auth_params.kms_key_id;
-	}
-	if (use_requester_pays) {
-		canonical_request += "\nx-amz-request-payer:requester";
 	}
 
 	canonical_request += "\n\n" + signed_headers + "\n" + payload_hash;

--- a/test/sql/test_headers_parsed.test
+++ b/test/sql/test_headers_parsed.test
@@ -1,4 +1,4 @@
-# name: test/sql/copy/csv/test_headers_parsed.test
+# name: test/sql/test_headers_parsed.test
 # description: This test triggers the http prefetch mechanism.
 # group: [csv]
 

--- a/test/sql/test_region_errors.test
+++ b/test/sql/test_region_errors.test
@@ -1,4 +1,6 @@
-
+# name: test/sql/test_region_errors.test
+# description: This test triggers the http prefetch mechanism.
+# group: [csv]
 
 require httpfs
 

--- a/test/sql/test_region_shenanigans.test
+++ b/test/sql/test_region_shenanigans.test
@@ -1,0 +1,35 @@
+
+
+require httpfs
+
+require parquet
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+set ignore_error_messages
+
+statement ok
+CREATE or replace SECRET s1 (
+    TYPE AWS,
+    KEY_ID '${AWS_ACCESS_KEY_ID}',
+    SECRET '${AWS_SECRET_ACCESS_KEY}'
+)
+
+# no region set, no error
+statement error
+select * from 's3://clickhouse-public-datasets/hits_compatible/hits.parquet' limit 1;
+----
+<REGEX>:.*HTTP Error.*Bad Request.*this can be caused by the S3 region being set incorrectly.*No region is provided.*
+
+
+statement ok
+set s3_region='us-east-1';
+
+# incorrect region set, error suggesting incorrect region
+statement error
+select * from 's3://clickhouse-public-datasets/hits_compatible/hits.parquet' limit 1;
+----
+<REGEX>:.*Bad Request - this can be caused by the S3 region being set incorrectly.*Provided region is "us-east-1".*
+


### PR DESCRIPTION
Temporary workaround for https://github.com/duckdblabs/duckdb-internal/issues/5905

@samansmink unsure if v1.4-andium is now the default bug fix branch.

Seems like httplib.hpp doesn't expect `HEAD` requests to get redirects. At this line is the check for a redirect
https://github.com/duckdb/duckdb/blob/d19df69e14a4e7bdce94ebe5fd9f398bbbe30c57/third_party/httplib/httplib.hpp#L7405

This error manifests in a way where the request fails, and the response information is not saved in any way, so we cannot  parse any of the response information in httpfs. Hence also the message "unknown error"

This is a pr to remove the default of us-east-1, which already clears a lot of things up. The Legacy Aws s3 endpoint will be used, which will work to read data (although not in test infrastructure, unclear why). The issue will be further be cleaned up in v1.4.1 with a change to the httplib code to fix the redirects on HEAD calls


This seems to also include a bug fix for requester-pays, but I think that will fall away if main is merged into v1.4. I am unsure what the current process is for bug fixes for v1.4 in httpfs