### PR TITLE
Check reads from cached buffers using the known length

### DIFF
--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -438,6 +438,9 @@ bool HTTPFileSystem::ReadInternal(FileHandle &handle, void *buffer, int64_t nr_b
 		if (!hfh.cached_file_handle->Initialized()) {
 			throw InternalException("Cached file not initialized properly");
 		}
+		if (hfh.cached_file_handle->GetSize() < location + nr_bytes) {
+			throw InternalException("Cached file length can't satisfy the requested Read");
+		}
 		memcpy(buffer, hfh.cached_file_handle->GetData() + location, nr_bytes);
 		DUCKDB_LOG_FILE_SYSTEM_READ(handle, nr_bytes, location);
 		hfh.file_offset = location + nr_bytes;


### PR DESCRIPTION
I'd say this can be treated as InternalError, given it signal some internal inconsistency, or at least that's my working assumption, open for discussion.

Fixes segfault reported in https://github.com/duckdb/duckdb-spatial/issues/712, turning into internal exception.