### PR TITLE
Add support for lazily expanding globs to S3FileSystem, and correctly record GET requests made during glob

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       extension_name: httpfs
-      duckdb_version: 1f9ecad746
+      duckdb_version: 9c2a64a
       ci_tools_version: main
 
   duckdb-stable-deploy:
@@ -27,7 +27,7 @@ jobs:
     secrets: inherit
     with:
       extension_name: httpfs
-      duckdb_version: 1f9ecad746
+      duckdb_version: 9c2a64a
       ci_tools_version: main
       deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') }}
       deploy_versioned: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# DuckDB HTTPFS extension
+
+The httpfs extension is an autoloadable extension implementing a file system that allows reading remote/writing remote files. For plain HTTP(S), only file reading is supported. For object storage using the S3 API, the httpfs extension supports reading/writing/globbing files.
+
+## Building & Loading the Extension
+
+The DuckDB submodule must be initialized prior to building.
+
+```bash
+git submodule init
+git pull --recurse-submodules
+```
+
+To build, type
+```
+make
+```
+
+## Testing
+
+Testing uses a local MinIO setup using Docker. See the [testing documentation for more information on how to set this up locally](test).

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -35,6 +35,7 @@ unique_ptr<HTTPParams> HTTPFSUtil::InitializeParameters(optional_ptr<FileOpener>
                                                         optional_ptr<FileOpenerInfo> info) {
 	auto result = make_uniq<HTTPFSParams>(*this);
 	result->Initialize(opener);
+	result->state = HTTPState::TryGetState(opener);
 
 	// No point in continuing without an opener
 	if (!opener) {

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -249,9 +249,6 @@ public:
 	static void UploadBufferImplementation(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer,
 	                                       string query_param, bool direct_throw);
 
-	bool ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
-	               FileOpener *opener = nullptr) override;
-
 	//! Wrapper around BufferManager::Allocate to limit the number of buffers
 	BufferHandle Allocate(idx_t part_size, uint16_t max_threads);
 
@@ -267,6 +264,11 @@ public:
 	                                const string &url);
 
 protected:
+	bool ListFilesExtended(const string &directory, const std::function<void(OpenFileInfo &info)> &callback,
+	                       optional_ptr<FileOpener> opener) override;
+	bool SupportsListFilesExtended() const override {
+		return true;
+	}
 	unique_ptr<MultiFileList> GlobFilesExtended(const string &path, const FileGlobInput &input,
 	                                            optional_ptr<FileOpener> opener) override;
 	bool SupportsGlobExtended() const override {

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -288,7 +288,7 @@ protected:
 // Helper class to do s3 ListObjectV2 api call https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
 struct AWSListObjectV2 {
 	static string Request(const string &path, HTTPParams &http_params, const S3AuthParams &s3_auth_params,
-	                      string &continuation_token, optional_ptr<HTTPState> state, bool use_delimiter = false);
+	                      string &continuation_token);
 	static void ParseFileList(string &aws_response, vector<OpenFileInfo> &result);
 	static vector<string> ParseCommonPrefix(string &aws_response);
 	static string ParseContinuationToken(string &aws_response);

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -263,11 +263,12 @@ public:
 	static string GetS3BadRequestError(const S3AuthParams &s3_auth_params, string correct_region = "");
 	static string GetS3AuthError(const S3AuthParams &s3_auth_params);
 	static string GetGCSAuthError(const S3AuthParams &s3_auth_params);
-	static HTTPException GetS3Error(const S3AuthParams &s3_auth_params, const HTTPResponse &response, const string &url);
+	static HTTPException GetS3Error(const S3AuthParams &s3_auth_params, const HTTPResponse &response,
+	                                const string &url);
 
 protected:
 	unique_ptr<MultiFileList> GlobFilesExtended(const string &path, const FileGlobInput &input,
-												optional_ptr<FileOpener> opener) override;
+	                                            optional_ptr<FileOpener> opener) override;
 	bool SupportsGlobExtended() const override {
 		return true;
 	}

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1184,18 +1184,18 @@ string S3FileSystem::GetName() const {
 	return "S3FileSystem";
 }
 
