### PR TITLE
Option to disable getting secrets from env vars/global scope

### DIFF
--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -128,6 +128,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 	};
 	config.AddExtensionOption("httpfs_client_implementation", "Select which is the HTTPUtil implementation to be used",
 	                          LogicalType::VARCHAR, "default", callback_httpfs_client_implementation);
+	config.AddExtensionOption("auto_fetch_secret_info_from_env",
+	                          "Automatically fetch AWS credentials from environment variables.", LogicalType::BOOLEAN,
+	                          Value::BOOLEAN(true));
 
 	if (config.http_util && config.http_util->GetName() == "WasmHTTPUtils") {
 		// Already handled, do not override

--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -128,7 +128,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	};
 	config.AddExtensionOption("httpfs_client_implementation", "Select which is the HTTPUtil implementation to be used",
 	                          LogicalType::VARCHAR, "default", callback_httpfs_client_implementation);
-	config.AddExtensionOption("auto_fetch_secret_info_from_env",
+	config.AddExtensionOption("disable_global_s3_configuration",
 	                          "Automatically fetch AWS credentials from environment variables.", LogicalType::BOOLEAN,
 	                          Value::BOOLEAN(true));
 

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -20,6 +20,33 @@
 
 namespace duckdb {
 
+class S3KeyValueReader {
+public:
+	S3KeyValueReader(FileOpener &opener_p, optional_ptr<FileOpenerInfo> info, const char **secret_types,
+	                 idx_t secret_types_len);
+
+	template <class TYPE>
+	SettingLookupResult TryGetSecretKeyOrSetting(const string &secret_key, const string &setting_name, TYPE &result) {
+		Value temp_result;
+		auto setting_scope = reader.TryGetSecretKeyOrSetting(secret_key, setting_name, temp_result);
+		if (!temp_result.IsNull() &&
+		    !(setting_scope.GetScope() == SettingScope::GLOBAL && !use_env_variables_for_secret_settings)) {
+			result = temp_result.GetValue<TYPE>();
+		}
+		return setting_scope;
+	}
+
+	template <class TYPE>
+	SettingLookupResult TryGetSecretKey(const string &secret_key, TYPE &value_out) {
+		// TryGetSecretKey never returns anything from global scope, so we don't need to check
+		return reader.TryGetSecretKey(secret_key, value_out);
+	}
+
+private:
+	bool use_env_variables_for_secret_settings;
+	KeyValueSecretReader reader;
+};
+
 struct S3AuthParams {
 	string region;
 	string access_key_id;
@@ -34,7 +61,7 @@ struct S3AuthParams {
 	string oauth2_bearer_token; // OAuth2 bearer token for GCS
 
 	static S3AuthParams ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info);
-	static S3AuthParams ReadFrom(KeyValueSecretReader& secret_reader, const std::string& file_path);
+	static S3AuthParams ReadFrom(S3KeyValueReader &secret_reader, const std::string &file_path);
 };
 
 struct AWSEnvironmentCredentialsProvider {
@@ -261,34 +288,7 @@ struct AWSListObjectV2 {
 };
 
 HTTPHeaders CreateS3Header(string url, string query, string host, string service, string method,
-									const S3AuthParams &auth_params, string date_now = "", string datetime_now = "",
-									string payload_hash = "", string content_type = "");
-
-class S3KeyValueReader {
-public:
-	S3KeyValueReader(FileOpener &opener_p, optional_ptr<FileOpenerInfo> info, const char **secret_types,
-	                 idx_t secret_types_len);
-
-	template <class TYPE>
-	SettingLookupResult TryGetSecretKeyOrSetting(const string &secret_key, const string &setting_name, TYPE &result) {
-		Value temp_result;
-		auto setting_scope = reader.TryGetSecretKeyOrSetting(secret_key, setting_name, temp_result);
-		if (!temp_result.IsNull() &&
-		    !(setting_scope.GetScope() == SettingScope::GLOBAL && !use_env_variables_for_secret_settings)) {
-			result = temp_result.GetValue<TYPE>();
-		}
-		return setting_scope;
-	}
-
-	template <class TYPE>
-	SettingLookupResult TryGetSecretKey(const string &secret_key, TYPE &value_out) {
-		// TryGetSecretKey never returns anything from global scope, so we don't need to check
-		return reader.TryGetSecretKey(secret_key, value_out);
-	}
-
-private:
-	bool use_env_variables_for_secret_settings;
-	KeyValueSecretReader reader;
-};
+                           const S3AuthParams &auth_params, string date_now = "", string datetime_now = "",
+                           string payload_hash = "", string content_type = "");
 
 } // namespace duckdb

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -35,10 +35,10 @@ struct S3AuthParams {
 
 	static S3AuthParams ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info);
 	//! Helper for creating secrets that should/should not inherit environment variable settings
-	static SettingLookupResult SetSecretOption(KeyValueSecretReader &secret_reader, string secret_option,
-	                                           string setting_name, string &result);
-	static SettingLookupResult SetSecretOption(KeyValueSecretReader &secret_reader, string secret_option,
-	                                           string setting_name, bool &result);
+	// static SettingLookupResult SetSecretOption(KeyValueSecretReader &secret_reader, string secret_option,
+	//                                            string setting_name, string &result);
+	// static SettingLookupResult SetSecretOption(KeyValueSecretReader &secret_reader, string secret_option,
+	//                                            string setting_name, bool &result);
 };
 
 struct AWSEnvironmentCredentialsProvider {

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -34,11 +34,6 @@ struct S3AuthParams {
 	string oauth2_bearer_token; // OAuth2 bearer token for GCS
 
 	static S3AuthParams ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info);
-	//! Helper for creating secrets that should/should not inherit environment variable settings
-	// static SettingLookupResult SetSecretOption(KeyValueSecretReader &secret_reader, string secret_option,
-	//                                            string setting_name, string &result);
-	// static SettingLookupResult SetSecretOption(KeyValueSecretReader &secret_reader, string secret_option,
-	//                                            string setting_name, bool &result);
 };
 
 struct AWSEnvironmentCredentialsProvider {

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -34,6 +34,11 @@ struct S3AuthParams {
 	string oauth2_bearer_token; // OAuth2 bearer token for GCS
 
 	static S3AuthParams ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info);
+	//! Helper for creating secrets that should/should not inherit environment variable settings
+	static SettingLookupResult SetSecretOption(KeyValueSecretReader &secret_reader, string secret_option,
+	                                           string setting_name, string &result);
+	static SettingLookupResult SetSecretOption(KeyValueSecretReader &secret_reader, string secret_option,
+	                                           string setting_name, bool &result);
 };
 
 struct AWSEnvironmentCredentialsProvider {

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -192,7 +192,7 @@ S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerI
 	}
 
 	const char *secret_types[] = {"s3", "r2", "gcs", "aws"};
