### PR TITLE
S3: Improve handling around regions, and improve S3 error display

### DIFF
--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -286,13 +286,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
 	    url, header_map, hfh.http_params,
 	    [&](const HTTPResponse &response) {
 		    if (static_cast<int>(response.status) >= 400) {
-			    string error =
-			        "HTTP GET error on '" + url + "' (HTTP " + to_string(static_cast<int>(response.status)) + ")";
-			    if (response.status == HTTPStatusCode::RangeNotSatisfiable_416) {
-				    error += " This could mean the file was changed. Try disabling the duckdb http metadata cache "
-				             "if enabled, and confirm the server supports range requests.";
-			    }
-			    throw HTTPException(response, error);
+			    throw GetHTTPError(handle, response, url);
 		    }
 		    if (static_cast<int>(response.status) < 300) { // done redirecting
 			    out_offset = 0;

--- a/src/include/http_metadata_cache.hpp
+++ b/src/include/http_metadata_cache.hpp
@@ -19,6 +19,7 @@ struct HTTPMetadataCacheEntry {
 	idx_t length;
 	timestamp_t last_modified;
 	string etag;
+	unordered_map<string, string> properties;
 };
 
 // Simple cache with a max age for an entry to be valid

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -129,6 +129,9 @@ protected:
 	//! TODO: make base function virtual?
 	void TryAddLogger(FileOpener &opener);
 
+	virtual void InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cache_entry);
+	virtual HTTPMetadataCacheEntry GetCacheEntry() const;
+
 public:
 	//! Fully downloads a file
 	void FullDownload(HTTPFileSystem &hfs, bool &should_write_cache);

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -256,6 +256,7 @@ public:
 	}
 
 	static string GetS3BadRequestError(const S3AuthParams &s3_auth_params, string correct_region = "");
+	static string ParseS3Error(const string &error);
 	static string GetS3AuthError(const S3AuthParams &s3_auth_params);
 	static string GetGCSAuthError(const S3AuthParams &s3_auth_params);
 	static HTTPException GetS3Error(const S3AuthParams &s3_auth_params, const HTTPResponse &response,

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -62,6 +62,7 @@ struct S3AuthParams {
 
 	static S3AuthParams ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info);
 	static S3AuthParams ReadFrom(S3KeyValueReader &secret_reader, const std::string &file_path);
+	void InitializeEndpoint();
 };
 
 struct AWSEnvironmentCredentialsProvider {
@@ -140,17 +141,7 @@ class S3FileHandle : public HTTPFileHandle {
 
 public:
 	S3FileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags, unique_ptr<HTTPParams> http_params_p,
-	             const S3AuthParams &auth_params_p, const S3ConfigParams &config_params_p)
-	    : HTTPFileHandle(fs, file, flags, std::move(http_params_p)), auth_params(auth_params_p),
-	      config_params(config_params_p), uploads_in_progress(0), parts_uploaded(0), upload_finalized(false),
-	      uploader_has_error(false), upload_exception(nullptr) {
-		auto_fallback_to_full_file_download = false;
-		if (flags.OpenForReading() && flags.OpenForWriting()) {
-			throw NotImplementedException("Cannot open an HTTP file for both reading and writing");
-		} else if (flags.OpenForAppending()) {
-			throw NotImplementedException("Cannot open an HTTP file for appending");
-		}
-	}
+	             const S3AuthParams &auth_params_p, const S3ConfigParams &config_params_p);
 	~S3FileHandle() override;
 
 	S3AuthParams auth_params;

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -62,6 +62,9 @@ struct S3AuthParams {
 
 	static S3AuthParams ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info);
 	static S3AuthParams ReadFrom(S3KeyValueReader &secret_reader, const std::string &file_path);
+	void SetRegion(string region_p);
+
+private:
 	void InitializeEndpoint();
 };
 
@@ -153,6 +156,10 @@ public:
 	void Initialize(optional_ptr<FileOpener> opener) override;
 
 	shared_ptr<S3WriteBuffer> GetBuffer(uint16_t write_buffer_idx);
