### PR TITLE
Fix CMake link order for static OpenSSL and Curl dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,14 +32,13 @@ build_loadable_extension(httpfs ${PARAMETERS} ${EXTENSION_SOURCES})
 if(EMSCRIPTEN)
   target_link_libraries(httpfs_loadable_extension duckdb_mbedtls)
 else()
-  target_link_libraries(httpfs_loadable_extension duckdb_mbedtls
-                        ${OPENSSL_LIBRARIES})
-  target_link_libraries(httpfs_extension duckdb_mbedtls ${OPENSSL_LIBRARIES})
-
   # Link dependencies into extension
   target_link_libraries(httpfs_loadable_extension ${CURL_LIBRARIES})
   target_link_libraries(httpfs_extension ${CURL_LIBRARIES})
 
+  target_link_libraries(httpfs_loadable_extension duckdb_mbedtls
+                        ${OPENSSL_LIBRARIES})
+  target_link_libraries(httpfs_extension duckdb_mbedtls ${OPENSSL_LIBRARIES})
 
   if(MINGW)
     find_package(ZLIB)


### PR DESCRIPTION
Fixes issue #151 