-	HttpfsKeyValueReader secret_reader(*opener, info, secret_types, 3);
+	S3KeyValueReader secret_reader(*opener, info, secret_types, 3);
 
 	// These settings we just set or leave to their S3AuthParams default value
 	secret_reader.TryGetSecretKeyOrSetting("key_id", "s3_access_key_id", result.access_key_id);
@@ -1373,6 +1373,15 @@ vector<string> AWSListObjectV2::ParseCommonPrefix(string &aws_response) {
 		}
 	}
 	return s3_prefixes;
+}
+
+S3KeyValueReader::S3KeyValueReader(FileOpener &opener_p, optional_ptr<FileOpenerInfo> info, const char **secret_types,
+                                   idx_t secret_types_len)
+    : reader(opener_p, info, secret_types, secret_types_len) {
+	Value use_env_vars_for_secret_info_setting;
+	reader.TryGetSecretKeyOrSetting("auto_fetch_secret_info_from_env", "auto_fetch_secret_info_from_env",
+	                                use_env_vars_for_secret_info_setting);
+	use_env_variables_for_secret_settings = use_env_vars_for_secret_info_setting.GetValue<bool>();
 }
 
 } // namespace duckdb

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1382,7 +1382,7 @@ S3KeyValueReader::S3KeyValueReader(FileOpener &opener_p, optional_ptr<FileOpener
                                    idx_t secret_types_len)
     : reader(opener_p, info, secret_types, secret_types_len) {
 	Value use_env_vars_for_secret_info_setting;
-	reader.TryGetSecretKeyOrSetting("auto_fetch_secret_info_from_env", "auto_fetch_secret_info_from_env",
+	reader.TryGetSecretKeyOrSetting("disable_global_s3_configuration", "disable_global_s3_configuration",
 	                                use_env_vars_for_secret_info_setting);
 	use_env_variables_for_secret_settings = use_env_vars_for_secret_info_setting.GetValue<bool>();
 }

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -183,31 +183,31 @@ S3AuthParams AWSEnvironmentCredentialsProvider::CreateParams() {
 	return params;
 }
 
-SettingLookupResult S3AuthParams::SetSecretOption(KeyValueSecretReader &secret_reader, string secret_option,
-                                                  string setting_name, string &result) {
-	Value use_env_vars_for_secret_info_setting;
-	secret_reader.TryGetSecretKeyOrSetting("auto_fetch_secret_info_from_env", "auto_fetch_secret_info_from_env",
-	                                       use_env_vars_for_secret_info_setting);
-	auto use_env_vars_for_secrets = use_env_vars_for_secret_info_setting.GetValue<bool>();
-
-	auto option_scope = secret_reader.TryGetSecretKeyOrSetting(secret_option, setting_name, result);
-	// if option scope is global, that means it was set in the environment
-	if (!result.empty() && option_scope.GetScope() == SettingScope::GLOBAL && !use_env_vars_for_secrets) {
-		result = "";
-	}
-	return option_scope;
-}
-
-SettingLookupResult S3AuthParams::SetSecretOption(KeyValueSecretReader &secret_reader, string secret_option,
-                                                  string setting_name, bool &result) {
-	Value use_env_vars_for_secret_info_setting;
-	secret_reader.TryGetSecretKeyOrSetting("auto_fetch_secret_info_from_env", "auto_fetch_secret_info_from_env",
-	                                       use_env_vars_for_secret_info_setting);
-	auto use_env_vars_for_secrets = use_env_vars_for_secret_info_setting.GetValue<bool>();
-
-	auto option_scope = secret_reader.TryGetSecretKeyOrSetting(secret_option, setting_name, result);
-	return option_scope;
-}
+// SettingLookupResult S3AuthParams::SetSecretOption(KeyValueSecretReader &secret_reader, string secret_option,
+//                                                   string setting_name, string &result) {
+// 	Value use_env_vars_for_secret_info_setting;
+// 	secret_reader.TryGetSecretKeyOrSetting("auto_fetch_secret_info_from_env", "auto_fetch_secret_info_from_env",
+// 	                                       use_env_vars_for_secret_info_setting);
+// 	auto use_env_vars_for_secrets = use_env_vars_for_secret_info_setting.GetValue<bool>();
+//
+// 	auto option_scope = secret_reader.TryGetSecretKeyOrSetting(secret_option, setting_name, result);
+// 	// if option scope is global, that means it was set in the environment
+// 	if (!result.empty() && option_scope.GetScope() == SettingScope::GLOBAL && !use_env_vars_for_secrets) {
+// 		result = "";
+// 	}
+// 	return option_scope;
+// }
+//
+// SettingLookupResult S3AuthParams::SetSecretOption(KeyValueSecretReader &secret_reader, string secret_option,
+//                                                   string setting_name, bool &result) {
+// 	Value use_env_vars_for_secret_info_setting;
+// 	secret_reader.TryGetSecretKeyOrSetting("auto_fetch_secret_info_from_env", "auto_fetch_secret_info_from_env",
+// 	                                       use_env_vars_for_secret_info_setting);
+// 	auto use_env_vars_for_secrets = use_env_vars_for_secret_info_setting.GetValue<bool>();
+//
+// 	auto option_scope = secret_reader.TryGetSecretKeyOrSetting(secret_option, setting_name, result);
+// 	return option_scope;
+// }
 
 S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info) {
 	auto result = S3AuthParams();
@@ -218,21 +218,21 @@ S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerI
 	}
 
 	const char *secret_types[] = {"s3", "r2", "gcs", "aws"};
