### PR TITLE
Fix header inclusion

### DIFF
--- a/src/include/httpfs_curl_client.hpp
+++ b/src/include/httpfs_curl_client.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <curl/curl.h>
+
 #include "duckdb/common/http_util.hpp"
 
 namespace duckdb {
@@ -8,7 +10,6 @@ class FileOpener;
 struct FileOpenerInfo;
 class HTTPState;
 
-#include <curl/curl.h>
 class CURLHandle {
 public:
 	CURLHandle(const string &token, const string &cert_path);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -89,7 +89,7 @@ static HTTPHeaders create_s3_header(string url, string query, string host, strin
 	if (use_sse_kms) {
 		signed_headers += ";x-amz-server-side-encryption;x-amz-server-side-encryption-aws-kms-key-id";
 	}
-    auto canonical_request = method + "\n" + S3FileSystem::UrlEncode(url) + "\n" + query;
+	auto canonical_request = method + "\n" + S3FileSystem::UrlEncode(url) + "\n" + query;
 	if (content_type.length() > 0) {
 		canonical_request += "\ncontent-type:" + content_type;
 	}


### PR DESCRIPTION
Header files shouldn't be included in the namespace, otherwise all symbols inside are namespace scoped.