### PR TITLE
CURL glob error message - Option 3

### DIFF
--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -115,7 +115,7 @@ static idx_t httpfs_client_count = 0;
 class HTTPFSCurlClient : public HTTPClient {
 public:
 	HTTPFSCurlClient(HTTPFSParams &http_params, const string &proto_host_port) {
-		// FIXME: proto_host_port is not used
+		proto_host = proto_host_port;
 		Initialize(http_params);
 	}
 	void Initialize(HTTPParams &http_p) override {
@@ -198,6 +198,10 @@ public:
 
 		auto curl_headers = TransformHeadersCurl(info.headers, info.params);
 		request_info->url = info.url;
+		if (StringUtil::StartsWith(info.url, proto_host))
+			request_info->url = info.url;
+		else
+			request_info->url = proto_host + info.url;
 
 		CURLcode res;
 		{
@@ -250,6 +254,10 @@ public:
 		curl_headers.Add("Content-Type: " + info.content_type);
 		// transform parameters
 		request_info->url = info.url;
+		if (StringUtil::StartsWith(info.url, proto_host))
+			request_info->url = info.url;
+		else
+			request_info->url = proto_host + info.url;
 
 		CURLcode res;
 		{
@@ -280,6 +288,10 @@ public:
 
 		auto curl_headers = TransformHeadersCurl(info.headers, info.params);
 		request_info->url = info.url;
+		if (StringUtil::StartsWith(info.url, proto_host))
+			request_info->url = info.url;
+		else
+			request_info->url = proto_host + info.url;
 		// transform parameters
 
 		CURLcode res;
@@ -312,6 +324,10 @@ public:
 		auto curl_headers = TransformHeadersCurl(info.headers, info.params);
 		// transform parameters
 		request_info->url = info.url;
+		if (StringUtil::StartsWith(info.url, proto_host))
+			request_info->url = info.url;
+		else
+			request_info->url = proto_host + info.url;
 
 		CURLcode res;
 		{
@@ -349,6 +365,10 @@ public:
 		curl_headers.Add(content_type.c_str());
 		// transform parameters
 		request_info->url = info.url;
+		if (StringUtil::StartsWith(info.url, proto_host))
+			request_info->url = info.url;
+		else
+			request_info->url = proto_host + info.url;
 
 		CURLcode res;
 		{
@@ -435,6 +455,7 @@ private:
 	unique_ptr<CURLHandle> curl;
 	optional_ptr<HTTPState> state;
 	unique_ptr<RequestInfo> request_info;
+	string proto_host;
 
 	static std::mutex &GetRefLock() {
 		static std::mutex mtx;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1241,7 +1241,7 @@ string AWSListObjectV2::Request(string &path, HTTPParams &http_params, S3AuthPar
 
 	// Get requests use fresh connection
 	string full_host = parsed_url.http_proto + parsed_url.host;
-	string listobjectv2_url = full_host + req_path + "?" + req_params;
+	string listobjectv2_url = req_path + "?" + req_params;
 	std::stringstream response;
 	GetRequestInfo get_request(
 	    full_host, listobjectv2_url, header_map, http_params,

--- a/test/sql/httpfs/check_glob_error_message.test
+++ b/test/sql/httpfs/check_glob_error_message.test
@@ -1,0 +1,12 @@
+# name: test/sql/httpfs/check_glob_error_message.test
+# description: 
+# group: [httpfs]
+
+require httpfs
+
+require parquet
+
+statement error
+FROM 's3://coiled-datasets/timeseries/20-years/parquet/1*.parquet'
+----
+<REGEX>:.*IO Error.*


### PR DESCRIPTION
~~The third option for fixing the [glob error message issue](https://github.com/duckdblabs/duckdb-internal/issues/7211).
We use `proto_host_port` to address the TODO that was left there. Before doing a request we check whether the url is a full url or just the path. In the latter case we add the `proto_host`.~~

Edit: Nothing to see here 😄 , wrong target. I meant to do it on my branch