-	KeyValueSecretReader secret_reader(*opener, info, secret_types, 3);
+	HttpfsKeyValueReader secret_reader(*opener, info, secret_types, 3);
 
 	// These settings we just set or leave to their S3AuthParams default value
-	S3AuthParams::SetSecretOption(secret_reader, "key_id", "s3_access_key_id", result.access_key_id);
-	S3AuthParams::SetSecretOption(secret_reader, "secret", "s3_secret_access_key", result.secret_access_key);
-	S3AuthParams::SetSecretOption(secret_reader, "session_token", "s3_session_token", result.session_token);
-	S3AuthParams::SetSecretOption(secret_reader, "region", "s3_region", result.region);
-	S3AuthParams::SetSecretOption(secret_reader, "use_ssl", "s3_use_ssl", result.use_ssl);
-	S3AuthParams::SetSecretOption(secret_reader, "kms_key_id", "s3_kms_key_id", result.kms_key_id);
-	S3AuthParams::SetSecretOption(secret_reader, "s3_url_compatibility_mode", "s3_url_compatibility_mode",
-	                              result.s3_url_compatibility_mode);
-	S3AuthParams::SetSecretOption(secret_reader, "requester_pays", "s3_requester_pays", result.requester_pays);
+	secret_reader.TryGetSecretKeyOrSetting("key_id", "s3_access_key_id", result.access_key_id);
+	secret_reader.TryGetSecretKeyOrSetting("secret", "s3_secret_access_key", result.secret_access_key);
+	secret_reader.TryGetSecretKeyOrSetting("session_token", "s3_session_token", result.session_token);
+	secret_reader.TryGetSecretKeyOrSetting("region", "s3_region", result.region);
+	secret_reader.TryGetSecretKeyOrSetting("use_ssl", "s3_use_ssl", result.use_ssl);
+	secret_reader.TryGetSecretKeyOrSetting("kms_key_id", "s3_kms_key_id", result.kms_key_id);
+	secret_reader.TryGetSecretKeyOrSetting("s3_url_compatibility_mode", "s3_url_compatibility_mode",
+	                                       result.s3_url_compatibility_mode);
+	secret_reader.TryGetSecretKeyOrSetting("requester_pays", "s3_requester_pays", result.requester_pays);
 	// Endpoint and url style are slightly more complex and require special handling for gcs and r2
