### PR TITLE
Apply patches from duckdb/duckdb

### DIFF
--- a/test/sql/test_headers_parsed.test
+++ b/test/sql/test_headers_parsed.test
@@ -6,6 +6,9 @@ require httpfs
 
 require parquet
 
+# FIXME: this tests fails in CI settings, to be investigated
+mode skip
+
 statement ok
 SET httpfs_client_implementation='curl';
 


### PR DESCRIPTION
This PR applies patches from duckdb/duckdb:
- `skip_test.patch`
