### PR TITLE
[DNM] Add `inherit_aws_config_from_environment` function so user can set s3 config values using environment variables

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,8 @@ set(HTTPFS_SOURCES
     crypto.cpp
     hash_functions.cpp
     create_secret_functions.cpp
-    httpfs_extension.cpp)
+    httpfs_extension.cpp
+    httpfs_functions.cpp)
 if(NOT EMSCRIPTEN)
   set(HTTPFS_SOURCES ${HTTPFS_SOURCES} crypto.cpp httpfs_httplib_client.cpp
                      httpfs_curl_client.cpp)

--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -1,11 +1,10 @@
 #include "httpfs_extension.hpp"
-
 #include "httpfs_client.hpp"
+#include "httpfs_functions.hpp"
 #include "create_secret_functions.hpp"
 #include "duckdb.hpp"
 #include "s3fs.hpp"
 #include "hffs.hpp"
-#include "include/httpfs_functions.hpp"
 #ifdef OVERRIDE_ENCRYPTION_UTILS
 #include "crypto.hpp"
 #endif // OVERRIDE_ENCRYPTION_UTILS
@@ -116,9 +115,6 @@ static void LoadInternal(ExtensionLoader &loader) {
 	} else {
 		config.http_util = make_shared_ptr<HTTPFSUtil>();
 	}
-
-	// auto provider = make_uniq<AWSEnvironmentCredentialsProvider>(config);
-	// provider->SetAll();
 
 	CreateS3SecretFunctions::Register(loader);
 	CreateBearerTokenFunctions::Register(loader);

--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -116,6 +116,10 @@ static void LoadInternal(ExtensionLoader &loader) {
 		config.http_util = make_shared_ptr<HTTPFSUtil>();
 	}
 
+	// set config values like s3_endpoint from env vars prefixed with DUCKDB like DUCKDB_S3_ENDPOINT
+	auto provider = make_uniq<AWSEnvironmentCredentialsProvider>(config);
+	provider->SetDuckDBSettings();
+
 	CreateS3SecretFunctions::Register(loader);
 	CreateBearerTokenFunctions::Register(loader);
 

