### PR TITLE
Remove `__RESPONSE_STATUS__` from response header

### DIFF
--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -410,7 +410,8 @@ private:
 		auto status_code = HTTPStatusCode(request_info->response_code);
 		auto response = make_uniq<HTTPResponse>(status_code);
 		if (res != CURLcode::CURLE_OK) {
-			// __RESPONSE_STATUS__ is used for error propagation and debugging. It stores the full HTTP status trail, e.g. in cases of redirection failures, to help trace the sequence of HTTP statuses.
+			// __RESPONSE_STATUS__ is used for error propagation and debugging. It stores the full HTTP status trail,
+			// e.g. in cases of redirection failures, to help trace the sequence of HTTP statuses.
 			if (!request_info->header_collection.empty() &&
 			    request_info->header_collection.back().HasHeader("__RESPONSE_STATUS__")) {
 				response->request_error = request_info->header_collection.back().GetHeaderValue("__RESPONSE_STATUS__");

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -424,6 +424,9 @@ private:
 		response->reason = HTTPUtil::GetStatusMessage(HTTPUtil::ToStatusCode(request_info->response_code));
 		if (!request_info->header_collection.empty()) {
 			for (auto &header : request_info->header_collection.back()) {
+				if (header.first == "__RESPONSE_STATUS__") {
+					continue;
+				}
 				response->headers.Insert(header.first, header.second);
 			}
 		}

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -410,7 +410,7 @@ private:
 		auto status_code = HTTPStatusCode(request_info->response_code);
 		auto response = make_uniq<HTTPResponse>(status_code);
 		if (res != CURLcode::CURLE_OK) {
-			// TODO: request error can come from HTTPS Status code toString() value.
+			// __RESPONSE_STATUS__ is used for error propagation and debugging. It stores the full HTTP status trail, e.g. in cases of redirection failures, to help trace the sequence of HTTP statuses.
 			if (!request_info->header_collection.empty() &&
 			    request_info->header_collection.back().HasHeader("__RESPONSE_STATUS__")) {
 				response->request_error = request_info->header_collection.back().GetHeaderValue("__RESPONSE_STATUS__");
@@ -424,6 +424,7 @@ private:
 		response->reason = HTTPUtil::GetStatusMessage(HTTPUtil::ToStatusCode(request_info->response_code));
 		if (!request_info->header_collection.empty()) {
 			for (auto &header : request_info->header_collection.back()) {
+				// We should not return __RESPONSE_STATUS__ to the user. It's only there for debugging.
 				if (header.first == "__RESPONSE_STATUS__") {
 					continue;
 				}

--- a/test/sql/copy/csv/test_url_with_plus.test
+++ b/test/sql/copy/csv/test_url_with_plus.test
@@ -4,6 +4,9 @@
 
 require httpfs
 
+# FIXME: check again later. Something must have changed on the server side and both httplib and curl get code 202 (Accepted).
+mode skip
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/copy/csv/test_url_with_plus.test
+++ b/test/sql/copy/csv/test_url_with_plus.test
@@ -4,9 +4,6 @@
 
 require httpfs
 
-# FIXME: check again later. Something must have changed on the server side and both httplib and curl get code 202 (Accepted).
-mode skip
-
 statement ok
 PRAGMA enable_verification
 


### PR DESCRIPTION
As the title suggests, we should not include `__RESPONSE_STATUS__` in the repsonse header of a request. We keep the content of `__RESPONSE_STATUS__` only for debugging purposes (e.g. failure after a redirect).