### PR TITLE
CURL: Use CA cert file when available

### DIFF
--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -130,7 +130,14 @@ public:
 		// call curl_global_init if not already done by another HTTPFS Client
 		InitCurlGlobal();
 
-		curl = make_uniq<CURLHandle>(bearer_token, SelectCURLCertPath());
+		std::string cert_file_path;
+		if (!http_params.ca_cert_file.empty()) {
+			cert_file_path = http_params.ca_cert_file;
+		} else {
+			cert_file_path = SelectCURLCertPath();
+		}
+
+		curl = make_uniq<CURLHandle>(bearer_token, cert_file_path);
 		request_info = make_uniq<RequestInfo>();
 
 		// set curl options

--- a/test/sql/httpfs/ca_cert_file.test
+++ b/test/sql/httpfs/ca_cert_file.test
@@ -1,0 +1,16 @@
+# name: test/sql/httpfs/ca_cert_file.test
+# description: Test that invalid ca_cert_file causes SSL connection to fail
+# group: [httpfs]
+
+require httpfs
+
+statement ok
+SET enable_server_cert_verification = true;
+
+statement ok
+SET ca_cert_file = 'README.md';
+
+statement error
+FROM read_blob('https://duckdb.org/')
+----
+<REGEX>:.*IO Error.*SSL.*


### PR DESCRIPTION
Basically what the title says.

Fixes: https://github.com/duckdblabs/duckdb-internal/issues/7232