### PR TITLE
Logarithmically grow read buffer for sequential reads

### DIFF
--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -468,7 +468,7 @@ bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders
 		if (res->Success() || res->status == HTTPStatusCode::PartialContent_206 ||
 		    res->status == HTTPStatusCode::Accepted_202) {
 
-			if (hfh.flags.RequireParallelAccess()) {
+			if (!hfh.flags.RequireParallelAccess()) {
 				// Update range request statistics
 				const auto duration = NumericCast<idx_t>(Timestamp::GetCurrentTimestamp().value - timestamp_before.value);
 				hfh.AddStatistics(file_offset, buffer_out_len, duration);

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -100,7 +100,14 @@ public:
 	// Return the client for re-use
 	void StoreClient(unique_ptr<HTTPClient> client);
 
+	// Whether to bypass the read buffer
+	bool SkipBuffer() const {
+		return flags.DirectIO() || flags.RequireParallelAccess();
+	}
+
 private:
+	void AllocateReadBuffer(optional_ptr<FileOpener> opener);
+
 	// Statistics that are used to adaptively grow the read_buffer
 	struct RangeRequestStatistics {
 		idx_t offset;

--- a/test/sql/json/table/internal_issue_6807.test_slow
+++ b/test/sql/json/table/internal_issue_6807.test_slow
@@ -1,0 +1,18 @@
+# name: test/sql/json/table/internal_issue_6807.test
+# description: Test logarithmic growth of read buffer for sequential reads
+# group: [table]
+
+require json
+
+require httpfs
+
+statement ok
+CALL enable_logging('HTTP');
+
+statement ok
+CREATE TABLE T AS FROM 'https://data.gharchive.org/2023-02-08-0.json.gz';
+
+query I
+SELECT count(*) FROM duckdb_logs_parsed('HTTP') WHERE request.type = 'GET' GROUP BY request.type;
+----
+9


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/6807#issuecomment-3631452424

Just some basic functionality, but it could be improved using stats in the future.