### PR TITLE
Improve S3KeyValueReader API

### DIFF
--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -24,6 +24,7 @@ class S3KeyValueReader {
 public:
 	S3KeyValueReader(FileOpener &opener_p, optional_ptr<FileOpenerInfo> info, const char **secret_types,
 	                 idx_t secret_types_len);
+	explicit S3KeyValueReader(const KeyValueSecretReader &reader);
 
 	template <class TYPE>
 	SettingLookupResult TryGetSecretKeyOrSetting(const string &secret_key, const string &setting_name, TYPE &result) {

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1378,12 +1378,16 @@ vector<string> AWSListObjectV2::ParseCommonPrefix(string &aws_response) {
 	return s3_prefixes;
 }
 
+
 S3KeyValueReader::S3KeyValueReader(FileOpener &opener_p, optional_ptr<FileOpenerInfo> info, const char **secret_types,
-                                   idx_t secret_types_len)
-    : reader(opener_p, info, secret_types, secret_types_len) {
+								   const idx_t secret_types_len)
+	: S3KeyValueReader(KeyValueSecretReader {opener_p, info, secret_types, secret_types_len}) {
+}
+
+S3KeyValueReader::S3KeyValueReader(const KeyValueSecretReader &_reader) : reader(_reader) {
 	Value use_env_vars_for_secret_info_setting;
 	reader.TryGetSecretKeyOrSetting("enable_global_s3_configuration", "enable_global_s3_configuration",
-	                                use_env_vars_for_secret_info_setting);
+									use_env_vars_for_secret_info_setting);
 	use_env_variables_for_secret_settings = use_env_vars_for_secret_info_setting.GetValue<bool>();
 }
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1378,16 +1378,15 @@ vector<string> AWSListObjectV2::ParseCommonPrefix(string &aws_response) {
 	return s3_prefixes;
 }
 
-
 S3KeyValueReader::S3KeyValueReader(FileOpener &opener_p, optional_ptr<FileOpenerInfo> info, const char **secret_types,
-								   const idx_t secret_types_len)
-	: S3KeyValueReader(KeyValueSecretReader {opener_p, info, secret_types, secret_types_len}) {
+                                   const idx_t secret_types_len)
+    : S3KeyValueReader(KeyValueSecretReader {opener_p, info, secret_types, secret_types_len}) {
 }
 
 S3KeyValueReader::S3KeyValueReader(const KeyValueSecretReader &_reader) : reader(_reader) {
 	Value use_env_vars_for_secret_info_setting;
 	reader.TryGetSecretKeyOrSetting("enable_global_s3_configuration", "enable_global_s3_configuration",
-									use_env_vars_for_secret_info_setting);
+	                                use_env_vars_for_secret_info_setting);
 	use_env_variables_for_secret_settings = use_env_vars_for_secret_info_setting.GetValue<bool>();
 }
 


### PR DESCRIPTION
The S3KeyValueReader constructor was very restricted and supported only one of the `KeyValueSecretReader`'s constructors. This adds a second constructor to the `S3KeyValueReader` to support just passing a `KeyValueSecretReader` instead all its constructor parameters