### PR TITLE
Fixup order of operations, first send THEN set body

### DIFF
--- a/src/httpfs_httplib_client.cpp
+++ b/src/httpfs_httplib_client.cpp
@@ -102,8 +102,12 @@ public:
 			info.buffer_out += string(data, data_length);
 			return true;
 		};
+		// First assign body, this is the body that will be uploaded
 		req.body.assign(const_char_ptr_cast(info.buffer_in), info.buffer_in_len);
-		return TransformResult(client->send(req));
+		auto transformed_req = TransformResult(client->send(req));
+		// Then, after actual re-quest, re-assign body to the response value of the POST request
+		transformed_req->body.assign(const_char_ptr_cast(info.buffer_in), info.buffer_in_len);
+		return std::move(transformed_req);
 	}
 
 private:


### PR DESCRIPTION
This would allow to eventually clean up https://github.com/duckdb/duckdb-iceberg/blob/v1.4-andium/src/aws.cpp#L325 and https://github.com/duckdb/duckdb-iceberg/blob/v1.4-andium/src/common/api_utils.cpp#L63 in Iceberg, and potentially solve other problems.

Note that reverting those in Iceberg needs some care, to avoid mix and match between incompatible extensions. I'd say we get this fix in httpfs in the v1.4.2-v1.4.3 cycle, and fix iceberg in the v1.4.3-v1.4.4 cycle.

Issue at its core is that POST have an outgoing body AND an incoming body.