### PR TITLE
Add back handling for use_delimiter, making recursive globs faster

### DIFF
--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -82,7 +82,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          LogicalType::BOOLEAN, Value(false));
 	config.AddExtensionOption("s3_requester_pays", "S3 use requester pays mode", LogicalType::BOOLEAN, Value(false));
 	config.AddExtensionOption(
-	    "allow_s3_recursive_globbing",
+	    "s3_allow_recursive_globbing",
 	    "Whether globs on S3-like storage are optimized with recursive strategy (alterative is listing)",
 	    LogicalType::BOOLEAN, Value(true));
 

--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -81,6 +81,10 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("s3_url_compatibility_mode", "Disable Globs and Query Parameters on S3 URLs",
 	                          LogicalType::BOOLEAN, Value(false));
 	config.AddExtensionOption("s3_requester_pays", "S3 use requester pays mode", LogicalType::BOOLEAN, Value(false));
+	config.AddExtensionOption(
+	    "allow_s3_recursive_globbing",
+	    "Whether globs on S3-like storage are optimized with recursive strategy (alterative is listing)",
+	    LogicalType::BOOLEAN, Value(true));
 
 	// S3 Uploader config
 	config.AddExtensionOption("s3_uploader_max_filesize", "S3 Uploader max filesize (between 50GB and 5TB)",

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -290,7 +290,7 @@ protected:
 // Helper class to do s3 ListObjectV2 api call https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
 struct AWSListObjectV2 {
 	static string Request(const string &path, HTTPParams &http_params, S3AuthParams &s3_auth_params,
-	                      string &continuation_token, optional_idx max_keys = optional_idx());
+	                      string &continuation_token, bool use_delimiter = false, optional_idx max_keys = optional_idx());
 	static void ParseFileList(string &aws_response, vector<OpenFileInfo> &result);
 	static vector<string> ParseCommonPrefix(string &aws_response);
 	static string ParseContinuationToken(string &aws_response);

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -290,7 +290,8 @@ protected:
 // Helper class to do s3 ListObjectV2 api call https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
 struct AWSListObjectV2 {
 	static string Request(const string &path, HTTPParams &http_params, S3AuthParams &s3_auth_params,
-	                      string &continuation_token, bool use_delimiter = false, optional_idx max_keys = optional_idx());
+	                      string &continuation_token, bool use_delimiter = false,
+	                      optional_idx max_keys = optional_idx());
 	static void ParseFileList(string &aws_response, vector<OpenFileInfo> &result);
 	static vector<string> ParseCommonPrefix(string &aws_response);
 	static string ParseContinuationToken(string &aws_response);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1333,7 +1333,14 @@ bool S3GlobResult::ExpandNextPath() const {
 		if (!common_prefixes.empty()) {
 			throw InternalException("We have common prefixes but we are doing a top-level request");
 		}
-		const bool use_recursive_glob = !StringUtil::Contains(parsed_s3_url.key, "**");
+
+		Value value;
+		bool allow_s3_recursive_globbing;
+		if (FileOpener::TryGetCurrentSetting(opener, "allow_s3_recursive_globbing", value)) {
+			allow_s3_recursive_globbing = value.GetValue<bool>();
+		}
+
+		const bool use_recursive_glob = !StringUtil::Contains(parsed_s3_url.key, "**") && allow_s3_recursive_globbing;
 		// issue the main request
 		string response_str = AWSListObjectV2::Request(shared_path, *http_params, s3_auth_params,
 		                                               main_continuation_token, use_recursive_glob);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1201,23 +1201,24 @@ void S3FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx
 static bool Match(vector<string>::const_iterator key, vector<string>::const_iterator key_end,
                   vector<string>::const_iterator pattern, vector<string>::const_iterator pattern_end, bool completed) {
 
-		if (key == key_end && !completed) {
-			return true;
-		}
+	if (key == key_end && !completed) {
+		return true;
+	}
 
 	while (key != key_end && pattern != pattern_end) {
 		if (*pattern == "**") {
 			if (std::next(pattern) == pattern_end) {
 				return true;
 			}
-			pattern ++;
+			pattern++;
 			while (key != key_end) {
 				if (Match(key, key_end, pattern, pattern_end, completed)) {
 					return true;
 				}
 				key++;
 			}
-			if (!completed) return true;
+			if (!completed)
+				return true;
 			return false;
 		}
 		if (!Glob(key->data(), key->length(), pattern->data(), pattern->length())) {
@@ -1299,22 +1300,22 @@ bool S3GlobResult::ExpandNextPath() const {
 		// we have common prefixes left to scan - perform the request
 		auto prefix_path = parsed_s3_url.prefix + parsed_s3_url.bucket + '/' + current_common_prefix;
 
-current_common_prefix = S3FileSystem::UrlDecode(current_common_prefix);
-               vector<string> pattern_splits = StringUtil::Split(parsed_s3_url.key, "/");
-               vector<string> key_splits = StringUtil::Split(current_common_prefix, "/");
-               //pattern_splits.resize(key_splits.size());
-               const bool is_match = Match(key_splits.begin(), key_splits.end(), pattern_splits.begin(), pattern_splits.end(), false);
-               if (is_match) {
-	prefix_path = S3FileSystem::UrlDecode(prefix_path);
-                       auto prefix_res = AWSListObjectV2::Request(prefix_path, *http_params, s3_auth_params,
-                                                                  common_prefix_continuation_token, true);
+		current_common_prefix = S3FileSystem::UrlDecode(current_common_prefix);
+		vector<string> pattern_splits = StringUtil::Split(parsed_s3_url.key, "/");
+		vector<string> key_splits = StringUtil::Split(current_common_prefix, "/");
+		const bool is_match =
+		    Match(key_splits.begin(), key_splits.end(), pattern_splits.begin(), pattern_splits.end(), false);
+		if (is_match) {
+			prefix_path = S3FileSystem::UrlDecode(prefix_path);
+			auto prefix_res = AWSListObjectV2::Request(prefix_path, *http_params, s3_auth_params,
+			                                           common_prefix_continuation_token, true);
 
-                       AWSListObjectV2::ParseFileList(prefix_res, s3_keys);
-                       auto more_prefixes = AWSListObjectV2::ParseCommonPrefix(prefix_res);
-                       common_prefixes.insert(common_prefixes.end(), more_prefixes.begin(), more_prefixes.end());
+			AWSListObjectV2::ParseFileList(prefix_res, s3_keys);
+			auto more_prefixes = AWSListObjectV2::ParseCommonPrefix(prefix_res);
+			common_prefixes.insert(common_prefixes.end(), more_prefixes.begin(), more_prefixes.end());
 
-                       common_prefix_continuation_token = AWSListObjectV2::ParseContinuationToken(prefix_res);
-               }
+			common_prefix_continuation_token = AWSListObjectV2::ParseContinuationToken(prefix_res);
+		}
 
 		if (common_prefix_continuation_token.empty()) {
 			// we are done with the current common prefix
@@ -1544,14 +1545,14 @@ string AWSListObjectV2::Request(const string &path, HTTPParams &http_params, S3A
 		// Construct the ListObjectsV2 call
 		string req_path = parsed_url.path.substr(0, parsed_url.path.length() - parsed_url.key.length());
 
-		map<string,string> req_params;
+		map<string, string> req_params;
 		// NOTE: req_params needs to be sorted before passing to sigv4 code
 		if (!continuation_token.empty()) {
 			req_params["continuation-token"] = S3FileSystem::UrlEncode(continuation_token, true);
 		}
 
 		if (use_delimiter) {
-			req_params["delimiter"] ="%2F";
+			req_params["delimiter"] = "%2F";
 		}
 
 		req_params["encoding-type"] = "url";
@@ -1562,7 +1563,7 @@ string AWSListObjectV2::Request(const string &path, HTTPParams &http_params, S3A
 		req_params["prefix"] = S3FileSystem::UrlEncode(parsed_url.key, true);
 
 		string encoded_params = "";
-		for (const auto & p : req_params) {
+		for (const auto &p : req_params) {
 			encoded_params += p.first + "=" + p.second + "&";
 		}
 		if (!encoded_params.empty()) {

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1216,6 +1216,7 @@ static bool Match(vector<string>::const_iterator key, vector<string>::const_iter
 				}
 				key++;
 			}
+			if (!completed) return true;
 			return false;
 		}
 		if (!Glob(key->data(), key->length(), pattern->data(), pattern->length())) {

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1333,9 +1333,10 @@ bool S3GlobResult::ExpandNextPath() const {
 		if (!common_prefixes.empty()) {
 			throw InternalException("We have common prefixes but we are doing a top-level request");
 		}
+		const bool use_recursive_glob = !StringUtil::Contains(parsed_s3_url.key, "**");
 		// issue the main request
-		string response_str =
-		    AWSListObjectV2::Request(shared_path, *http_params, s3_auth_params, main_continuation_token, true);
+		string response_str = AWSListObjectV2::Request(shared_path, *http_params, s3_auth_params,
+		                                               main_continuation_token, use_recursive_glob);
 		main_continuation_token = AWSListObjectV2::ParseContinuationToken(response_str);
 		AWSListObjectV2::ParseFileList(response_str, s3_keys);
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1335,7 +1335,7 @@ bool S3GlobResult::ExpandNextPath() const {
 		}
 
 		Value value;
-		bool allow_s3_recursive_globbing;
+		bool allow_s3_recursive_globbing = true;
 		if (FileOpener::TryGetCurrentSetting(opener, "allow_s3_recursive_globbing", value)) {
 			allow_s3_recursive_globbing = value.GetValue<bool>();
 		}

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1219,16 +1219,14 @@ static bool Match(vector<string>::const_iterator key, vector<string>::const_iter
 			return false;
 		}
 		if (!Glob(key->data(), key->length(), pattern->data(), pattern->length())) {
+			//std::cout << *key << "\t" << *pattern << " are different\n";
 			return false;
 		}
 		key++;
 		pattern++;
 	}
-	if (*pattern == "**" && !completed) {
-		while (*pattern == "**") pattern++;
-		if (pattern == pattern_end) {
-			return true;
-		}
+	if (pattern != pattern_end && !completed) {
+		return true;
 	}
 	return key == key_end && pattern == pattern_end;
 }
@@ -1305,7 +1303,7 @@ bool S3GlobResult::ExpandNextPath() const {
                vector<string> key_splits = StringUtil::Split(current_common_prefix, "/");
                //pattern_splits.resize(key_splits.size());
                const bool is_match = Match(key_splits.begin(), key_splits.end(), pattern_splits.begin(), pattern_splits.end(), false);
-	//	std::cout << current_common_prefix << "\t" << parsed_s3_url.key << "\t" << (is_match ? "MATCH" : "no" )<< "\n";
+		//std::cout << current_common_prefix << "\t" << parsed_s3_url.key << "\t" << (is_match ? "MATCH" : "no" )<< "\n";
                if (is_match) {
                        auto prefix_res = AWSListObjectV2::Request(prefix_path, *http_params, s3_auth_params,
                                                                   common_prefix_continuation_token, true);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1299,7 +1299,7 @@ bool S3GlobResult::ExpandNextPath() const {
 		// we have common prefixes left to scan - perform the request
 		auto prefix_path = parsed_s3_url.prefix + parsed_s3_url.bucket + '/' + current_common_prefix;
 
-
+current_common_prefix = S3FileSystem::UrlDecode(current_common_prefix);
                vector<string> pattern_splits = StringUtil::Split(parsed_s3_url.key, "/");
                vector<string> key_splits = StringUtil::Split(current_common_prefix, "/");
                //pattern_splits.resize(key_splits.size());

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1336,7 +1336,7 @@ bool S3GlobResult::ExpandNextPath() const {
 
 		Value value;
 		bool allow_s3_recursive_globbing = true;
-		if (FileOpener::TryGetCurrentSetting(opener, "allow_s3_recursive_globbing", value)) {
+		if (FileOpener::TryGetCurrentSetting(opener, "s3_allow_recursive_globbing", value)) {
 			allow_s3_recursive_globbing = value.GetValue<bool>();
 		}
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -22,6 +22,7 @@
 #include "create_secret_functions.hpp"
 
 #include <iostream>
+#include <iostream>
 #include <thread>
 #ifdef EMSCRIPTEN
 #define SAME_THREAD_UPLOAD
@@ -1220,7 +1221,6 @@ static bool Match(vector<string>::const_iterator key, vector<string>::const_iter
 			return false;
 		}
 		if (!Glob(key->data(), key->length(), pattern->data(), pattern->length())) {
-			//std::cout << *key << "\t" << *pattern << " are different\n";
 			return false;
 		}
 		key++;
@@ -1304,14 +1304,15 @@ bool S3GlobResult::ExpandNextPath() const {
                vector<string> key_splits = StringUtil::Split(current_common_prefix, "/");
                //pattern_splits.resize(key_splits.size());
                const bool is_match = Match(key_splits.begin(), key_splits.end(), pattern_splits.begin(), pattern_splits.end(), false);
-		//std::cout << current_common_prefix << "\t" << parsed_s3_url.key << "\t" << (is_match ? "MATCH" : "no" )<< "\n";
                if (is_match) {
+	prefix_path = S3FileSystem::UrlDecode(prefix_path);
                        auto prefix_res = AWSListObjectV2::Request(prefix_path, *http_params, s3_auth_params,
                                                                   common_prefix_continuation_token, true);
 
                        AWSListObjectV2::ParseFileList(prefix_res, s3_keys);
                        auto more_prefixes = AWSListObjectV2::ParseCommonPrefix(prefix_res);
                        common_prefixes.insert(common_prefixes.end(), more_prefixes.begin(), more_prefixes.end());
+
                        common_prefix_continuation_token = AWSListObjectV2::ParseContinuationToken(prefix_res);
                }
 

--- a/test/sql/copy/csv/glob/read_csv_glob_s3.test
+++ b/test/sql/copy/csv/glob/read_csv_glob_s3.test
@@ -92,7 +92,7 @@ SELECT * FROM read_csv('s3://test-bucket/read_csv_glob_s3/glob/*/*.csv', auto_de
 
 # forcing string parsing works
 query I
-SELECT * FROM read_csv('s3://test-bucket/read_csv_glob_s3/glob/[aei]*/*.csv', columns=STRUCT_PACK(d := 'STRING')) ORDER BY 1
+SELECT * FROM read_csv('s3://test-bucket/read_csv_glob_s3/glob/[ai]*/*.csv', columns=STRUCT_PACK(d := 'STRING')) ORDER BY 1
 ----
 1
 2
@@ -108,7 +108,7 @@ SELECT * FROM read_csv('s3://test-bucket/read_csv_glob_s3/glob/[aei]*/*.csv', co
 3
 
 query II
-SELECT a, b LIKE '%a_.csv' FROM read_csv('s3://test-bucket/read_csv_glob_s3/glob/[aei]*/*.csv', columns=STRUCT_PACK(d := 'STRING'), filename=1) t(a,b) ORDER BY 1
+SELECT a, b LIKE '%a_.csv' FROM read_csv('s3://test-bucket/read_csv_glob_s3/glob/[ai]*/*.csv', columns=STRUCT_PACK(d := 'STRING'), filename=1) t(a,b) ORDER BY 1
 ----
 1	0
 2	0

--- a/test/sql/copy/parquet/parquet_glob_s3.test
+++ b/test/sql/copy/parquet/parquet_glob_s3.test
@@ -160,6 +160,18 @@ EXPLAIN ANALYZE SELECT COUNT(*) FROM 's3://test-bucket/parquet_glob_s3/g*/*.parq
 analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 0.*GET\: 6.*PUT\: 0.*\#POST\: 0.*
 
 statement ok
+SET allow_s3_recursive_globbing = false;
+
+# S3 glob gives us information necessary to skip HEAD requests
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM 's3://test-bucket/parquet_glob_s3/g*/*.parquet';
+----
+analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 0.*GET\: 4.*PUT\: 0.*\#POST\: 0.*
+
+statement ok
+SET allow_s3_recursive_globbing = true;
+
+statement ok
 SET VARIABLE file_list = (SELECT LIST(file) FROM GLOB('s3://test-bucket/parquet_glob_s3/g*/*.parquet'))
 
 # sanity check for request count

--- a/test/sql/copy/parquet/parquet_glob_s3.test
+++ b/test/sql/copy/parquet/parquet_glob_s3.test
@@ -160,7 +160,7 @@ EXPLAIN ANALYZE SELECT COUNT(*) FROM 's3://test-bucket/parquet_glob_s3/g*/*.parq
 analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 0.*GET\: 6.*PUT\: 0.*\#POST\: 0.*
 
 statement ok
-SET allow_s3_recursive_globbing = false;
+SET s3_allow_recursive_globbing = false;
 
 # S3 glob gives us information necessary to skip HEAD requests
 query II
@@ -169,7 +169,7 @@ EXPLAIN ANALYZE SELECT COUNT(*) FROM 's3://test-bucket/parquet_glob_s3/g*/*.parq
 analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 0.*GET\: 4.*PUT\: 0.*\#POST\: 0.*
 
 statement ok
-SET allow_s3_recursive_globbing = true;
+SET s3_allow_recursive_globbing = true;
 
 statement ok
 SET VARIABLE file_list = (SELECT LIST(file) FROM GLOB('s3://test-bucket/parquet_glob_s3/g*/*.parquet'))

--- a/test/sql/copy/parquet/parquet_glob_s3.test
+++ b/test/sql/copy/parquet/parquet_glob_s3.test
@@ -157,7 +157,7 @@ endloop
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM 's3://test-bucket/parquet_glob_s3/g*/*.parquet';
 ----
-analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 0.*GET\: 4.*PUT\: 0.*\#POST\: 0.*
+analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 0.*GET\: 6.*PUT\: 0.*\#POST\: 0.*
 
 statement ok
 SET VARIABLE file_list = (SELECT LIST(file) FROM GLOB('s3://test-bucket/parquet_glob_s3/g*/*.parquet'))

--- a/test/sql/copy/s3/glob_s3_paging.test_slow
+++ b/test/sql/copy/s3/glob_s3_paging.test_slow
@@ -108,7 +108,7 @@ FROM glob('s3://test-bucket/parquet_glob*/some-non-existent-folder');
 query I
 FROM duckdb_logs_parsed('http') SELECT count(request.url);
 ----
-6
+10
 
 # Begin tests
 query I

--- a/test/sql/copy/s3/glob_s3_paging.test_slow
+++ b/test/sql/copy/s3/glob_s3_paging.test_slow
@@ -61,6 +61,55 @@ endloop
 
 endloop
 
+statement ok
+SET allow_s3_recursive_globbing = false;
+
+statement ok
+CALL enable_logging('HTTP');
+
+query I
+FROM glob('s3://test-bucket/parquet_glob*/some-non-existent-folder');
+----
+
+
+query I
+FROM duckdb_logs_parsed('http') SELECT count(request.url);
+----
+5
+
+# first to /?encoding-type=url&list-type=2&prefix=parquet_glob
+# then next 5 via continuation
+
+statement ok
+SET allow_s3_recursive_globbing = true;
+
+statement ok
+CALL truncate_duckdb_logs();
+
+query I
+FROM glob('s3://test-bucket/parquet_glob*/some-non-existent-folder');
+----
+
+
+query I
+FROM duckdb_logs_parsed('http') SELECT count(request.url);
+----
+2
+
+# first to  /?encoding-type=url&list-type=2&prefix=parquet_glob (listing only at that level)
+# second to /?delimiter=%2F&encoding-type=url&list-type=2&prefix=parquet_glob_s3_paging%2F (to list one level up the subdirectories)
+
+statement ok
+CALL enable_logging('HTTP');
+
+statement ok
+FROM glob('s3://test-bucket/parquet_glob*/some-non-existent-folder');
+
+query I
+FROM duckdb_logs_parsed('http') SELECT count(request.url);
+----
+6
+
 # Begin tests
 query I
 select sum(column0) from 's3://test-bucket/parquet_glob_s3_paging/paging/t*-${urlstyle}-urls.${format}'

--- a/test/sql/copy/s3/glob_s3_paging.test_slow
+++ b/test/sql/copy/s3/glob_s3_paging.test_slow
@@ -67,6 +67,9 @@ SET allow_s3_recursive_globbing = false;
 statement ok
 CALL enable_logging('HTTP');
 
+statement ok
+CALL truncate_duckdb_logs();
+
 query I
 FROM glob('s3://test-bucket/parquet_glob*/some-non-existent-folder');
 ----
@@ -75,7 +78,7 @@ FROM glob('s3://test-bucket/parquet_glob*/some-non-existent-folder');
 query I
 FROM duckdb_logs_parsed('http') SELECT count(request.url);
 ----
-5
+6
 
 # first to /?encoding-type=url&list-type=2&prefix=parquet_glob
 # then next 5 via continuation
@@ -94,7 +97,7 @@ FROM glob('s3://test-bucket/parquet_glob*/some-non-existent-folder');
 query I
 FROM duckdb_logs_parsed('http') SELECT count(request.url);
 ----
-5
+2
 
 # first to  /?encoding-type=url&list-type=2&prefix=parquet_glob (listing only at that level)
 # second to /?delimiter=%2F&encoding-type=url&list-type=2&prefix=parquet_glob_s3_paging%2F (to list one level up the subdirectories)
@@ -103,12 +106,15 @@ statement ok
 CALL enable_logging('HTTP');
 
 statement ok
+CALL truncate_duckdb_logs();
+
+statement ok
 FROM glob('s3://test-bucket/parquet_glob*/some-non-existent-folder');
 
 query I
 FROM duckdb_logs_parsed('http') SELECT count(request.url);
 ----
-10
+2
 
 # Begin tests
 query I

--- a/test/sql/copy/s3/glob_s3_paging.test_slow
+++ b/test/sql/copy/s3/glob_s3_paging.test_slow
@@ -96,10 +96,10 @@ endloop
 statement ok
 CALL enable_logging('HTTP');
 
-foreach allow_s3_recursive_globs true false
+foreach s3_allow_recursive_globs true false
 
 statement ok
-SET allow_s3_recursive_globbing = ${allow_s3_recursive_globs}
+SET s3_allow_recursive_globbing = ${s3_allow_recursive_globs}
 
 query I
 SELECT count(*) FROM glob('s3://test-bucket/parquet_glob*/some-non-existent-folder/*');

--- a/test/sql/copy/s3/glob_s3_paging.test_slow
+++ b/test/sql/copy/s3/glob_s3_paging.test_slow
@@ -94,7 +94,7 @@ FROM glob('s3://test-bucket/parquet_glob*/some-non-existent-folder');
 query I
 FROM duckdb_logs_parsed('http') SELECT count(request.url);
 ----
-2
+5
 
 # first to  /?encoding-type=url&list-type=2&prefix=parquet_glob (listing only at that level)
 # second to /?delimiter=%2F&encoding-type=url&list-type=2&prefix=parquet_glob_s3_paging%2F (to list one level up the subdirectories)

--- a/test/sql/copy/s3/glob_s3_paging.test_slow
+++ b/test/sql/copy/s3/glob_s3_paging.test_slow
@@ -61,61 +61,6 @@ endloop
 
 endloop
 
-statement ok
-SET allow_s3_recursive_globbing = false;
-
-statement ok
-CALL enable_logging('HTTP');
-
-statement ok
-CALL truncate_duckdb_logs();
-
-query I
-FROM glob('s3://test-bucket/parquet_glob*/some-non-existent-folder');
-----
-
-
-query I
-FROM duckdb_logs_parsed('http') SELECT count(request.url);
-----
-6
-
-# first to /?encoding-type=url&list-type=2&prefix=parquet_glob
-# then next 5 via continuation
-
-statement ok
-SET allow_s3_recursive_globbing = true;
-
-statement ok
-CALL truncate_duckdb_logs();
-
-query I
-FROM glob('s3://test-bucket/parquet_glob*/some-non-existent-folder');
-----
-
-
-query I
-FROM duckdb_logs_parsed('http') SELECT count(request.url);
-----
-2
-
-# first to  /?encoding-type=url&list-type=2&prefix=parquet_glob (listing only at that level)
-# second to /?delimiter=%2F&encoding-type=url&list-type=2&prefix=parquet_glob_s3_paging%2F (to list one level up the subdirectories)
-
-statement ok
-CALL enable_logging('HTTP');
-
-statement ok
-CALL truncate_duckdb_logs();
-
-statement ok
-FROM glob('s3://test-bucket/parquet_glob*/some-non-existent-folder');
-
-query I
-FROM duckdb_logs_parsed('http') SELECT count(request.url);
-----
-2
-
 # Begin tests
 query I
 select sum(column0) from 's3://test-bucket/parquet_glob_s3_paging/paging/t*-${urlstyle}-urls.${format}'
@@ -147,3 +92,32 @@ endloop
 endloop
 
 endloop
+
+statement ok
+CALL enable_logging('HTTP');
+
+foreach allow_s3_recursive_globs true false
+
+statement ok
+SET allow_s3_recursive_globbing = ${allow_s3_recursive_globs}
+
+query I
+SELECT count(*) FROM glob('s3://test-bucket/parquet_glob*/some-non-existent-folder/*');
+----
+0
+
+query I
+SELECT count(*) FROM glob('s3://test-bucket/parquet_glob*/paging/*');
+----
+8000
+
+endloop
+
+query IIIII
+FROM (FROM duckdb_logs_parsed('HTTP') SELECT count(*), sum(request.type == 'HEAD') head, sum(request.type == 'GET') get, sum(request.type == 'POST') post, sum(request.type == 'PUT') put GROUP BY context_id ORDER BY context_id) WHERE post == 0;
+----
+5	0	5	0	0
+13	0	13	0	0
+11	0	11	0	0
+11	0	11	0	0
+

--- a/test/sql/copy/s3/glob_s3_recursive.test_slow
+++ b/test/sql/copy/s3/glob_s3_recursive.test_slow
@@ -114,8 +114,6 @@ FROM duckdb_logs_parsed('HTTP') SELECT count(*), sum(request.type == 'HEAD'), su
 1	0	1	0	0
 1	0	1	0	0
 
-mode unskip
-
 #
 # Querying with a ** glob have the same performances
 #

--- a/test/sql/copy/s3/glob_s3_recursive.test_slow
+++ b/test/sql/copy/s3/glob_s3_recursive.test_slow
@@ -9,6 +9,9 @@ require httpfs
 set ignore_error_messages
 
 statement ok
+CREATE SECRET coiled (TYPE s3, SCOPE 's3://coiled-datasets', endpoint 's3.amazonaws.com', key_id '', secret '');
+
+statement ok
 CALL enable_logging('HTTP');
 
 #

--- a/test/sql/copy/s3/glob_s3_recursive.test_slow
+++ b/test/sql/copy/s3/glob_s3_recursive.test_slow
@@ -9,7 +9,7 @@ require httpfs
 set ignore_error_messages
 
 statement ok
-CREATE SECRET coiled (TYPE s3, SCOPE 's3://coiled-datasets', endpoint 's3.amazonaws.com', key_id '', secret '');
+CREATE SECRET coiled (TYPE s3, SCOPE 's3://coiled-datasets', endpoint 's3.amazonaws.com', key_id '', secret '', region 'us-east-2');
 
 statement ok
 CALL enable_logging('HTTP');

--- a/test/sql/copy/s3/glob_s3_recursive.test_slow
+++ b/test/sql/copy/s3/glob_s3_recursive.test_slow
@@ -24,7 +24,7 @@ CALL truncate_duckdb_logs();
 foreach allow_globbing true false
 
 statement ok
-SET allow_s3_recursive_globbing = ${allow_globbing};
+SET s3_allow_recursive_globbing = ${allow_globbing};
 
 query I
 SELECT count(*) FROM glob('s3://coiled-datasets/timeseries/*s/non-existing-folder/*');
@@ -49,7 +49,7 @@ CALL truncate_duckdb_logs();
 foreach allow_globbing true false
 
 statement ok
-SET allow_s3_recursive_globbing = ${allow_globbing};
+SET s3_allow_recursive_globbing = ${allow_globbing};
 
 query I
 SELECT count(*) FROM glob('s3://coiled-datasets/timeseries/*s/parquet/*');
@@ -74,7 +74,7 @@ CALL truncate_duckdb_logs();
 foreach allow_globbing true false
 
 statement ok
-SET allow_s3_recursive_globbing = ${allow_globbing};
+SET s3_allow_recursive_globbing = ${allow_globbing};
 
 query I
 SELECT count(*) FROM (FROM glob('s3://coiled-datasets/timeseries/*s/parquet/*.parquet') LIMIT 100);
@@ -99,7 +99,7 @@ CALL truncate_duckdb_logs();
 foreach allow_globbing true false
 
 statement ok
-SET allow_s3_recursive_globbing = ${allow_globbing};
+SET s3_allow_recursive_globbing = ${allow_globbing};
 
 query I
 SELECT count(*) FROM glob('s3://coiled-datasets/timeseries/1990s/parquet/*');
@@ -124,7 +124,7 @@ CALL truncate_duckdb_logs();
 foreach allow_globbing true false
 
 statement ok
-SET allow_s3_recursive_globbing = ${allow_globbing};
+SET s3_allow_recursive_globbing = ${allow_globbing};
 
 query I
 SELECT count(*) FROM glob('s3://coiled-datasets/timeseries/1990s/**/*.parquet');

--- a/test/sql/copy/s3/glob_s3_recursive.test_slow
+++ b/test/sql/copy/s3/glob_s3_recursive.test_slow
@@ -1,0 +1,139 @@
+# name: test/sql/copy/s3/glob_s3_recursive.test_slow
+# description: Test globbing of a large number of parquet files to test the paging mechanism
+# group: [s3]
+
+require parquet
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+CALL enable_logging('HTTP');
+
+#
+# Querying non existent path (after a glob), should be fail fast
+#
+
+statement ok
+CALL truncate_duckdb_logs();
+
+foreach allow_globbing true false
+
+statement ok
+SET allow_s3_recursive_globbing = ${allow_globbing};
+
+query I
+SELECT count(*) FROM glob('s3://coiled-datasets/timeseries/*s/non-existing-folder/*');
+----
+0
+
+endloop
+
+query IIIII
+FROM duckdb_logs_parsed('HTTP') SELECT count(*), sum(request.type == 'HEAD'), sum(request.type == 'GET'), sum(request.type == 'POST'), sum(request.type == 'PUT') GROUP BY context_id ORDER BY context_id;
+----
+3	0	3	0	0
+46	0	46	0	0
+
+#
+# Querying a selective path (after a glob), should be fail faster
+#
+
+statement ok
+CALL truncate_duckdb_logs();
+
+foreach allow_globbing true false
+
+statement ok
+SET allow_s3_recursive_globbing = ${allow_globbing};
+
+query I
+SELECT count(*) FROM glob('s3://coiled-datasets/timeseries/*s/parquet/*');
+----
+1620
+
+endloop
+
+query IIIII
+FROM duckdb_logs_parsed('HTTP') SELECT count(*), sum(request.type == 'HEAD'), sum(request.type == 'GET'), sum(request.type == 'POST'), sum(request.type == 'PUT') GROUP BY context_id ORDER BY context_id;
+----
+6	0	6	0	0
+46	0	46	0	0
+
+#
+# Querying a selective path (after a glob) with a limit should be fail faster in both modes
+#
+
+statement ok
+CALL truncate_duckdb_logs();
+
+foreach allow_globbing true false
+
+statement ok
+SET allow_s3_recursive_globbing = ${allow_globbing};
+
+query I
+SELECT count(*) FROM (FROM glob('s3://coiled-datasets/timeseries/*s/parquet/*.parquet') LIMIT 100);
+----
+100
+
+endloop
+
+query IIIII
+FROM duckdb_logs_parsed('HTTP') SELECT count(*), sum(request.type == 'HEAD'), sum(request.type == 'GET'), sum(request.type == 'POST'), sum(request.type == 'PUT') GROUP BY context_id ORDER BY context_id;
+----
+3	0	3	0	0
+1	0	1	0	0
+
+#
+# Querying with a final glob should give same performances
+#
+
+statement ok
+CALL truncate_duckdb_logs();
+
+foreach allow_globbing true false
+
+statement ok
+SET allow_s3_recursive_globbing = ${allow_globbing};
+
+query I
+SELECT count(*) FROM glob('s3://coiled-datasets/timeseries/1990s/parquet/*');
+----
+523
+
+endloop
+
+query IIIII
+FROM duckdb_logs_parsed('HTTP') SELECT count(*), sum(request.type == 'HEAD'), sum(request.type == 'GET'), sum(request.type == 'POST'), sum(request.type == 'PUT') GROUP BY context_id ORDER BY context_id;
+----
+1	0	1	0	0
+1	0	1	0	0
+
+mode unskip
+
+#
+# Querying with a ** glob have the same performances
+#
+
+statement ok
+CALL truncate_duckdb_logs();
+
+foreach allow_globbing true false
+
+statement ok
+SET allow_s3_recursive_globbing = ${allow_globbing};
+
+query I
+SELECT count(*) FROM glob('s3://coiled-datasets/timeseries/1990s/**/*.parquet');
+----
+521
+
+endloop
+
+query IIIII
+FROM duckdb_logs_parsed('HTTP') SELECT count(*), sum(request.type == 'HEAD'), sum(request.type == 'GET'), sum(request.type == 'POST'), sum(request.type == 'PUT') GROUP BY context_id ORDER BY context_id;
+----
+2	0	2	0	0
+2	0	2	0	0

--- a/test/sql/copy/s3/starstar.test
+++ b/test/sql/copy/s3/starstar.test
@@ -126,14 +126,14 @@ FROM GLOB('s3://test-bucket/glob_ss/*/*/t0.csv');
 ----
 s3://test-bucket/glob_ss/a/b/t0.csv
 
-query I
+query I rowsort
 FROM GLOB('s3://test-bucket/glob_ss/**/t0.csv');
 ----
 s3://test-bucket/glob_ss/a/b/t0.csv
 s3://test-bucket/glob_ss/a/t0.csv
 s3://test-bucket/glob_ss/t0.csv
 
-query I
+query I rowsort
 FROM GLOB('s3://test-bucket/glob_ss/**/*/t0.csv');
 ----
 s3://test-bucket/glob_ss/a/b/t0.csv
@@ -143,27 +143,27 @@ query I
 FROM GLOB('s3://test-bucket/glob_ss/*/*/*/t0.csv');
 ----
 
-query I
+query I  rowsort
 FROM GLOB('s3://test-bucket/glob_ss/**');
 ----
 s3://test-bucket/glob_ss/a/b/t0.csv
 s3://test-bucket/glob_ss/a/t0.csv
 s3://test-bucket/glob_ss/t0.csv
 
-query I
+query I rowsort
 FROM GLOB('s3://test-bucket/glob_ss/**/*');
 ----
 s3://test-bucket/glob_ss/a/b/t0.csv
 s3://test-bucket/glob_ss/a/t0.csv
 s3://test-bucket/glob_ss/t0.csv
 
-query I
+query I rowsort
 FROM GLOB('s3://test-bucket/glob_ss/*/**');
 ----
 s3://test-bucket/glob_ss/a/b/t0.csv
 s3://test-bucket/glob_ss/a/t0.csv
 
-query I
+query I rowsort
 FROM GLOB('s3://test-bucket/glob_ss/a/**');
 ----
 s3://test-bucket/glob_ss/a/b/t0.csv
@@ -221,7 +221,7 @@ SELECT COUNT(*) FROM GLOB('s3://test-bucket/glob_ss/partitioned/**/*');
 ----
 10
 
-query I
+query I rowsort
 FROM GLOB('s3://test-bucket/glob_ss/partitioned/**/*.parquet');
 ----
 s3://test-bucket/glob_ss/partitioned/a=0/b=0/data_0.parquet


### PR DESCRIPTION
Test is:
```sql
CALL enable_logging('HTTP');
.timer on
FROM glob('s3://coiled-datasets/timeseries/*-years/parquet/*.parquet');
FROM duckdb_logs_parsed('HTTP') SELECT count(*);
```
that takes now about 2s and 4 requests (vs 42s and 46 requests, both main and v1.4-andium behaviour).

One can look at the difference via `FROM duckdb_logs_parsed('HTTP') SELECT request.url;` while toggling `SET allow_s3_recursive_globbing = false;`/`SET allow_s3_recursive_globbing = true;`:
```
│ /?encoding-type=url&list-type=2&prefix=timeseries%2F                                                                                                                                                                                         │
│ /?continuation-token=11e5rOWab38dy2uXgMSmx%2B8xAYGzeScEsqHifLHfxqNEbKLf7NiBeAbL38fFcRlk9sLuZlLf98zbkf2u0fYKO3HhyhwqXCgxU&encoding-type=url&list-type=2&prefix=timeseries%2F                                                                  │
│ /?continuation-token=1ag6ez2QkIXhAZgecXjczrkErG75B8loUGMlTuIhvt3Jt4FoBOKK1fKy3XDCA8TdqdSeRxv%2B7kMBUaeBfgEhdaw%3D%3D&encoding-type=url&list-type=2&prefix=timeseries%2F                                                                      │
│ /?continuation-token=1HSOEN%2FRH2Zc5pXJh6Jcx7GWiV9erWtkJrWSQmhnHceYuCDeVkDouFT86aH6vsrFQhORFDuwWaQxQVzhdDAY7dw%3D%3D&encoding-type=url&list-type=2&prefix=timeseries%2F                                                                      │
│ /?continuation-token=1SXO9x37RvK0%2FhCJE%2BbxPoBikpdmjd5%2FSXvCbq%2BZR2ESMnrk1B78qPkMoACmt%2BNtSP2Z5YYhnPXX8acYsVy7NMQ%3D%3D&encoding-type=url&list-type=2&prefix=timeseries%2F                                                              │
│ /?continuation-token=1ZkHF3sIKDud%2BIIEPsRksgRB2jpF6UMvDqpUf%2FgDL%2BsyoQfoBiG2kwgK0Y2IO0rYry4n%2FhtabJcxNrNVSeb8ATA%3D%3D&encoding-type=url&list-type=2&prefix=timeseries%2F                                                                │
│ /?continuation-token=1mj9qKmmG3HiFLDNSX9PEHrqj8fLr4SDMK55W%2Bvg%2BPyq24UMMZiVOR5Da8l3dmNDNosfPu2clm3M8n8LDu32OHg%3D%3D&encoding-type=url&list-type=2&prefix=timeseries%2F                                                                    │
│ /?continuation-token=1swIROhM2IyFW9SKfJLmF0xiT%2BhhguFNSj4O6wRSUbeie5NtMoCXhBVNGQXh6g4AeXo4hOv1wYf4PvtR2jdWiYQ%3D%3D&encoding-type=url&list-type=2&prefix=timeseries%2F                                                                      │
│ /?continuation-token=1qZxLDva9BngXXDKnFdjKyn06%2Fyhzv%2FqUkluNOVZl6n8n8CjwLXAZn8qwzAz6vQ%2FsE0vbmb%2Fckb4LfgOR6VVBjg%3D%3D&encoding-type=url&list-type=2&prefix=timeseries%2F                                                                │
│ /?continuation-token=13%2F6p41lFEClH%2FJkk7I2P5HZb2Oj7%2B9E0tLkSjixyFaEEemjiWHt%2FGow5hKpxYN0v4SjUoOCc9ZVqBsIS6BYeOQ%3D%3D&encoding-type=url&list-type=2&prefix=timeseries%2F                                                                │
.... more like this, all continuation happens at the level of the first glob
```
vs
```
│ /?delimiter=%2F&encoding-type=url&list-type=2&prefix=timeseries%2F                                                                                                                                             │
│ /?delimiter=%2F&encoding-type=url&list-type=2&prefix=timeseries%2F20-years%2F                                                                                                                                  │
│ /?delimiter=%2F&encoding-type=url&list-type=2&prefix=timeseries%2F20-years%2Fparquet%2F                                                                                                                        │
│ /?continuation-token=1EsJlUTGcNUrzxV5MykA9qEVBV03ndN0WG1uCUGhwxm2f1FG6cvnPOQdTltlhGgTalu5xggNk%2FJwl2ECbKppmtaYGHnrpgfHo&delimiter=%2F&encoding-type=url&list-type=2&prefix=timeseries%2F20-years%2Fparquet%2F │
```
where one can see the directories are scanned recursively (first `timeseries%2F` obtaining the next level of directories, then one level deeper at `timeseries%2F20-years%2F`, then at timeseries%2F20-years%2Fparquet%2F with a continuation call since there were more than a 1000 there).

This changes from basically listing anything with a common root, to listing by directory and recursively expanding (and matching accordingly).


This will worsen performances in structures where just listing it's faster then directory traversing, say a structure like:
```
1
└── 2
    └── 3
        └── 4
            └── 5
                └── 6
                    ├── file
                    ├── file2
                    └── file3

```
then 6 hops are required before finally listing at depth 6 (vs a single request given there are less than 1000 files).

This will worsen performance by a number of requests that's equal to the total number of nodes in the trees.

Worse case for current globbing methods are partitioned files, where there are many files per each directory, so the extra cost of walking the directories is limited, while the number of request will growth with the total number of files in the folder.

Approximate complexities are:
* recursive globbing: `O(number of internal directories on the path) + O(result set)`
* regular globbing: `O(total number of files matching the prefix)`

A more extreme example, in the first case, it's a query like:
```
FROM glob('s3://coiled-datasets/timeseries/*-years/i-do-not-exist/*.parquet');
```
where if `i-do-not-exist` is not there, 2 network trip are enough, vs the 46 fixed cost that it's still needed in any case in the other configuration.

I think having number of roundtrip bounded by result set it's better over the board, so I would propose that as default.