### PR TITLE
Add test for instantiating persistent secrets in parallel

### DIFF
--- a/test/sql/secrets/create_secret_minio.test
+++ b/test/sql/secrets/create_secret_minio.test
@@ -76,3 +76,28 @@ copy (select 1 as a) to 's3://test-bucket/only-this-file-gets-auth.parquet'
 statement error
 copy (select 1 as a) to 's3://test-bucket/no-auth-here.parquet'
 ----
+
+# start reading persistent secrets concurrently
+loop z 0 100
+
+restart
+
+statement ok
+set s3_access_key_id='';
+
+statement ok
+set s3_secret_access_key='';
+
+statement ok
+set secret_directory='__TEST_DIR__/create_secret_minio'
+
+concurrentloop i 0 10
+
+query I
+FROM 's3://test-bucket/only-this-file-gets-auth.parquet'
+----
+1
+
+endloop
+
+endloop


### PR DESCRIPTION
Add test for https://github.com/duckdb/duckdb-httpfs/issues/169

Actual fix is upstream - https://github.com/duckdb/duckdb/pull/20686