+
+protected:
+	void InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cache_entry) override;
+	HTTPMetadataCacheEntry GetCacheEntry() const override;
 
 protected:
 	string multipart_upload_id;

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -289,7 +289,7 @@ protected:
 
 // Helper class to do s3 ListObjectV2 api call https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
 struct AWSListObjectV2 {
-	static string Request(const string &path, HTTPParams &http_params, const S3AuthParams &s3_auth_params,
+	static string Request(const string &path, HTTPParams &http_params, S3AuthParams &s3_auth_params,
 	                      string &continuation_token);
 	static void ParseFileList(string &aws_response, vector<OpenFileInfo> &result);
 	static vector<string> ParseCommonPrefix(string &aws_response);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -978,6 +978,11 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 		FileOpenerInfo info = {path};
 		auth_params = S3AuthParams::ReadFrom(opener, info);
 		if (!correct_region.empty()) {
+			DUCKDB_LOG_WARNING(
+			    logger,
+			    "Read S3 file \"%s\" from incorrect region \"%s\" - retrying with updated region \"%s\".\n"
+			    "Consider setting the S3 region to this explicitly to avoid extra round-trips.",
+			    path, auth_params.region, correct_region);
 			auth_params.SetRegion(std::move(correct_region));
 		}
 		HTTPFileHandle::Initialize(opener);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1411,6 +1411,11 @@ string AWSListObjectV2::Request(const string &path, HTTPParams &http_params, S3A
 		}
 	}
 	if (!updated_bucket_region.empty()) {
+		DUCKDB_LOG_WARNING(http_params.logger,
+		                   "Ran S3 glob \"%s\" from incorrect region \"%s\" - retrying with updated region \"%s\".\n"
+		                   "Consider setting the S3 region to this explicitly to avoid extra round-trips.",
+		                   path, s3_auth_params.region, updated_bucket_region);
+
 		// bucket region was updated - update and re-run the request against the correct endpoint
 		s3_auth_params.SetRegion(std::move(updated_bucket_region));
 		return AWSListObjectV2::Request(path, http_params, s3_auth_params, continuation_token);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -211,6 +211,12 @@ void S3AuthParams::InitializeEndpoint() {
 		return;
 	}
 	if (region.empty()) {
+		if (access_key_id.empty()) {
+			// no access key and no region - use legacy global endpoint
+			endpoint = "s3.amazonaws.com";
+			return;
+		}
+		// access key but no region - default to us-east-1
 		region = "us-east-1";
 	}
 	endpoint = StringUtil::Format("s3.%s.amazonaws.com", region);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -293,6 +293,12 @@ S3FileHandle::S3FileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFla
 	} else if (flags.OpenForAppending()) {
 		throw NotImplementedException("Cannot open an HTTP file for appending");
 	}
+	if (file.extended_info) {
+		auto entry = file.extended_info->options.find("s3_region");
+		if (entry != file.extended_info->options.end()) {
+			auth_params.SetRegion(entry->second.ToString());
+		}
+	}
 }
 
 S3FileHandle::~S3FileHandle() {
@@ -1223,6 +1229,9 @@ bool S3GlobResult::ExpandNextPath() const {
 				result_full_url += '?' + parsed_s3_url.query_param;
 			}
 			s3_key.path = std::move(result_full_url);
+			if (!s3_auth_params.region.empty()) {
+				s3_key.extended_info->options["s3_region"] = s3_auth_params.region;
+			}
 			expanded_files.push_back(std::move(s3_key));
 		}
 	}

--- a/test/sql/copy/s3/url_encode.test
+++ b/test/sql/copy/s3/url_encode.test
@@ -124,30 +124,3 @@ statement ok
 set s3_endpoint='${DUCKDB_S3_ENDPOINT}'
 
 endloop
-
-# Check that the generated urls are correct for an empty endpoint
-statement ok
-set s3_endpoint='';
-
-statement error
-SELECT * FROM 's3://test-bucket/whatever.parquet';
-----
-<REGEX>:.*HTTP Error: Unable to connect to URL .*http://test-bucket.s3.eu-west-1.amazonaws.com/whatever.parquet.*: 301 .Moved Permanently..*
-.*
-.*Bad Request - this can be caused by the S3 region being set incorrectly.*
-.*Provided region is: .eu-west-1.*
-.*Correct region is: .us-east-1.*
-
-statement error
-SELECT * FROM 'r2://test-bucket/whatever.parquet';
-----
-<REGEX>:.*HTTP Error: Unable to connect to URL .*http://test-bucket.s3.eu-west-1.amazonaws.com/whatever.parquet.*: 301 .Moved Permanently..*
-.*
-.*Bad Request - this can be caused by the S3 region being set incorrectly.*
-.*Provided region is: .eu-west-1.*
-.*Correct region is: .us-east-1.*
-
-statement error
-SELECT * FROM 'gcs://test-bucket/whatever.parquet';
-----
-HTTP GET error on 'http://storage.googleapis.com/test-bucket/whatever.parquet'