--- a/src/httpfs_functions.cpp
+++ b/src/httpfs_functions.cpp
@@ -1,0 +1,51 @@
+#include "httpfs_functions.hpp"
+#include "s3fs.hpp"
+#include "include/httpfs_functions.hpp"
+
+#include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/function/cast/cast_function_set.hpp"
+#include "duckdb/function/cast/default_casts.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/parser/expression/function_expression.hpp"
+
+class ExtensionLoader;
+
+namespace duckdb {
+
+static unique_ptr<FunctionData> HttpfsInheritS3ConfigFromEnvBind(ClientContext &context, TableFunctionBindInput &input,
+                                                                 vector<LogicalType> &return_types,
+                                                                 vector<string> &names) {
+	names.emplace_back("key");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("value");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+// inherit from config function
+static void HttpfsInheritS3ConfigFromEnv(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
+	auto &config = context.db->config;
+	auto provider = make_uniq<AWSEnvironmentCredentialsProvider>(config);
+	auto set_vals = provider->SetAll();
+	idx_t i = 0;
+	for (auto &name : set_vals) {
+		FlatVector::GetData<string_t>(output.data[0])[i] = name.first;
+		FlatVector::GetData<string_t>(output.data[1])[i] = name.second;
+		++i;
+	}
+	output.SetCardinality(i);
+}
+
+vector<TableFunctionSet> HttpfsFunctions::GetTableFunctions(ExtensionLoader &loader) {
+	vector<TableFunctionSet> functions;
+	TableFunctionSet inherit_aws_config("inherit_aws_config_from_environment");
+	TableFunction table_function({}, HttpfsInheritS3ConfigFromEnv, HttpfsInheritS3ConfigFromEnvBind);
+
+	inherit_aws_config.AddFunction(table_function);
+	functions.emplace_back(inherit_aws_config);
+	return functions;
+}
+
+} // namespace duckdb

--- a/src/httpfs_functions.cpp
+++ b/src/httpfs_functions.cpp
@@ -45,7 +45,8 @@ static void HttpfsInheritS3ConfigFromEnv(ClientContext &context, TableFunctionIn
 	if (global_state.finished) {
 		return;
 	}
-	auto provider = make_uniq<AWSEnvironmentCredentialsProvider>(context);
+	D_ASSERT(context.db);
+	auto provider = make_uniq<AWSEnvironmentCredentialsProvider>(context.db->config);
 	auto set_vals = provider->SetAll();
 	idx_t i = 0;
 	for (auto &name : set_vals) {

--- a/src/include/httpfs_functions.hpp
+++ b/src/include/httpfs_functions.hpp
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// httpfs_functions.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/parser/parsed_data/create_copy_function_info.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+
+namespace duckdb {
+class ExtensionLoader;
+
+class HttpfsFunctions {
+public:
+	static vector<TableFunctionSet> GetTableFunctions(ExtensionLoader &loader);
+};
+} // namespace duckdb

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -79,8 +79,9 @@ struct AWSEnvironmentCredentialsProvider {
 
 	DBConfig &config;
 
-	void SetExtensionOptionValue(string key, const char *env_var);
-	void SetAll();
+	Value SetExtensionOptionValue(string key, const char *env_var);
+	case_insensitive_map_t<string> SetAll();
+	void SetValue(string key, Value &val, case_insensitive_map_t<string> &ret);
 	S3AuthParams CreateParams();
 };
 

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -31,7 +31,7 @@ public:
 		auto setting_scope = reader.TryGetSecretKeyOrSetting(secret_key, setting_name, temp_result);
 		if (temp_result.IsNull() || setting_scope.GetScope() == SettingScope::GLOBAL) {
 			// if setting is global, do not use it for s3 key value reader. User must call
-			// inherit_aws_config_from_environment so global/env vars are used for s3secrets
+			// inherit_aws_config_from_environment to load env vars into extension config.
 			return setting_scope;
 		}
 		result = temp_result.GetValue<TYPE>();

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -85,12 +85,13 @@ struct AWSEnvironmentCredentialsProvider {
 	static constexpr const char *DUCKDB_KMS_KEY_ID_ENV_VAR = "DUCKDB_S3_KMS_KEY_ID";
 	static constexpr const char *DUCKDB_REQUESTER_PAYS_ENV_VAR = "DUCKDB_S3_REQUESTER_PAYS";
 
-	explicit AWSEnvironmentCredentialsProvider(ClientContext &context) : context(context) {};
+	explicit AWSEnvironmentCredentialsProvider(DBConfig &config) : config(config) {};
 
-	ClientContext &context;
+	DBConfig &config;
 
 	void SetExtensionOptionValue(string key, const char *env_var, vector<AWSEnvVarToConfigHelper> &ret);
 	vector<AWSEnvVarToConfigHelper> SetAll();
+	vector<AWSEnvVarToConfigHelper> SetDuckDBSettings();
 	S3AuthParams CreateParams();
 };
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -157,19 +157,27 @@ void AWSEnvironmentCredentialsProvider::SetExtensionOptionValue(string key, cons
 		} else {
 			val = Value(evar);
 		}
-		context.config.set_variables[key] = val;
+		config.options.set_variables[key] = val;
 		ret.emplace_back(env_var_name, key, val.ToString());
 	}
 }
 
 vector<AWSEnvVarToConfigHelper> AWSEnvironmentCredentialsProvider::SetAll() {
-	Value set_val;
 	vector<AWSEnvVarToConfigHelper> ret;
 	SetExtensionOptionValue("s3_region", DEFAULT_REGION_ENV_VAR, ret);
 	SetExtensionOptionValue("s3_region", REGION_ENV_VAR, ret);
 	SetExtensionOptionValue("s3_access_key_id", ACCESS_KEY_ENV_VAR, ret);
 	SetExtensionOptionValue("s3_secret_access_key", SECRET_KEY_ENV_VAR, ret);
 	SetExtensionOptionValue("s3_session_token", SESSION_TOKEN_ENV_VAR, ret);
+	auto duckdb_settings = SetDuckDBSettings();
+	for (auto &val : duckdb_settings) {
+		ret.emplace_back(val);
+	}
+	return ret;
+}
+
+vector<AWSEnvVarToConfigHelper> AWSEnvironmentCredentialsProvider::SetDuckDBSettings() {
+	vector<AWSEnvVarToConfigHelper> ret;
 	SetExtensionOptionValue("s3_endpoint", DUCKDB_ENDPOINT_ENV_VAR, ret);
 	SetExtensionOptionValue("s3_use_ssl", DUCKDB_USE_SSL_ENV_VAR, ret);
 	SetExtensionOptionValue("s3_kms_key_id", DUCKDB_KMS_KEY_ID_ENV_VAR, ret);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -189,6 +189,7 @@ case_insensitive_map_t<string> AWSEnvironmentCredentialsProvider::SetAll() {
 	SetValue("s3_kms_key_id", set_val, ret);
 	set_val = SetExtensionOptionValue("s3_requester_pays", DUCKDB_REQUESTER_PAYS_ENV_VAR);
 	SetValue("s3_requester_pays", set_val, ret);
+	return ret;
 }
 
 S3AuthParams AWSEnvironmentCredentialsProvider::CreateParams() {

--- a/test/sql/copy/csv/glob/copy_csv_glob_s3.test
+++ b/test/sql/copy/csv/glob/copy_csv_glob_s3.test
@@ -24,6 +24,10 @@ require-env DUCKDB_S3_USE_SSL
 # override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
 set ignore_error_messages
 
+# load env variables into local config options
+statement ok
+call inherit_aws_config_from_environment();
+
 # copy files to S3 before beginning tests
 statement ok
 COPY (select * from 'duckdb/data/csv/glob/a1/a1.csv') to 's3://test-bucket/copy_csv_glob_s3/copy/a1/a1.csv';

--- a/test/sql/copy/csv/glob/read_csv_glob_s3.test
+++ b/test/sql/copy/csv/glob/read_csv_glob_s3.test
@@ -21,6 +21,9 @@ require-env DUCKDB_S3_ENDPOINT
 
 require-env DUCKDB_S3_USE_SSL
 
+statement ok
+call inherit_aws_config_from_environment();
+
 # override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
 set ignore_error_messages
 

--- a/test/sql/copy/parquet/parquet_glob_s3.test
+++ b/test/sql/copy/parquet/parquet_glob_s3.test
@@ -29,6 +29,9 @@ set ignore_error_messages
 statement ok
 set enable_external_file_cache=false;
 
+statement ok
+call inherit_aws_config_from_environment();
+
 # Copy files to S3 before beginning tests
 statement ok
 COPY (select * from 'duckdb/data/parquet-testing/glob/t1.parquet') to 's3://test-bucket/parquet_glob_s3/glob/t1.parquet';

--- a/test/sql/copy/parquet/parquet_http_prefetch.test
+++ b/test/sql/copy/parquet/parquet_http_prefetch.test
@@ -24,6 +24,9 @@ require-env DUCKDB_S3_USE_SSL
 set ignore_error_messages
 
 statement ok
+call inherit_aws_config_from_environment();
+
+statement ok
 CREATE TABLE test_fetch_delay (a INT, b INT);
 
 statement ok

--- a/test/sql/copy/parquet/test_parquet_force_download.test
+++ b/test/sql/copy/parquet/test_parquet_force_download.test
@@ -15,6 +15,9 @@ SET force_download=true;
 statement ok
 set enable_external_file_cache=false;
 
+statement ok
+call inherit_aws_config_from_environment();
+
 query II
 explain analyze SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://raw.githubusercontent.com/duckdb/duckdb/main/data/parquet-testing/userdata1.parquet')
 ----

--- a/test/sql/copy/s3/csv_s3_file_size_bytes.test
+++ b/test/sql/copy/s3/csv_s3_file_size_bytes.test
@@ -30,6 +30,9 @@ CREATE TABLE bigdata AS SELECT i AS col_a, i AS col_b FROM range(0,10000) tbl(i)
 statement ok
 set threads=1
 
+statement ok
+call inherit_aws_config_from_environment();
+
 # parameter in bytes
 statement ok
 COPY (FROM bigdata) TO 's3://test-bucket/file_size_bytes_csv1' (FORMAT CSV, FILE_SIZE_BYTES 1000);

--- a/test/sql/copy/s3/download_config.test
+++ b/test/sql/copy/s3/download_config.test
@@ -23,6 +23,9 @@ require-env DUCKDB_S3_USE_SSL
 set ignore_error_messages
 
 statement ok
+call inherit_aws_config_from_environment();
+
+statement ok
 CREATE TABLE test as SELECT * FROM range(0,10) tbl(i);
 
 foreach url_style path vhost

--- a/test/sql/copy/s3/fully_qualified_s3_url.test
+++ b/test/sql/copy/s3/fully_qualified_s3_url.test
@@ -24,6 +24,9 @@ require-env DUCKDB_S3_USE_SSL
 set ignore_error_messages
 
 statement ok
+call inherit_aws_config_from_environment();
+
+statement ok
 CREATE TABLE test as SELECT * FROM range(0,10) tbl(i);
 
 #set some false credentials to verify query param override

--- a/test/sql/copy/s3/glob_s3_paging.test_slow
+++ b/test/sql/copy/s3/glob_s3_paging.test_slow
@@ -39,6 +39,9 @@ foreach urlstyle path vhost
 statement ok
 SET s3_url_style='${urlstyle}'
 
+statement ok
+call inherit_aws_config_from_environment();
+
 ## For both formats we generate 2000 files which we will glob to test the paging mechanism of aws ListObjectV2 call is handled properly
 foreach format parquet csv
 

--- a/test/sql/copy/s3/hive_partitioned_write_s3.test_slow
+++ b/test/sql/copy/s3/hive_partitioned_write_s3.test_slow
@@ -33,6 +33,9 @@ set http_timeout=120000;
 statement ok
 set http_retries=6;
 
+statement ok
+call inherit_aws_config_from_environment();
+
 # around 200MB worth of data, will require the PartitionedColumnData to spill to disk
 statement ok
 COPY (SELECT i%2::INT32 as part_col, i::INT32 FROM range(0,25000000) tbl(i)) TO 's3://test-bucket/partitioned_memory_spill' (FORMAT parquet, PARTITION_BY part_col, overwrite_or_ignore TRUE);

--- a/test/sql/copy/s3/http_log.test
+++ b/test/sql/copy/s3/http_log.test
@@ -21,6 +21,9 @@ require-env DUCKDB_S3_USE_SSL
 # override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
 set ignore_error_messages
 
+statement ok
+call inherit_aws_config_from_environment();
+
 # Create some test data
 statement ok
 COPY (SELECT 'value-1' as value) TO 's3://test-bucket/http_log/test.parquet';

--- a/test/sql/copy/s3/http_proxy.test
+++ b/test/sql/copy/s3/http_proxy.test
@@ -27,6 +27,9 @@ statement ok
 PRAGMA enable_verification
 
 statement ok
+call inherit_aws_config_from_environment();
+
+statement ok
 COPY (SELECT 'value-1' as value) TO 's3://test-bucket/proxy-test/test.parquet';
 
 query I

--- a/test/sql/copy/s3/http_secret.test
+++ b/test/sql/copy/s3/http_secret.test
@@ -21,6 +21,9 @@ require-env DUCKDB_S3_USE_SSL
 # override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
 set ignore_error_messages
 
+statement ok
+call inherit_aws_config_from_environment();
+
 # Create some test data
 statement ok
 COPY (SELECT 'value-1' as value) TO 's3://test-bucket/http-secret-test/test.parquet';

--- a/test/sql/copy/s3/metadata_cache.test
+++ b/test/sql/copy/s3/metadata_cache.test
@@ -30,6 +30,9 @@ statement ok
 set enable_external_file_cache=false;
 
 statement ok
+call inherit_aws_config_from_environment();
+
+statement ok
 CREATE TABLE test as SELECT * FROM range(0,10) tbl(i);
 
 statement ok

--- a/test/sql/copy/s3/parquet_s3_tpch.test_slow
+++ b/test/sql/copy/s3/parquet_s3_tpch.test_slow
@@ -39,6 +39,9 @@ set http_retries=6;
 statement ok
 CALL DBGEN(sf=0.01);
 
+statement ok
+call inherit_aws_config_from_environment();
+
 # copy tpch files to S3
 statement ok
 COPY lineitem to 's3://test-bucket/tpch-sf0_01/lineitem.parquet';

--- a/test/sql/copy/s3/s3_hive_partition.test
+++ b/test/sql/copy/s3/s3_hive_partition.test
@@ -28,6 +28,9 @@ CREATE TABLE test AS SELECT 1 as id, 'value1' as value;
 CREATE TABLE test2 AS SELECT 2 as id, 'value2' as value;
 
 statement ok
+call inherit_aws_config_from_environment();
+
+statement ok
 COPY test TO 's3://test-bucket/hive-partitioning/simple/key_!-_.*()=zisiswurking1/test.parquet';
 COPY test2 TO 's3://test-bucket/hive-partitioning/simple/key_!-_.*()=zisiswurking2/test.parquet';
 

--- a/test/sql/copy/s3/starstar.test
+++ b/test/sql/copy/s3/starstar.test
@@ -22,11 +22,12 @@ require-env DUCKDB_S3_USE_SSL
 # override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
 set ignore_error_messages
 
+statement ok
+call inherit_aws_config_from_environment();
+
 # create a table
 statement ok
 CREATE TABLE mytable AS SELECT i as a, (i*2) as b, power(i,2) as c from range(0,10) tbl(i);
-
-
 
 # sanity check: the bucket is empty
 query I

--- a/test/sql/copy/s3/upload_file_parallel.test_slow
+++ b/test/sql/copy/s3/upload_file_parallel.test_slow
@@ -26,9 +26,6 @@ require-env DUCKDB_S3_USE_SSL
 set ignore_error_messages
 
 statement ok
-call inherit_aws_config_from_environment();
-
-statement ok
 CALL DBGEN(sf=1)
 
 statement ok
@@ -55,8 +52,9 @@ WHERE
 # We do this in parallel to also test synchronization of s3fs between 2 connections
 concurrentloop threadid 0 2
 
+# you have to load the env variables into secrets in every thread
 statement ok
-SET s3_endpoint='${DUCKDB_S3_ENDPOINT}';SET s3_use_ssl=${DUCKDB_S3_USE_SSL};
+call inherit_aws_config_from_environment();
 
 # Parquet file
 statement ok
@@ -97,6 +95,10 @@ WHERE
 
 # Upload and query 100 tiny files in parallel
 concurrentloop threadid 0 100
+
+# you have to load the env variables into secrets in every thread
+statement ok
+call inherit_aws_config_from_environment();
 
 statement ok
 SET s3_secret_access_key='${AWS_SECRET_ACCESS_KEY}';SET s3_access_key_id='${AWS_ACCESS_KEY_ID}';SET s3_region='${AWS_DEFAULT_REGION}'; SET s3_endpoint='${DUCKDB_S3_ENDPOINT}';SET s3_use_ssl=${DUCKDB_S3_USE_SSL};

--- a/test/sql/copy/s3/upload_file_parallel.test_slow
+++ b/test/sql/copy/s3/upload_file_parallel.test_slow
@@ -26,6 +26,9 @@ require-env DUCKDB_S3_USE_SSL
 set ignore_error_messages
 
 statement ok
+call inherit_aws_config_from_environment();
+
+statement ok
 CALL DBGEN(sf=1)
 
 statement ok

--- a/test/sql/copy/s3/upload_large_file.test_slow
+++ b/test/sql/copy/s3/upload_large_file.test_slow
@@ -60,6 +60,9 @@ WHERE
 ----
 123141078.2283
 
+statement ok
+call inherit_aws_config_from_environment();
+
 # Parquet file ~300MB
 statement ok
 COPY lineitem TO 's3://test-bucket/multipart/export_large.parquet' (FORMAT 'parquet');

--- a/test/sql/copy/s3/upload_large_json_file.test_slow
+++ b/test/sql/copy/s3/upload_large_json_file.test_slow
@@ -30,6 +30,9 @@ set ignore_error_messages
 statement ok
 set http_timeout=120000;
 
+statement ok
+call inherit_aws_config_from_environment();
+
 # More retries (longest wait will be 25600ms)
 statement ok
 set http_retries=6;

--- a/test/sql/copy/s3/upload_small_file.test
+++ b/test/sql/copy/s3/upload_small_file.test
@@ -24,6 +24,9 @@ require-env DUCKDB_S3_USE_SSL
 set ignore_error_messages
 
 statement ok
+call inherit_aws_config_from_environment();
+
+statement ok
 CREATE TABLE web_page as (SELECT * FROM "duckdb/data/csv/real/web_page.csv");
 
 query IIIIIIIIIIIIII

--- a/test/sql/copy/s3/url_encode.test
+++ b/test/sql/copy/s3/url_encode.test
@@ -24,6 +24,9 @@ require-env DUCKDB_S3_USE_SSL
 set ignore_error_messages
 
 statement ok
+call inherit_aws_config_from_environment();
+
+statement ok
 CREATE TABLE test_1 as (SELECT 1 FROM range(0,5));
 CREATE TABLE test_2 as (SELECT 2 FROM range(0,5));
 CREATE TABLE test_3 as (SELECT 3 FROM range(0,5));

--- a/test/sql/httpfs/curl_space_encoding.test
+++ b/test/sql/httpfs/curl_space_encoding.test
@@ -27,6 +27,9 @@ statement ok
 CREATE TABLE test_1 as (SELECT 1 FROM range(0,5));
 
 statement ok
+call inherit_aws_config_from_environment();
+
+statement ok
 SET httpfs_client_implementation = curl
 
 foreach prefix s3:// r2:// s3a:// s3n://

--- a/test/sql/secret/secret_aws.test
+++ b/test/sql/secret/secret_aws.test
@@ -29,13 +29,7 @@ statement ok
 SET enable_logging=true
 
 statement ok
-set s3_use_ssl='${DUCKDB_S3_USE_SSL}'
-
-statement ok
-set s3_endpoint='${DUCKDB_S3_ENDPOINT}'
-
-statement ok
-set s3_region='${AWS_DEFAULT_REGION}'
+call inherit_aws_config_from_environment();
 
 # Create some test data
 statement ok

--- a/test/sql/test_inherit_from_env.test
+++ b/test/sql/test_inherit_from_env.test
@@ -1,0 +1,9 @@
+# name: test/sql/test_inherit_from_env.test
+# group: [sql]
+
+require httpfs
+
+mode output_result
+
+statement ok
+call inherit_aws_config_from_environment();

--- a/test/sql/test_inherit_from_env.test
+++ b/test/sql/test_inherit_from_env.test
@@ -3,15 +3,47 @@
 
 require httpfs
 
+require parquet
+
 require-env AWS_DEFAULT_REGION
 
 require-env AWS_ACCESS_KEY_ID
 
 require-env AWS_SECRET_ACCESS_KEY
 
-statement II
-call inherit_aws_config_from_environment() order by all;
+# override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
+set ignore_error_messages
+
+# not using any keys, should be fine
+statement ok
+SELECT * FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet') LIMIT 5;
+
+query III
+call inherit_aws_config_from_environment();
 ----
-AWS_ACCESS_KEY_ID	minio_duckdb_user
-AWS_DEFAULT_REGION	eu-west-1
-AWS_SECRET_ACCESS_KEY	<redacted>
+AWS_DEFAULT_REGION	s3_region	eu-west-1
+AWS_ACCESS_KEY_ID	s3_access_key_id	minio_duckdb_user
+AWS_SECRET_ACCESS_KEY	s3_secret_access_key	minio_duckdb_user_password
+DUCKDB_S3_ENDPOINT	s3_endpoint	duckdb-minio.com:9000
+DUCKDB_S3_USE_SSL	s3_use_ssl	false
+
+query I
+select current_setting('s3_access_key_id');
+----
+minio_duckdb_user
+
+query I
+select current_setting('s3_region');
+----
+eu-west-1
+
+query I
+select current_setting('s3_secret_access_key');
+----
+minio_duckdb_user_password
+
+# should fail because we inherit incorrect values from env (like the endpoint)
+statement error
+SELECT * FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet') LIMIT 5;
+----
+<REGEX>:.*duckdb-minio.com:9000.*

--- a/test/sql/test_inherit_from_env.test
+++ b/test/sql/test_inherit_from_env.test
@@ -3,7 +3,15 @@
 
 require httpfs
 
-mode output_result
+require-env AWS_DEFAULT_REGION
 
-statement ok
-call inherit_aws_config_from_environment();
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+statement II
+call inherit_aws_config_from_environment() order by all;
+----
+AWS_ACCESS_KEY_ID	minio_duckdb_user
+AWS_DEFAULT_REGION	eu-west-1
+AWS_SECRET_ACCESS_KEY	<redacted>

--- a/test/sql/test_inherit_from_env.test
+++ b/test/sql/test_inherit_from_env.test
@@ -11,6 +11,10 @@ require-env AWS_ACCESS_KEY_ID
 
 require-env AWS_SECRET_ACCESS_KEY
 
+require-env DUCKDB_S3_ENDPOINT
+
+require-env DUCKDB_S3_USE_SSL
+
 # override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
 set ignore_error_messages
 

--- a/test/sql/test_read_public_bucket.test
+++ b/test/sql/test_read_public_bucket.test
@@ -18,23 +18,23 @@ require-env AWS_SECRET_ACCESS_KEY
 set ignore_error_messages
 
 statement ok
+SELECT * FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet') LIMIT 5;
+
+# default to not using globally scoped settings for secrets
+statement ok
+call inherit_aws_config_from_environment();
+
+# set region correctly
+statement ok
 set s3_region='us-east-2';
 
-# set endpoint to the correct default, otherwise it will pick up the env variable
+# set s3_endpoint back
 statement ok
 set s3_endpoint='s3.amazonaws.com';
 
 # see duckdb-internal/issues/6620
-# env vars for access_key_id and secret_key_id are used
-# which results in 403
+# when env vars are loaded, this should fail since the env vars are incorrect
 statement error
 SELECT * FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet') LIMIT 5;
 ----
-<REGEX>:.*HTTP Error:.*403.*Authentication Failure.*
-
-# default to not using globally scoped settings for secrets
-statement ok
-set enable_global_s3_configuration=false;
-
-statement ok
-SELECT * FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet') LIMIT 5;
+<REGEX>:.*HTTP GET error.*


### PR DESCRIPTION
DO NOT MERGE, this is a breaking change and we need to discuss if this is a break we want to make.

Follow up for https://github.com/duckdblabs/duckdb-internal/issues/6620

In v1.4.4 duckdb-httpfs will automatically read environment variables like `AWS_SECRET_ACCESS_KEY`, and `AWS_SECRET_KEY_ID` and populate the config values `s3_secret_access_key` and `DBConfigOptions` with those environment variables. These config values would then be used for any remote reads on a blob storage like s3/r2. https://github.com/duckdb/duckdb-httpfs/pull/182 introduced the ability to disable the automatic use of these values during remote reads, it did not disable automatically reading and setting those values.

With this PR for v1.5, we will disable auto loading environment values not prefixed with DUCKDB into the config options, and only do when the user requests it. To allow a user to set config values from environment variables, we introduce the function `inherit_aws_config_from_environment()` that a user can call which will set the config values `s3_region`, `s3_secret_access_key`, `s3_session_token`, `s3_endpoint`, `s3_use_ssl`, `s3_kms_key_id`, and `s3_requester_pays`. These config options are only set locally, we can set these config options globally if needed.