-	auto endpoint_result = SetSecretOption(secret_reader, "endpoint", "s3_endpoint", result.endpoint);
-	auto url_style_result = SetSecretOption(secret_reader, "url_style", "s3_url_style", result.url_style);
+	auto endpoint_result = secret_reader.TryGetSecretKeyOrSetting("endpoint", "s3_endpoint", result.endpoint);
+	auto url_style_result = secret_reader.TryGetSecretKeyOrSetting("url_sxstyle", "s3_url_style", result.url_style);
 
 	if (StringUtil::StartsWith(info.file_path, "gcs://") || StringUtil::StartsWith(info.file_path, "gs://")) {
 		// For GCS urls we force the endpoint and vhost path style, allowing only to be overridden by secrets

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -183,6 +183,32 @@ S3AuthParams AWSEnvironmentCredentialsProvider::CreateParams() {
 	return params;
 }
 
+SettingLookupResult S3AuthParams::SetSecretOption(KeyValueSecretReader &secret_reader, string secret_option,
+                                                  string setting_name, string &result) {
+	Value use_env_vars_for_secret_info_setting;
+	secret_reader.TryGetSecretKeyOrSetting("auto_fetch_secret_info_from_env", "auto_fetch_secret_info_from_env",
+	                                       use_env_vars_for_secret_info_setting);
+	auto use_env_vars_for_secrets = use_env_vars_for_secret_info_setting.GetValue<bool>();
+
+	auto option_scope = secret_reader.TryGetSecretKeyOrSetting(secret_option, setting_name, result);
+	// if option scope is global, that means it was set in the environment
+	if (!result.empty() && option_scope.GetScope() == SettingScope::GLOBAL && !use_env_vars_for_secrets) {
+		result = "";
+	}
+	return option_scope;
+}
+
+SettingLookupResult S3AuthParams::SetSecretOption(KeyValueSecretReader &secret_reader, string secret_option,
+                                                  string setting_name, bool &result) {
+	Value use_env_vars_for_secret_info_setting;
+	secret_reader.TryGetSecretKeyOrSetting("auto_fetch_secret_info_from_env", "auto_fetch_secret_info_from_env",
+	                                       use_env_vars_for_secret_info_setting);
+	auto use_env_vars_for_secrets = use_env_vars_for_secret_info_setting.GetValue<bool>();
+
+	auto option_scope = secret_reader.TryGetSecretKeyOrSetting(secret_option, setting_name, result);
+	return option_scope;
+}
+
 S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info) {
 	auto result = S3AuthParams();
 
@@ -195,20 +221,18 @@ S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerI
 	KeyValueSecretReader secret_reader(*opener, info, secret_types, 3);
 
 	// These settings we just set or leave to their S3AuthParams default value
-	secret_reader.TryGetSecretKeyOrSetting("region", "s3_region", result.region);
-	secret_reader.TryGetSecretKeyOrSetting("key_id", "s3_access_key_id", result.access_key_id);
-	secret_reader.TryGetSecretKeyOrSetting("secret", "s3_secret_access_key", result.secret_access_key);
-	secret_reader.TryGetSecretKeyOrSetting("session_token", "s3_session_token", result.session_token);
-	secret_reader.TryGetSecretKeyOrSetting("region", "s3_region", result.region);
-	secret_reader.TryGetSecretKeyOrSetting("use_ssl", "s3_use_ssl", result.use_ssl);
-	secret_reader.TryGetSecretKeyOrSetting("kms_key_id", "s3_kms_key_id", result.kms_key_id);
-	secret_reader.TryGetSecretKeyOrSetting("s3_url_compatibility_mode", "s3_url_compatibility_mode",
-	                                       result.s3_url_compatibility_mode);
-	secret_reader.TryGetSecretKeyOrSetting("requester_pays", "s3_requester_pays", result.requester_pays);
-
+	S3AuthParams::SetSecretOption(secret_reader, "key_id", "s3_access_key_id", result.access_key_id);
+	S3AuthParams::SetSecretOption(secret_reader, "secret", "s3_secret_access_key", result.secret_access_key);
+	S3AuthParams::SetSecretOption(secret_reader, "session_token", "s3_session_token", result.session_token);
+	S3AuthParams::SetSecretOption(secret_reader, "region", "s3_region", result.region);
+	S3AuthParams::SetSecretOption(secret_reader, "use_ssl", "s3_use_ssl", result.use_ssl);
+	S3AuthParams::SetSecretOption(secret_reader, "kms_key_id", "s3_kms_key_id", result.kms_key_id);
+	S3AuthParams::SetSecretOption(secret_reader, "s3_url_compatibility_mode", "s3_url_compatibility_mode",
+	                              result.s3_url_compatibility_mode);
+	S3AuthParams::SetSecretOption(secret_reader, "requester_pays", "s3_requester_pays", result.requester_pays);
 	// Endpoint and url style are slightly more complex and require special handling for gcs and r2
-	auto endpoint_result = secret_reader.TryGetSecretKeyOrSetting("endpoint", "s3_endpoint", result.endpoint);
-	auto url_style_result = secret_reader.TryGetSecretKeyOrSetting("url_style", "s3_url_style", result.url_style);
+	auto endpoint_result = SetSecretOption(secret_reader, "endpoint", "s3_endpoint", result.endpoint);
+	auto url_style_result = SetSecretOption(secret_reader, "url_style", "s3_url_style", result.url_style);
 
 	if (StringUtil::StartsWith(info.file_path, "gcs://") || StringUtil::StartsWith(info.file_path, "gs://")) {
 		// For GCS urls we force the endpoint and vhost path style, allowing only to be overridden by secrets

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -183,32 +183,6 @@ S3AuthParams AWSEnvironmentCredentialsProvider::CreateParams() {
 	return params;
 }
 
-// SettingLookupResult S3AuthParams::SetSecretOption(KeyValueSecretReader &secret_reader, string secret_option,
-//                                                   string setting_name, string &result) {
-// 	Value use_env_vars_for_secret_info_setting;
-// 	secret_reader.TryGetSecretKeyOrSetting("auto_fetch_secret_info_from_env", "auto_fetch_secret_info_from_env",
-// 	                                       use_env_vars_for_secret_info_setting);
-// 	auto use_env_vars_for_secrets = use_env_vars_for_secret_info_setting.GetValue<bool>();
-//
-// 	auto option_scope = secret_reader.TryGetSecretKeyOrSetting(secret_option, setting_name, result);
-// 	// if option scope is global, that means it was set in the environment
-// 	if (!result.empty() && option_scope.GetScope() == SettingScope::GLOBAL && !use_env_vars_for_secrets) {
-// 		result = "";
-// 	}
-// 	return option_scope;
-// }
-//
-// SettingLookupResult S3AuthParams::SetSecretOption(KeyValueSecretReader &secret_reader, string secret_option,
-//                                                   string setting_name, bool &result) {
-// 	Value use_env_vars_for_secret_info_setting;
-// 	secret_reader.TryGetSecretKeyOrSetting("auto_fetch_secret_info_from_env", "auto_fetch_secret_info_from_env",
-// 	                                       use_env_vars_for_secret_info_setting);
-// 	auto use_env_vars_for_secrets = use_env_vars_for_secret_info_setting.GetValue<bool>();
-//
-// 	auto option_scope = secret_reader.TryGetSecretKeyOrSetting(secret_option, setting_name, result);
-// 	return option_scope;
-// }
-
 S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info) {
 	auto result = S3AuthParams();
 
@@ -232,7 +206,7 @@ S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerI
 	secret_reader.TryGetSecretKeyOrSetting("requester_pays", "s3_requester_pays", result.requester_pays);
 	// Endpoint and url style are slightly more complex and require special handling for gcs and r2
 	auto endpoint_result = secret_reader.TryGetSecretKeyOrSetting("endpoint", "s3_endpoint", result.endpoint);
-	auto url_style_result = secret_reader.TryGetSecretKeyOrSetting("url_sxstyle", "s3_url_style", result.url_style);
+	auto url_style_result = secret_reader.TryGetSecretKeyOrSetting("url_style", "s3_url_style", result.url_style);
 
 	if (StringUtil::StartsWith(info.file_path, "gcs://") || StringUtil::StartsWith(info.file_path, "gs://")) {
 		// For GCS urls we force the endpoint and vhost path style, allowing only to be overridden by secrets

--- a/test/sql/test_read_public_bucket.test
+++ b/test/sql/test_read_public_bucket.test
@@ -1,0 +1,36 @@
+# name: test/sql/test_read_public_bucket.test
+# description: test aws extension with different chain configs
+# group: [sql]
+
+require parquet
+
+require httpfs
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+# override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
+set ignore_error_messages
+
+statement ok
+set s3_region='us-east-2';
+
+# set endpoint to the correct default, otherwise it will pick up the env variable
+statement ok
+set s3_endpoint='s3.amazonaws.com';
+
+# see duckdb-internal/issues/6620
+# env vars for access_key_id and secret_key_id are used
+# which results in 403
+statement error
+SELECT * FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet') LIMIT 5;
+----
+<REGEX>:.*HTTP Error:.*403.*Authentication Failure.*
+
+# default to not using globally scoped settings for secrets
+statement ok
+set auto_fetch_secret_info_from_env=false;
+
+statement ok
+SELECT * FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet') LIMIT 5;

--- a/test/sql/test_read_public_bucket.test
+++ b/test/sql/test_read_public_bucket.test
@@ -6,6 +6,10 @@ require parquet
 
 require httpfs
 
+# should only run in CI when the test server is available.
+# then we have access to invalid AWS ACCESS KEYS and SECRET KEYS
+require-env S3_TEST_SERVER_AVAILABLE 1
+
 require-env AWS_ACCESS_KEY_ID
 
 require-env AWS_SECRET_ACCESS_KEY

--- a/test/sql/test_read_public_bucket.test
+++ b/test/sql/test_read_public_bucket.test
@@ -34,7 +34,7 @@ SELECT * FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/par
 
 # default to not using globally scoped settings for secrets
 statement ok
-set auto_fetch_secret_info_from_env=false;
+set disable_global_s3_configuration=false;
 
 statement ok
 SELECT * FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet') LIMIT 5;


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/6620

### Problem solved
DuckDB silently uses env variables for secrets. This can be undesireable for the following reasons
- workflows/scripts using env based secrets are moved to other machines that do not have these environment variables. 
- You are accessing public s3 data that does not require a secret, and for some reason the env secrets are no longer valid, resulting in a 403 for public data

For v1.4.4, we are adding the ability to turn off the silent use of env variables for secret generation with the `auto_fetch_secret_info_from_env` setting. By default it will stay on in v1.4.X releases, but in v1.5.0 we will turn it off. 

This setting should not affect secrets created in the aws extension using the `env` credential chain, as those secrets will be generated with the aws sdk in the aws extension, which will not look at this setting. 