--- a/test/sql/s3/incorrect_s3_region.test_slow
+++ b/test/sql/s3/incorrect_s3_region.test_slow
@@ -4,8 +4,11 @@
 
 require httpfs
 
-# override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
-set ignore_error_messages
+# override MinIO setup
+statement ok
+SET s3_access_key_id='';
+SET s3_secret_access_key='';
+SET s3_endpoint='s3.amazonaws.com';
 
 statement ok
 set enable_logging=true;

--- a/test/sql/s3/incorrect_s3_region.test_slow
+++ b/test/sql/s3/incorrect_s3_region.test_slow
@@ -1,0 +1,29 @@
+# name: test/sql/s3/incorrect_s3_region.test_slow
+# description: Test globbing when the incorrect S3 region is specified
+# group: [httpfs]
+
+require httpfs
+
+# override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
+set ignore_error_messages
+
+statement ok
+set enable_logging=true;
+
+foreach s3_region us-east-1 us-west-2 us-west-2
+
+query I
+SELECT COUNT(*) FROM (FROM glob('s3://overturemaps-us-west-2/**/*.parquet') LIMIT 10);
+----
+10
+
+statement ok
+SET s3_region='${s3_region}'
+
+endloop
+
+# we should have a message signaling we're using the incorrect region
+query I
+SELECT COUNT(*) > 0 FROM duckdb_logs WHERE 'incorrect region' IN message;
+----
+true

--- a/test/sql/s3/incorrect_s3_region.test_slow
+++ b/test/sql/s3/incorrect_s3_region.test_slow
@@ -1,6 +1,6 @@
 # name: test/sql/s3/incorrect_s3_region.test_slow
 # description: Test globbing when the incorrect S3 region is specified
-# group: [httpfs]
+# group: [s3]
 
 require httpfs
 


### PR DESCRIPTION

Currently the S3 region handling, especially when using authentication, is confusing:

* Users can provide authentication without a region
* We default to no region
* In AWS, it is not possible to use authentication without a specified region

This provides the situation where adding authentication can break querying S3 buckets, even public buckets that were accessible without authentication.

For example, we can query this public dataset:
```sql
FROM 's3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet' limit 5;
┌───────┬──────────┬──────────────────────┬──────────────────────┬─────────────────────┐
│  id   │   name   │          x           │          y           │      timestamp      │
│ int64 │ varchar  │        double        │        double        │      timestamp      │
├───────┼──────────┼──────────────────────┼──────────────────────┼─────────────────────┤
│  1008 │ Dan      │  -0.2593739064966327 │ -0.11831401276595055 │ 2000-01-01 00:00:00 │
│   987 │ Patricia │  0.06960070748839864 │   0.7553510282326446 │ 2000-01-01 00:00:01 │
│   980 │ Zelda    │ -0.28184273582036146 │  -0.5105072002053843 │ 2000-01-01 00:00:02 │
│  1020 │ Ursula   │  -0.5699035745358587 │   0.5231316337340712 │ 2000-01-01 00:00:03 │
│   967 │ Michael  │  -0.2514604896781125 │   0.8109300499654029 │ 2000-01-01 00:00:04 │
└───────┴──────────┴──────────────────────┴──────────────────────┴─────────────────────┘
```

Now we provide a secret without a region:
```sql
CREATE OR REPLACE PERSISTENT SECRET secret (
      TYPE s3,
      PROVIDER config,
      KEY_ID '....',
      SECRET '....'
  );
FROM 's3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet' limit 5;
```
Now the same request fails:
```
HTTP Error:
HTTP GET error on 'https://coiled-datasets.s3.amazonaws.com/timeseries/20-years/parquet/part.0.parquet' (HTTP 400)

Bad Request - this can be caused by the S3 region being set incorrectly.
* No region is provided.
```

Inspecting the underlying S3 error, we get this:

```
AuthorizationHeaderMalformed: The authorization header is malformed; a non-empty region must be provided in the credential.
```

The error is helpful, so we provide a region. We don't know where this random dataset is hosted, so we just choose one:

```sql
set s3_region='us-east-1';
FROM 's3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet' limit 5;
```
```
HTTP Error:
Unable to connect to URL "https://coiled-datasets.s3.us-east-1.amazonaws.com/timeseries/20-years/parquet/part.0.parquet": 301 (Moved Permanently).

Bad Request - this can be caused by the S3 region being set incorrectly.
* Provided region is: "us-east-1"
* Correct region is: "us-east-2"
```

