### PR TITLE
Add lazy globbing test, and fix issue in S3FileSystem::ListFiles where an absolute path instead of a relative path was returned

### DIFF
--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -290,7 +290,7 @@ protected:
 // Helper class to do s3 ListObjectV2 api call https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
 struct AWSListObjectV2 {
 	static string Request(const string &path, HTTPParams &http_params, const S3AuthParams &s3_auth_params,
-	                      string &continuation_token);
+	                      string &continuation_token, optional_idx max_keys = optional_idx());
 	static void ParseFileList(string &aws_response, vector<OpenFileInfo> &result);
 	static vector<string> ParseCommonPrefix(string &aws_response);
 	static string ParseContinuationToken(string &aws_response);

--- a/test/README.md
+++ b/test/README.md
@@ -37,19 +37,7 @@ Then run the test server in the back-ground using Docker. Note that Docker must 
 source ./scripts/run_s3_test_server.sh
 ```
 
-Now set up the following environment variables to enable running of the tests.
-
-This can be done either manually:
-```bash
-export S3_TEST_SERVER_AVAILABLE=1
-export AWS_DEFAULT_REGION=eu-west-1
-export AWS_ACCESS_KEY_ID=minio_duckdb_user
-export AWS_SECRET_ACCESS_KEY=minio_duckdb_user_password
-export DUCKDB_S3_ENDPOINT=duckdb-minio.com:9000  
-export DUCKDB_S3_USE_SSL=false
-```
-
-Or using the `set_s3_test_server_variables.sh` script  
+Now set up the following environment variables using the `set_s3_test_server_variables.sh` script to enable running of the tests.
 
 ```bash
 # use source so it sets the environment variables in your current environment

--- a/test/sql/copy/parquet/parquet_lazy_glob.test_slow
+++ b/test/sql/copy/parquet/parquet_lazy_glob.test_slow
@@ -1,0 +1,45 @@
+# name: test/sql/copy/parquet/parquet_lazy_glob.test_slow
+# description: Test basic globbing of parquet files over s3
+# group: [parquet]
+
+require parquet
+
+require httpfs
+
+require-env S3_TEST_SERVER_AVAILABLE 1
+
+# Require that these environment variables are also set
+
+require-env AWS_DEFAULT_REGION
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+require-env DUCKDB_S3_ENDPOINT
+
+require-env DUCKDB_S3_USE_SSL
+
+foreach part_count 2 2000
+
+statement ok
+CREATE OR REPLACE TABLE vals AS SELECT i part_key, concat('this is a value for part key ', i) v FROM range(${part_count}) t(i);
+
+statement ok
+COPY vals to 's3://test-bucket/parquet_glob_s3_many_files' (FORMAT PARQUET, PARTITION_BY (part_key), OVERWRITE 1);
+
+query I
+SELECT case when COUNT(*) = ${part_count} then NULL else {'expected': ${part_count}, 'got': COUNT(*)} end FROM glob('s3://test-bucket/parquet_glob_s3_many_files/**/*.parquet')
+----
+NULL
+
+query I
+SELECT COUNT(*) FROM (SELECT * FROM glob('s3://test-bucket/parquet_glob_s3_many_files/**/*.parquet') LIMIT 2)
+----
+2
+
+query II
+SELECT part_key, v FROM 's3://test-bucket/parquet_glob_s3_many_files/**/*.parquet' EXCEPT ALL SELECT part_key, v FROM vals
+----
+
+endloop


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb-httpfs/pull/216

This PR adds a test with 2000 keys on MinIO to test the lazy globbing behavior.

In addition, this PR fixes `S3FileSystem::ListFilesExtended` - this was incorrectly returning absolute paths, when the contract is that `ListFiles` should return relative paths. As a result, we would try to delete files like so when running `OVERWRITE` on partitioned writes:

```
s3://bucket-name/s3://bucket-name/file.parquet
```

This would (surprisingly) not work.