### PR TITLE
CURL: Refactor the client to better use the curl API for constructing URLs

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1433,7 +1433,7 @@ string AWSListObjectV2::Request(const string &path, HTTPParams &http_params, S3A
 
 		// Get requests use fresh connection
 		string full_host = parsed_url.http_proto + parsed_url.host;
-		string listobjectv2_url = full_host + req_path + "?" + req_params;
+		string listobjectv2_url = req_path + "?" + req_params;
 		std::stringstream response;
 		ErrorData error;
 		GetRequestInfo get_request(

--- a/test/sql/httpfs/check_glob_error_message.test
+++ b/test/sql/httpfs/check_glob_error_message.test
@@ -1,0 +1,12 @@
+# name: test/sql/httpfs/check_glob_error_message.test
+# description: check error message consistency between curl and httplib
+# group: [httpfs]
+
+require httpfs
+
+require parquet
+
+statement error
+FROM 's3://coiled-datasets/timeseries/20-years/parquet/1*.parquet'
+----
+<REGEX>:.*IO Error.*


### PR DESCRIPTION
This PR refactors the `curl` client to make url handling cleaner and more consistent to `httplib` client implementation.

First, it addresses a TODO by actually using `proto_host_port`. This value is now used to construct a base URL via libcurl’s API, which fixes issues caused by incomplete or incorrectly assembled URLs (e.g. https://github.com/duckdblabs/duckdb-internal/issues/6041)

Second, the code is now more “curl-ified.” URL construction and manipulation are delegated to the library instead of relying on our own functions. As part of this, the custom `EncodeSpaces` helper is removed. When setting URLs via `curl_url_set()` (using `CURLUPART_URL` or `CURLUPART_PATH`), the library correctly handles URL encoding internally, making the manual encoding unnecessary. 

Also, fixes issues in error messages (e.g. https://github.com/duckdblabs/duckdb-internal/issues/7211)