-bool S3FileSystem::ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
-                             FileOpener *opener) {
+bool S3FileSystem::ListFilesExtended(const string &directory, const std::function<void(OpenFileInfo &info)> &callback,
+                                     optional_ptr<FileOpener> opener) {
 	string trimmed_dir = directory;
 	StringUtil::RTrim(trimmed_dir, PathSeparator(trimmed_dir));
-	auto glob_res = Glob(JoinPath(trimmed_dir, "**"), opener);
+	auto glob_res = GlobFilesExtended(JoinPath(trimmed_dir, "**"), FileGlobOptions::ALLOW_EMPTY, opener);
 
-	if (glob_res.empty()) {
+	if (!glob_res || glob_res->GetExpandResult() == FileExpandResult::NO_FILES) {
 		return false;
 	}
 
-	for (const auto &file : glob_res) {
-		callback(file.path, false);
+	for (auto file : glob_res->Files()) {
+		callback(file);
 	}
 
 	return true;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -2,7 +2,6 @@
 
 #include "crypto.hpp"
 #include "duckdb.hpp"
-#ifndef DUCKDB_AMALGAMATION
 #include "duckdb/common/exception/http_exception.hpp"
 #include "duckdb/logging/log_type.hpp"
 #include "duckdb/logging/file_system_logger.hpp"
@@ -11,12 +10,12 @@
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/function/scalar/strftime_format.hpp"
 #include "http_state.hpp"
-#endif
 
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/scalar/string_common.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
+#include "duckdb/common/multi_file/multi_file_list.hpp"
 
 #include "create_secret_functions.hpp"
 
@@ -647,7 +646,7 @@ string S3FileSystem::GetPrefix(const string &url) {
 	return prefix;
 }
 
-ParsedS3Url S3FileSystem::S3UrlParse(string url, S3AuthParams &params) {
+ParsedS3Url S3FileSystem::S3UrlParse(string url, const S3AuthParams &params) {
 	string http_proto, prefix, host, bucket, key, path, query_param, trimmed_s3_url;
 
 	prefix = GetPrefix(url);
@@ -1046,71 +1045,101 @@ static bool Match(vector<string>::const_iterator key, vector<string>::const_iter
 	return key == key_end && pattern == pattern_end;
 }
 
-vector<OpenFileInfo> S3FileSystem::Glob(const string &glob_pattern, FileOpener *opener) {
-	if (opener == nullptr) {
+
+struct S3GlobResult : public LazyMultiFileList {
+public:
+	S3GlobResult(S3FileSystem &fs, const string &path, optional_ptr<FileOpener> opener);
+
+protected:
+	bool ExpandNextPath() const override;
+
+private:
+	S3FileSystem &fs;
+	string glob_pattern;
+	optional_ptr<FileOpener> opener;
+	mutable bool finished = false;
+	S3AuthParams s3_auth_params;
+	string shared_path;
+	ParsedS3Url parsed_s3_url;
+	mutable string main_continuation_token;
+};
+
+S3GlobResult::S3GlobResult(S3FileSystem &fs, const string &glob_pattern_p, optional_ptr<FileOpener> opener) : fs(fs), glob_pattern(glob_pattern_p), opener(opener) {
+	if (!opener) {
 		throw InternalException("Cannot S3 Glob without FileOpener");
 	}
-
 	FileOpenerInfo info = {glob_pattern};
 
 	// Trim any query parameters from the string
-	S3AuthParams s3_auth_params = S3AuthParams::ReadFrom(opener, info);
+	s3_auth_params = S3AuthParams::ReadFrom(opener, info);
 
 	// In url compatibility mode, we ignore globs allowing users to query files with the glob chars
 	if (s3_auth_params.s3_url_compatibility_mode) {
-		return {glob_pattern};
+		expanded_files.emplace_back(glob_pattern);
+		finished = true;
+		return;
 	}
 
-	auto parsed_s3_url = S3UrlParse(glob_pattern, s3_auth_params);
+	parsed_s3_url = fs.S3UrlParse(glob_pattern, s3_auth_params);
 	auto parsed_glob_url = parsed_s3_url.trimmed_s3_url;
 
 	// AWS matches on prefix, not glob pattern, so we take a substring until the first wildcard char for the aws calls
 	auto first_wildcard_pos = parsed_glob_url.find_first_of("*[\\");
 	if (first_wildcard_pos == string::npos) {
-		return {glob_pattern};
+		expanded_files.emplace_back(glob_pattern);
+		finished = true;
+		return;
 	}
 
-	string shared_path = parsed_glob_url.substr(0, first_wildcard_pos);
+	shared_path = parsed_glob_url.substr(0, first_wildcard_pos);
+
+	fs.ReadQueryParams(parsed_s3_url.query_param, s3_auth_params);
+}
+
+bool S3GlobResult::ExpandNextPath() const {
+	if (finished) {
+		return false;
+	}
+
+	FileOpenerInfo info = {glob_pattern};
 	auto http_util = HTTPFSUtil::GetHTTPUtil(opener);
 	auto http_params = http_util->InitializeParameters(opener, info);
 
-	ReadQueryParams(parsed_s3_url.query_param, s3_auth_params);
-
 	// Do main listobjectsv2 request
 	vector<OpenFileInfo> s3_keys;
-	string main_continuation_token;
 
-	// Main paging loop
-	do {
-		// main listobject call, may
-		string response_str = AWSListObjectV2::Request(shared_path, *http_params, s3_auth_params,
-		                                               main_continuation_token, HTTPState::TryGetState(opener).get());
-		main_continuation_token = AWSListObjectV2::ParseContinuationToken(response_str);
-		AWSListObjectV2::ParseFileList(response_str, s3_keys);
+	// issue the request
+	string response_str = AWSListObjectV2::Request(shared_path, *http_params, s3_auth_params,
+	                                               main_continuation_token, HTTPState::TryGetState(opener).get());
+	main_continuation_token = AWSListObjectV2::ParseContinuationToken(response_str);
+	AWSListObjectV2::ParseFileList(response_str, s3_keys);
 
-		// Repeat requests until the keys of all common prefixes are parsed.
-		auto common_prefixes = AWSListObjectV2::ParseCommonPrefix(response_str);
-		while (!common_prefixes.empty()) {
-			auto prefix_path = parsed_s3_url.prefix + parsed_s3_url.bucket + '/' + common_prefixes.back();
-			common_prefixes.pop_back();
+	// Repeat requests until the keys of all common prefixes are parsed.
+	auto common_prefixes = AWSListObjectV2::ParseCommonPrefix(response_str);
+	while (!common_prefixes.empty()) {
+		auto prefix_path = parsed_s3_url.prefix + parsed_s3_url.bucket + '/' + common_prefixes.back();
+		common_prefixes.pop_back();
 
-			// TODO we could optimize here by doing a match on the prefix, if it doesn't match we can skip this prefix
-			// Paging loop for common prefix requests
-			string common_prefix_continuation_token;
-			do {
-				auto prefix_res =
-				    AWSListObjectV2::Request(prefix_path, *http_params, s3_auth_params,
-				                             common_prefix_continuation_token, HTTPState::TryGetState(opener).get());
-				AWSListObjectV2::ParseFileList(prefix_res, s3_keys);
-				auto more_prefixes = AWSListObjectV2::ParseCommonPrefix(prefix_res);
-				common_prefixes.insert(common_prefixes.end(), more_prefixes.begin(), more_prefixes.end());
-				common_prefix_continuation_token = AWSListObjectV2::ParseContinuationToken(prefix_res);
-			} while (!common_prefix_continuation_token.empty());
-		}
-	} while (!main_continuation_token.empty());
+		// TODO we could optimize here by doing a match on the prefix, if it doesn't match we can skip this prefix
+		// Paging loop for common prefix requests
+		string common_prefix_continuation_token;
+		do {
+			auto prefix_res =
+			    AWSListObjectV2::Request(prefix_path, *http_params, s3_auth_params,
+			                             common_prefix_continuation_token, HTTPState::TryGetState(opener).get());
+			AWSListObjectV2::ParseFileList(prefix_res, s3_keys);
+			auto more_prefixes = AWSListObjectV2::ParseCommonPrefix(prefix_res);
+			common_prefixes.insert(common_prefixes.end(), more_prefixes.begin(), more_prefixes.end());
+			common_prefix_continuation_token = AWSListObjectV2::ParseContinuationToken(prefix_res);
+		} while (!common_prefix_continuation_token.empty());
+	}
+
+	if (main_continuation_token.empty()) {
+		// no continuations left - done
+		finished = true;
+	}
 
 	vector<string> pattern_splits = StringUtil::Split(parsed_s3_url.key, "/");
-	vector<OpenFileInfo> result;
 	for (auto &s3_key : s3_keys) {
 
 		vector<string> key_splits = StringUtil::Split(s3_key.path, "/");
@@ -1123,10 +1152,14 @@ vector<OpenFileInfo> S3FileSystem::Glob(const string &glob_pattern, FileOpener *
 				result_full_url += '?' + parsed_s3_url.query_param;
 			}
 			s3_key.path = std::move(result_full_url);
-			result.push_back(std::move(s3_key));
+			expanded_files.push_back(std::move(s3_key));
 		}
 	}
-	return result;
+	return true;
+}
+
+unique_ptr<MultiFileList> S3FileSystem::GlobFilesExtended(const string &path, const FileGlobInput &input, optional_ptr<FileOpener> opener) {
+	return make_uniq<S3GlobResult>(*this, path, opener);
 }
 
 string S3FileSystem::GetName() const {
@@ -1150,7 +1183,7 @@ bool S3FileSystem::ListFiles(const string &directory, const std::function<void(c
 	return true;
 }
 
-string S3FileSystem::GetS3BadRequestError(S3AuthParams &s3_auth_params, string correct_region) {
+string S3FileSystem::GetS3BadRequestError(const S3AuthParams &s3_auth_params, string correct_region) {
 	string extra_text = "\n\nBad Request - this can be caused by the S3 region being set incorrectly.";
 	if (s3_auth_params.region.empty()) {
 		extra_text += "\n* No region is provided.";
@@ -1163,7 +1196,7 @@ string S3FileSystem::GetS3BadRequestError(S3AuthParams &s3_auth_params, string c
 	return extra_text;
 }
 
-string S3FileSystem::GetS3AuthError(S3AuthParams &s3_auth_params) {
+string S3FileSystem::GetS3AuthError(const S3AuthParams &s3_auth_params) {
 	string extra_text = "\n\nAuthentication Failure - this is usually caused by invalid or missing credentials.";
 	if (s3_auth_params.secret_access_key.empty() && s3_auth_params.access_key_id.empty()) {
 		extra_text += "\n* No credentials are provided.";
@@ -1174,7 +1207,7 @@ string S3FileSystem::GetS3AuthError(S3AuthParams &s3_auth_params) {
 	return extra_text;
 }
 
-string S3FileSystem::GetGCSAuthError(S3AuthParams &s3_auth_params) {
+string S3FileSystem::GetGCSAuthError(const S3AuthParams &s3_auth_params) {
 	string extra_text = "\n\nAuthentication Failure - GCS authentication failed.";
 	if (s3_auth_params.oauth2_bearer_token.empty() && s3_auth_params.secret_access_key.empty() &&
 	    s3_auth_params.access_key_id.empty()) {
@@ -1191,7 +1224,7 @@ string S3FileSystem::GetGCSAuthError(S3AuthParams &s3_auth_params) {
 	return extra_text;
 }
 
-HTTPException S3FileSystem::GetS3Error(S3AuthParams &s3_auth_params, const HTTPResponse &response, const string &url) {
+HTTPException S3FileSystem::GetS3Error(const S3AuthParams &s3_auth_params, const HTTPResponse &response, const string &url) {
 	string extra_text;
 	if (response.status == HTTPStatusCode::BadRequest_400) {
 		extra_text = GetS3BadRequestError(s3_auth_params);
@@ -1217,7 +1250,7 @@ HTTPException S3FileSystem::GetHTTPError(FileHandle &handle, const HTTPResponse 
 
 	return GetS3Error(s3_handle.auth_params, response, url);
 }
-string AWSListObjectV2::Request(string &path, HTTPParams &http_params, S3AuthParams &s3_auth_params,
+string AWSListObjectV2::Request(const string &path, HTTPParams &http_params, const S3AuthParams &s3_auth_params,
                                 string &continuation_token, optional_ptr<HTTPState> state, bool use_delimiter) {
 	auto parsed_url = S3FileSystem::S3UrlParse(path, s3_auth_params);
 

--- a/test/sql/copy/parquet/parquet_glob_s3.test
+++ b/test/sql/copy/parquet/parquet_glob_s3.test
@@ -157,7 +157,7 @@ endloop
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM 's3://test-bucket/parquet_glob_s3/g*/*.parquet';
 ----
-analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 0.*GET\: 3.*PUT\: 0.*\#POST\: 0.*
+analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 0.*GET\: 4.*PUT\: 0.*\#POST\: 0.*
 
 statement ok
 SET VARIABLE file_list = (SELECT LIST(file) FROM GLOB('s3://test-bucket/parquet_glob_s3/g*/*.parquet'))


### PR DESCRIPTION
This PR implements the lazy glob interface added in https://github.com/duckdb/duckdb/pull/20619 to the S3 globs. Note that the default batch size (1000 keys) is relatively generous - so this is most likely not properly tested by the existing test set. I've run some tests locally with large buckets, and also ran some tests with max key size = 4, and that works - but I'll work on adding some more tests in a follow-up.

This PR also fixes an issue where the `GET` requests made during globs were not correctly recorded due to the `HTTPState` not being initialized correctly.