### PR TITLE
[minor] Remove unused function

### DIFF
--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -15,25 +15,6 @@
 
 namespace duckdb {
 
-static void SetHttpfsClientImplementation(DBConfig &config, const string &value) {
-	if (config.http_util && config.http_util->GetName() == "WasmHTTPUtils") {
-		if (value == "wasm" || value == "default") {
-			// Already handled, do not override
-			return;
-		}
-		throw InvalidInputException("Unsupported option for httpfs_client_implementation, only `wasm` and "
-		                            "`default` are currently supported for duckdb-wasm");
-	}
-	if (value == "httplib" || value == "default") {
-		if (!config.http_util || config.http_util->GetName() != "HTTPFSUtil") {
-			config.http_util = make_shared_ptr<HTTPFSUtil>();
-		}
-		return;
-	}
-	throw InvalidInputException("Unsupported option for httpfs_client_implementation, only `curl`, `httplib` and "
-	                            "`default` are currently supported");
-}
-
 static void LoadInternal(ExtensionLoader &loader) {
 	auto &instance = loader.GetDatabaseInstance();
 	auto &fs = instance.GetFileSystem();


### PR DESCRIPTION
I found this function is unused anywhere:
```sh
[/tmp/duckdb-httpfs] (main) 
vscode@eebee01fa8d2$ git grep "SetHttpfsClientImplementation"
src/httpfs_extension.cpp:static void SetHttpfsClientImplementation(DBConfig &config, const string &value) {
```