### PR TITLE
Add URL basic auth support (user:pass@host)

### DIFF
--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -941,7 +941,15 @@ unique_ptr<HTTPClient> HTTPFileHandle::CreateClient() {
 	// Create a new client
 	string path_out, proto_host_port;
 	HTTPUtil::DecomposeURL(path, path_out, proto_host_port);
-	return http_params.http_util.InitializeClient(http_params, proto_host_port);
+
+	// Parse basic auth credentials from URL if present (user:pass@host format)
+	string basic_auth_username, basic_auth_password;
+	HTTPFSUtil::ParseBasicAuth(path, basic_auth_username, basic_auth_password);
+
+	// Use HTTPFSUtil to create client with basic auth support
+	auto &httpfs_util = static_cast<HTTPFSUtil &>(http_params.http_util);
+	return httpfs_util.InitializeClientWithAuth(http_params, proto_host_port, basic_auth_username,
+	                                            basic_auth_password);
 }
 
 void HTTPFileHandle::StoreClient(unique_ptr<HTTPClient> client) {

--- a/src/httpfs_httplib_client.cpp
+++ b/src/httpfs_httplib_client.cpp
@@ -7,8 +7,12 @@ namespace duckdb {
 
 class HTTPFSClient : public HTTPClient {
 public:
-	HTTPFSClient(HTTPFSParams &http_params, const string &proto_host_port) {
+	HTTPFSClient(HTTPFSParams &http_params, const string &proto_host_port,
+	             const string &basic_auth_username, const string &basic_auth_password) {
 		client = make_uniq<duckdb_httplib_openssl::Client>(proto_host_port);
+		if (!basic_auth_username.empty() || !basic_auth_password.empty()) {
+			client->set_basic_auth(basic_auth_username, basic_auth_password);
+		}
 		Initialize(http_params);
 	}
 	void Initialize(HTTPParams &http_p) override {
@@ -162,8 +166,53 @@ private:
 };
 
 unique_ptr<HTTPClient> HTTPFSUtil::InitializeClient(HTTPParams &http_params, const string &proto_host_port) {
-	auto client = make_uniq<HTTPFSClient>(http_params.Cast<HTTPFSParams>(), proto_host_port);
+	auto client = make_uniq<HTTPFSClient>(http_params.Cast<HTTPFSParams>(), proto_host_port, "", "");
 	return std::move(client);
+}
+
+unique_ptr<HTTPClient> HTTPFSUtil::InitializeClientWithAuth(HTTPParams &http_params, const string &proto_host_port,
+                                                            const string &basic_auth_username,
+                                                            const string &basic_auth_password) {
+	auto client = make_uniq<HTTPFSClient>(http_params.Cast<HTTPFSParams>(), proto_host_port,
+	                                      basic_auth_username, basic_auth_password);
+	return std::move(client);
+}
+
+void HTTPFSUtil::ParseBasicAuth(const string &url, string &username_out, string &password_out) {
+	username_out.clear();
+	password_out.clear();
+
+	// Find the scheme end (://)
+	auto scheme_end = url.find("://");
+	if (scheme_end == string::npos) {
+		return;
+	}
+
+	// Find the path start
+	auto path_start = url.find('/', scheme_end + 3);
+	if (path_start == string::npos) {
+		path_start = url.length();
+	}
+
+	// Extract the authority part (between scheme:// and path)
+	string authority = url.substr(scheme_end + 3, path_start - scheme_end - 3);
+
+	// Check for @ which indicates userinfo
+	auto at_pos = authority.find('@');
+	if (at_pos == string::npos) {
+		return;
+	}
+
+	string userinfo = authority.substr(0, at_pos);
+
+	// Parse username:password
+	auto colon_pos = userinfo.find(':');
+	if (colon_pos != string::npos) {
+		username_out = userinfo.substr(0, colon_pos);
+		password_out = userinfo.substr(colon_pos + 1);
+	} else {
+		username_out = userinfo;
+	}
 }
 
 unordered_map<string, string> HTTPFSUtil::ParseGetParameters(const string &text) {

--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -39,8 +39,16 @@ public:
 	                                            optional_ptr<FileOpenerInfo> info) override;
 	unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
 
+	//! Initialize client with explicit basic auth credentials
+	unique_ptr<HTTPClient> InitializeClientWithAuth(HTTPParams &http_params, const string &proto_host_port,
+	                                                const string &basic_auth_username,
+	                                                const string &basic_auth_password);
+
 	static unordered_map<string, string> ParseGetParameters(const string &text);
 	static shared_ptr<HTTPUtil> GetHTTPUtil(optional_ptr<FileOpener> opener);
+
+	//! Parse basic auth credentials from URL (user:pass@host format)
+	static void ParseBasicAuth(const string &url, string &username_out, string &password_out);
 
 	string GetName() const override;
 };
@@ -48,6 +56,11 @@ public:
 class HTTPFSCurlUtil : public HTTPFSUtil {
 public:
 	unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
+
+	//! Initialize client with explicit basic auth credentials
+	unique_ptr<HTTPClient> InitializeClientWithAuth(HTTPParams &http_params, const string &proto_host_port,
+	                                                const string &basic_auth_username,
+	                                                const string &basic_auth_password);
 
 	static unordered_map<string, string> ParseGetParameters(const string &text);
 

--- a/test/sql/httpfs/url_basic_auth.test
+++ b/test/sql/httpfs/url_basic_auth.test
@@ -1,0 +1,38 @@
+# name: test/sql/httpfs/url_basic_auth.test
+# description: Test URL embedded basic auth (user:pass@host)
+# group: [httpfs]
+
+require httpfs
+
+statement ok
+PRAGMA enable_verification
+
+# Test with correct credentials - should return authenticated: true
+query I
+SELECT content LIKE '%"authenticated": true%' FROM read_text('https://testuser:testpass@httpbin.org/basic-auth/testuser/testpass')
+----
+true
+
+# Test with wrong password - should fail with HTTP 401
+statement error
+SELECT * FROM read_text('https://testuser:wrongpass@httpbin.org/basic-auth/testuser/testpass')
+----
+401
+
+# Test with no credentials - should fail with HTTP 401
+statement error
+SELECT * FROM read_text('https://httpbin.org/basic-auth/testuser/testpass')
+----
+401
+
+# Test with blank password (user:@host) - should fail with HTTP 401
+statement error
+SELECT * FROM read_text('https://testuser:@httpbin.org/basic-auth/testuser/testpass')
+----
+401
+
+# Test HTTP (non-SSL) variant
+query I
+SELECT content LIKE '%"authenticated": true%' FROM read_text('http://testuser:testpass@httpbin.org/basic-auth/testuser/testpass')
+----
+true


### PR DESCRIPTION
Adds support for embedding basic auth credentials directly in HTTP URLs using the standard user:password@host format.

Features:
- New ParseBasicAuth() helper to extract credentials from URLs
- New InitializeClientWithAuth() method for clients with credentials
- Both httplib and curl clients support basic auth
- Credentials are stripped from the URL before making requests

Example usage:
SELECT * FROM read_text('https://user:pass@example.com/protected')