### PR TITLE
Add JSON profiling support for HTTP stats

### DIFF
--- a/src/include/http_state.hpp
+++ b/src/include/http_state.hpp
@@ -96,6 +96,10 @@ public:
 		Reset();
 	}
 	void WriteProfilingInformation(std::ostream &ss) override;
+	//! Write HTTP profiling information to JSON format
+	//! NOTE: This method is intended to override ClientContextState::WriteProfilingInformationToJSON
+	//! when DuckDB adds it to the base class. Until then, it's implemented without override.
+	void WriteProfilingInformationToJSON(duckdb_yyjson::yyjson_mut_doc *doc, duckdb_yyjson::yyjson_mut_val *obj);
 
 private:
 	//! Mutex to lock when getting the cached file(Parallel Only)


### PR DESCRIPTION
This PR adds structured JSON profiling output for HTTPFS statistics, complementing the existing text-based profiling. 

This is in preparation of another PR on DuckDB itself that will add comprehensive NDJSON logging and profiling support eventually. I will link the DuckDB PR once it's ready @carlopi. Thanks!

### Changes
- Added `WriteProfilingInformationToJSON()` method to `HTTPState` class
- Exports HTTP metrics as structured JSON: `total_bytes_received`, `total_bytes_sent`, `head_count`, `get_count`, `put_count`, `post_count`, `delete_count`
- Uses DuckDB's yyjson library for JSON construction

### Forward Compatibility
The method is implemented without `override` for forward compatibility. When DuckDB adds `WriteProfilingInformationToJSON()` to `ClientContextState`, this implementation will automatically override it. Adding `override` at that time is recommended for compile-time safety.
