### PR TITLE
Clean also global_metadata_cache on discovering a URL is now changed

### DIFF
--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -266,13 +266,19 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
 				    string responseEtag = response.GetHeaderValue("ETag");
 
 				    if (!responseEtag.empty() && responseEtag != hfh.etag) {
+					    if (global_metadata_cache) {
+						    global_metadata_cache->Erase(handle.path);
+					    }
 					    throw HTTPException(
 					        response,
-					        "ETag was initially %s and now it returned %s, this likely means the remote file has "
-					        "changed.\nTry to restart the read or close the file-handle and read the file again (e.g. "
-					        "`DETACH` in the file is a database file).\nYou can disable checking etags via `SET "
+					        "ETag on reading file \"%s\" was initially %s and now it returned %s, this likely means "
+					        "the "
+					        "remote file has "
+					        "changed.\nFor parquet or similar single table sources, consider retrying the query, for "
+					        "persistent FileHandles such as databases consider `DETACH` and re-`ATTACH` "
+					        "\nYou can disable checking etags via `SET "
 					        "unsafe_disable_etag_checks = true;`",
-					        hfh.etag, response.GetHeaderValue("ETag"));
+					        handle.path, hfh.etag, response.GetHeaderValue("ETag"));
 				    }
 			    }
 


### PR DESCRIPTION
Improve on https://github.com/duckdb/duckdb-httpfs/pull/111 by handling also the case where `enable_http_metadata_cache` is enabled, by cleaning up now known to be outdated entries.

Implements comment from @lnkuiper at https://github.com/duckdb/duckdb-httpfs/pull/111/files#r2378080003, after discussion together we think this should properly clean up any problem with parquet-like files.

After the fix:
```sql
D SET enable_http_metadata_cache = true;
D FROM 's3://testbucket-break-the-duck/test-file.parquet' LIMIT 0;
┌──────────┐
│ random() │
│  double  │
├──────────┤
│  0 rows  │
└──────────┘
D --- now change the file
D --- queries checking only cached data will keep working
D FROM 's3://testbucket-break-the-duck/test-file.parquet' LIMIT 0;
┌──────────┐
│ random() │
│  double  │
├──────────┤
│  0 rows  │
└──────────┘
D --- queries requiring new data should fail
D FROM 's3://testbucket-break-the-duck/test-file.parquet' LIMIT 3;
HTTP Error:
ETag on reading file "s3://testbucket-break-the-duck/test-file.parquet" was initially "4f6be7645d412feb33a81760c9835251" and now it returned "834918e12d3ae53314ca9fd1508b54ad", this likely means the remote file has changed.
For parquet or similar single table sources, consider retrying the query, for persistent FileHandles such as databases consider `DETACH` and re-`ATTACH` 
You can disable checking etags via `SET unsafe_disable_etag_checks = true;`
D --- retry
D FROM 's3://testbucket-break-the-duck/test-file.parquet' LIMIT 3;
┌───────┐
│   i   │
│ int32 │
├───────┤
│   806 │
│   112 │
│  1213 │
└───────┘
```
or in alternative, instead of the final retry, also querying pre-cached data would now work properly (meaning cached data has been cleaned up).

I think it's an improvement that retrying the query will now work.

Making this work within a same query is more complex, and I'd say outside the current scope.