Helpfully, this tells us the correct region, so we can fix it, and now we can query it again:

```sql
set s3_region='us-east-2';
FROM 's3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet' limit 5;
┌───────┬──────────┬──────────────────────┬──────────────────────┬─────────────────────┐
│  id   │   name   │          x           │          y           │      timestamp      │
│ int64 │ varchar  │        double        │        double        │      timestamp      │
├───────┼──────────┼──────────────────────┼──────────────────────┼─────────────────────┤
│  1008 │ Dan      │  -0.2593739064966327 │ -0.11831401276595055 │ 2000-01-01 00:00:00 │
│   987 │ Patricia │  0.06960070748839864 │   0.7553510282326446 │ 2000-01-01 00:00:01 │
│   980 │ Zelda    │ -0.28184273582036146 │  -0.5105072002053843 │ 2000-01-01 00:00:02 │
│  1020 │ Ursula   │  -0.5699035745358587 │   0.5231316337340712 │ 2000-01-01 00:00:03 │
│   967 │ Michael  │  -0.2514604896781125 │   0.8109300499654029 │ 2000-01-01 00:00:04 │
└───────┴──────────┴──────────────────────┴──────────────────────┴─────────────────────┘
```

But these were a lot of manual steps to query a file we used to just be able to query prior to providing credentials.

### Automatic Region Forwarding

This PR resolves this by doing the following:

* When authentication data is provided, but no region is provided, we default to `us-east-1`
* When we receive information about the correct region, instead of throwing an error we retry with that region, and log a warning.

This now gives us the following behavior after registering credentials:

```sql
memory D FROM 's3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet' limit 5;
WARNING:
Read S3 file "s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet" from incorrect region "us-east-1" - retrying with updated region "us-east-2".
Consider setting the S3 region to this explicitly to avoid extra round-trips.

┌───────┬──────────┬──────────────────────┬──────────────────────┬─────────────────────┐
│  id   │   name   │          x           │          y           │      timestamp      │
│ int64 │ varchar  │        double        │        double        │      timestamp      │
├───────┼──────────┼──────────────────────┼──────────────────────┼─────────────────────┤
│  1008 │ Dan      │  -0.2593739064966327 │ -0.11831401276595055 │ 2000-01-01 00:00:00 │
│   987 │ Patricia │  0.06960070748839864 │   0.7553510282326446 │ 2000-01-01 00:00:01 │
│   980 │ Zelda    │ -0.28184273582036146 │  -0.5105072002053843 │ 2000-01-01 00:00:02 │
│  1020 │ Ursula   │  -0.5699035745358587 │   0.5231316337340712 │ 2000-01-01 00:00:03 │
│   967 │ Michael  │  -0.2514604896781125 │   0.8109300499654029 │ 2000-01-01 00:00:04 │
└───────┴──────────┴──────────────────────┴──────────────────────┴─────────────────────┘
```

This is still not amazing since adding credentials now results in a warning being triggered, but it is a lot better than before as we can continue operating on the dataset without change. We could also choose not to print this warning but I think it's probably a good idea as otherwise we're just silently doing more round-trips. We probably want to add a flag to disable the warning going forward.

### HTTP Metadata Cache

The `HTTPMetadataCacheEntry` is extended to also contain the `s3_region` for the file. As a result, we only hit this redirect once per query. If HTTP metadata caching is enabled (`SET enable_http_metadata_cache=true;`), we will only hit it once per file per setting. 

We could consider having a separate cache for S3 bucket regions - given that S3 bucket regions are much more stable than files (i.e. a user might overwrite a file - but I don't think it's possible for an S3 bucket to change region).

### Globbing and `FileOpenInfo`

When we glob, we also get a similar redirect response from AWS. Since globbing always targets a single bucket, we now know not just where to glob, but also the region to use for all of the files in the bucket. Instead of triggering a redirect for every file, the glob will now insert the S3 region into the `FileOpenInfo` which is then used to read the actual files. We will thus only hit a single redirect per glob executed.

### S3 Errors

When S3 responds with an error code, it sends us [an XML in the body detailing the error further](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html). We previously ignored this error. This PR adds code to instead parse the error and show the `Code` and `Message`. This can help users understand why certain requests fail versus the more opaque "error 403". 