### PR TITLE
Expose `create_s3_header` and add new API for `S3AuthParams::ReadFrom`

### DIFF
--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -34,6 +34,7 @@ struct S3AuthParams {
 	string oauth2_bearer_token; // OAuth2 bearer token for GCS
 
 	static S3AuthParams ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info);
+	static S3AuthParams ReadFrom(KeyValueSecretReader& secret_reader, const std::string& file_path);
 };
 
 struct AWSEnvironmentCredentialsProvider {
@@ -258,4 +259,8 @@ struct AWSListObjectV2 {
 	static vector<string> ParseCommonPrefix(string &aws_response);
 	static string ParseContinuationToken(string &aws_response);
 };
+
+HTTPHeaders create_s3_header(string url, string query, string host, string service, string method,
+									const S3AuthParams &auth_params, string date_now = "", string datetime_now = "",
+									string payload_hash = "", string content_type = "");
 } // namespace duckdb

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -260,7 +260,7 @@ struct AWSListObjectV2 {
 	static string ParseContinuationToken(string &aws_response);
 };
 
-HTTPHeaders create_s3_header(string url, string query, string host, string service, string method,
+HTTPHeaders CreateS3Header(string url, string query, string host, string service, string method,
 									const S3AuthParams &auth_params, string date_now = "", string datetime_now = "",
 									string payload_hash = "", string content_type = "");
 } // namespace duckdb

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -28,7 +28,7 @@
 
 namespace duckdb {
 
-HTTPHeaders create_s3_header(string url, string query, string host, string service, string method,
+HTTPHeaders CreateS3Header(string url, string query, string host, string service, string method,
                              const S3AuthParams &auth_params, string date_now, string datetime_now, string payload_hash,
                              string content_type) {
 
@@ -754,7 +754,7 @@ unique_ptr<HTTPResponse> S3FileSystem::PostRequest(FileHandle &handle, string ur
 	} else {
 		// Use existing S3 authentication
 		auto payload_hash = GetPayloadHash(buffer_in, buffer_in_len);
-		headers = create_s3_header(parsed_s3_url.path, http_params, parsed_s3_url.host, "s3", "POST", auth_params, "",
+		headers = CreateS3Header(parsed_s3_url.path, http_params, parsed_s3_url.host, "s3", "POST", auth_params, "",
 		                           "", payload_hash, "application/octet-stream");
 	}
 
@@ -777,7 +777,7 @@ unique_ptr<HTTPResponse> S3FileSystem::PutRequest(FileHandle &handle, string url
 	} else {
 		// Use existing S3 authentication
 		auto payload_hash = GetPayloadHash(buffer_in, buffer_in_len);
-		headers = create_s3_header(parsed_s3_url.path, http_params, parsed_s3_url.host, "s3", "PUT", auth_params, "",
+		headers = CreateS3Header(parsed_s3_url.path, http_params, parsed_s3_url.host, "s3", "PUT", auth_params, "",
 		                           "", payload_hash, content_type);
 	}
 
@@ -797,7 +797,7 @@ unique_ptr<HTTPResponse> S3FileSystem::HeadRequest(FileHandle &handle, string s3
 	} else {
 		// Use existing S3 authentication
 		headers =
-		    create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "HEAD", auth_params, "", "", "", "");
+		    CreateS3Header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "HEAD", auth_params, "", "", "", "");
 	}
 
 	return HTTPFileSystem::HeadRequest(handle, http_url, headers);
@@ -816,7 +816,7 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_
 	} else {
 		// Use existing S3 authentication
 		headers =
-		    create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "GET", auth_params, "", "", "", "");
+		    CreateS3Header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "GET", auth_params, "", "", "", "");
 	}
 
 	return HTTPFileSystem::GetRequest(handle, http_url, headers);
@@ -836,7 +836,7 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, strin
 	} else {
 		// Use existing S3 authentication
 		headers =
-		    create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "GET", auth_params, "", "", "", "");
+		    CreateS3Header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "GET", auth_params, "", "", "", "");
 	}
 
 	return HTTPFileSystem::GetRangeRequest(handle, http_url, headers, file_offset, buffer_out, buffer_out_len);
@@ -855,7 +855,7 @@ unique_ptr<HTTPResponse> S3FileSystem::DeleteRequest(FileHandle &handle, string 
 	} else {
 		// Use existing S3 authentication
 		headers =
-		    create_s3_header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "DELETE", auth_params, "", "", "", "");
+		    CreateS3Header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "DELETE", auth_params, "", "", "", "");
 	}
 
 	return HTTPFileSystem::DeleteRequest(handle, http_url, headers);
@@ -1243,7 +1243,7 @@ string AWSListObjectV2::Request(string &path, HTTPParams &http_params, S3AuthPar
 	string listobjectv2_url = req_path + "?" + req_params;
 
 	auto header_map =
-	    create_s3_header(req_path, req_params, parsed_url.host, "s3", "GET", s3_auth_params, "", "", "", "");
+	    CreateS3Header(req_path, req_params, parsed_url.host, "s3", "GET", s3_auth_params, "", "", "", "");
 
 	// Get requests use fresh connection
 	string full_host = parsed_url.http_proto + parsed_url.host;


### PR DESCRIPTION
This exposes a previously internal function (`create_s3_header`) and splits up `S3AuthParams::ReadFrom` to allow creating `S3AuthParams` from a `KeyValueSecretReader`