### PR TITLE
Run also slow tests, and avoid skipping HTTP-connected errors

### DIFF
--- a/.github/workflows/IntegrationTests.yml
+++ b/.github/workflows/IntegrationTests.yml
@@ -85,4 +85,4 @@ jobs:
         run: |
           source ./scripts/run_s3_test_server.sh
           source ./scripts/set_s3_test_server_variables.sh
-          make test
+          ./build/release/test/unittest "*" --skip-error-messages "[]"

--- a/test/extension/duckdb_extension_settings.test
+++ b/test/extension/duckdb_extension_settings.test
@@ -2,6 +2,9 @@
 # description: settings for extensions
 # group: [extension]
 
+# TODO: move back to duckdb/duckdb
+mode skip
+
 require httpfs
 
 statement ok

--- a/test/sql/copy/csv/parallel/test_parallel_csv.test
+++ b/test/sql/copy/csv/parallel/test_parallel_csv.test
@@ -2,6 +2,9 @@
 # description: Test parallel read CSV function on ghub bugs
 # group: [parallel]
 
+# TODO: figure out where that bucket went
+mode skip
+
 require httpfs
 
 query II

--- a/test/sql/secrets/create_secret_r2.test
+++ b/test/sql/secrets/create_secret_r2.test
@@ -30,7 +30,7 @@ __default_r2	r2	config	['r2://']
 statement error
 FROM 's3://test-bucket/test.csv'
 ----
-<REGEX>:.*HTTP Error.*HTTP GET error on.*
+<REGEX>:.*HTTP Error.*
 
 # Account ID is only for R2, trying to set this for S3 will fail
 statement error

--- a/test/sql/storage/external_file_cache/external_file_cache_httpfs.test
+++ b/test/sql/storage/external_file_cache/external_file_cache_httpfs.test
@@ -8,11 +8,23 @@ require httpfs
 
 # first query caches the data
 statement ok
-from 's3://duckdb-blobs/data/shakespeare.parquet';
-
+from 'https://blobs.duckdb.org/data/shakespeare.parquet';
 
 # second query should only have a head request, no gets
 query II
-explain analyze from 's3://duckdb-blobs/data/shakespeare.parquet';
+explain analyze from 'https://blobs.duckdb.org/data/shakespeare.parquet';
 ----
 analyzed_plan	<REGEX>:.*GET: 0.*
+
+statement ok
+SET enable_http_metadata_cache = true;
+
+# first query saves the metadata (and data, but that was already there)
+statement ok
+from 'https://blobs.duckdb.org/data/shakespeare.parquet';
+
+# second query should do no HEAD and no GET
+query II
+explain analyze from 'https://blobs.duckdb.org/data/shakespeare.parquet';
+----
+analyzed_plan	<REGEX>:.*HEAD: 0.*

--- a/test/sql/storage/external_file_cache/external_file_cache_read_blob.test_slow
+++ b/test/sql/storage/external_file_cache/external_file_cache_read_blob.test_slow
@@ -8,18 +8,18 @@ require httpfs
 
 # first read_blob should do 1 GET
 query II
-explain analyze from read_blob('s3://duckdb-blobs/data/shakespeare.parquet');
+explain analyze from read_blob('https://blobs.duckdb.org/data/shakespeare.parquet');
 ----
 analyzed_plan	<REGEX>:.*GET: 1.*
 
 # second one should do 0
 query II
-explain analyze from read_blob('s3://duckdb-blobs/data/shakespeare.parquet');
+explain analyze from read_blob('https://blobs.duckdb.org/data/shakespeare.parquet');
 ----
 analyzed_plan	<REGEX>:.*GET: 0.*
 
 # although the read was cached using read_blob, the parquet reader can read from cache
 query II
-explain analyze from 's3://duckdb-blobs/data/shakespeare.parquet';
+explain analyze from 'https://blobs.duckdb.org/data/shakespeare.parquet';
 ----
 analyzed_plan	<REGEX>:.*GET: 0.*


### PR DESCRIPTION
Found some failures indeed.
This will be fail more often, since actual networking issues will result in failures, but given this extension is dealing with network, better err on the safer side.