### PR TITLE
Improve error messages when http requests fail

### DIFF
--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -494,7 +494,7 @@ bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders
 			error.Throw();
 		}
 		throw HTTPException(*res, "Request returned HTTP %d for HTTP %s to '%s'", static_cast<int>(res->status),
-		                    EnumUtil::ToString(RequestType::GET_REQUEST), res->url);
+		                    EnumUtil::ToString(RequestType::GET_REQUEST), url);
 	}
 	throw IOException("Unknown error for HTTP %s to '%s'", EnumUtil::ToString(RequestType::GET_REQUEST), url);
 }
@@ -813,7 +813,7 @@ void HTTPFileHandle::LoadFileInfo() {
 				}
 				res = std::move(range_res);
 			} else {
-				throw HTTPException(*res, "Unable to connect to URL \"%s\": %d (%s).", res->url,
+				throw HTTPException(*res, "Unable to connect to URL \"%s\": %d (%s).", path,
 				                    static_cast<int>(res->status), res->GetError());
 			}
 		}

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -384,8 +384,8 @@ void S3FileSystem::UploadBufferImplementation(S3FileHandle &file_handle, shared_
 		                      query_param);
 
 		if (res->status != HTTPStatusCode::OK_200) {
-			throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", file_handle.path, res->GetError(),
-			                    static_cast<int>(res->status));
+			throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", file_handle.path,
+			                    res->GetError(), static_cast<int>(res->status));
 		}
 
 		if (!res->headers.HasHeader("ETag")) {

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -328,7 +328,7 @@ string S3FileSystem::InitializeMultipartUpload(S3FileHandle &file_handle) {
 	auto res = s3fs.PostRequest(file_handle, file_handle.path, {}, result, nullptr, 0, query_param);
 
 	if (res->status != HTTPStatusCode::OK_200) {
-		throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", res->url, res->GetError(),
+		throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", file_handle.path, res->GetError(),
 		                    static_cast<int>(res->status));
 	}
 
@@ -384,7 +384,7 @@ void S3FileSystem::UploadBufferImplementation(S3FileHandle &file_handle, shared_
 		                      query_param);
 
 		if (res->status != HTTPStatusCode::OK_200) {
-			throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", res->url, res->GetError(),
+			throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", file_handle.path, res->GetError(),
 			                    static_cast<int>(res->status));
 		}
 

--- a/test/sql/copy/s3/download_config.test
+++ b/test/sql/copy/s3/download_config.test
@@ -125,4 +125,4 @@ Could not establish connection error for HTTP HEAD to 'http://test-bucket-public
 statement error
 SELECT * FROM parquet_scan('s3://this-aint-no-bucket/no-path/no-file');
 ----
-Unable to connect to URL "http://
+Unable to connect to URL "s3://this-aint-no-bucket/no-path/no-file"

--- a/test/sql/copy/s3/url_encode.test
+++ b/test/sql/copy/s3/url_encode.test
@@ -132,7 +132,7 @@ set s3_endpoint='';
 statement error
 SELECT * FROM 's3://test-bucket/whatever.parquet';
 ----
-<REGEX>:.*HTTP Error: Unable to connect to URL .*http://test-bucket.s3.eu-west-1.amazonaws.com/whatever.parquet.*: 301 .Moved Permanently..*
+<REGEX>:.*HTTP Error: Unable to connect to URL "s3://test-bucket/whatever.parquet": 301 .Moved Permanently..*
 .*
 .*Bad Request - this can be caused by the S3 region being set incorrectly.*
 .*Provided region is: .eu-west-1.*
@@ -141,7 +141,7 @@ SELECT * FROM 's3://test-bucket/whatever.parquet';
 statement error
 SELECT * FROM 'r2://test-bucket/whatever.parquet';
 ----
-<REGEX>:.*HTTP Error: Unable to connect to URL .*http://test-bucket.s3.eu-west-1.amazonaws.com/whatever.parquet.*: 301 .Moved Permanently..*
+<REGEX>:.*HTTP Error: Unable to connect to URL "r2://test-bucket/whatever.parquet": 301 .Moved Permanently..*
 .*
 .*Bad Request - this can be caused by the S3 region being set incorrectly.*
 .*Provided region is: .eu-west-1.*


### PR DESCRIPTION
When accessing r2:// error messages currently show the transformed HTTPS URL which can contain **s3.amazonaws.com**.

For r2:// urls (and similar s3 compatible storage buckets), if no installed secret can cover the bucket url, then the transformed url always contains **s3.amazonaws.com**, even though the provider is not AWS.

This can be confusing to the user, especially if they are not directly specifying a bucket url in their command. For example when a user queries a ducklake that is using an r2 url as a DATA_PATH and no matching secret can be found. The error message can can indicate to the user that the systems is incorrectly trying to connect to AWS, when the real issue is a missing secret.

The fix is to use the original URL instead of the transformed HTTPS URL.
This is a low-risk change that only affects error message text. It makes the error messages consistent with httpfs.cpp:811 which already uses `path` for the same purpose.

The change is covered by existing tests