### PR TITLE
[minor] Fix compilation warning

### DIFF
--- a/src/httpfs_httplib_client.cpp
+++ b/src/httpfs_httplib_client.cpp
@@ -115,7 +115,7 @@ public:
 		auto transformed_req = TransformResult(client->send(req));
 		// Then, after actual re-quest, re-assign body to the response value of the POST request
 		transformed_req->body.assign(const_char_ptr_cast(info.buffer_in), info.buffer_in_len);
-		return std::move(transformed_req);
+		return transformed_req;
 	}
 
 private:


### PR DESCRIPTION
I get the following compilation warning on build.
```sh
/home/vscode/duckdb/build/debug/_deps/httpfs_extension_fc-src/src/httpfs_httplib_client.cpp: In member function ‘virtual duckdb::unique_ptr<duckdb::HTTPResponse> duckdb::HTTPFSClient::Post(duckdb::PostRequestInfo&)’:
/home/vscode/duckdb/build/debug/_deps/httpfs_extension_fc-src/src/httpfs_httplib_client.cpp:118:33: warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
  118 |                 return std::move(transformed_req);
      |                        ~~~~~~~~~^~~~~~~~~~~~~~~~~
```