### PR TITLE
HTTPClient caching across FileHandles

### DIFF
--- a/src/hffs.cpp
+++ b/src/hffs.cpp
@@ -44,8 +44,8 @@ static string ParseNextUrlFromLinkHeader(const string &link_header_content) {
 
 HFFileHandle::~HFFileHandle() {};
 
-unique_ptr<HTTPClient> HFFileHandle::CreateClient() {
-	return http_params.http_util.InitializeClient(http_params, parsed_url.endpoint);
+string HFFileHandle::BaseUrl() const {
+	return parsed_url.endpoint;
 }
 
 string HuggingFaceFileSystem::ListHFRequest(ParsedHFUrl &url, HTTPFSParams &http_params, string &next_page_url,

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -395,10 +395,11 @@ HTTPFileHandle::HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpe
 }
 
 shared_ptr<HTTPClientCache> HTTPFileSystem::GetOrCreateClientCache(const string &path) {
-	lock_guard<mutex> lock(client_cache_map_lock);
-
 	string path_out, proto_host_port;
 	HTTPUtil::DecomposeURL(path, path_out, proto_host_port);
+
+	lock_guard<mutex> lock(client_cache_map_lock);
+	std::cout << proto_host_port << "\n";
 	if (client_cache_map.count(proto_host_port) == 0) {
 		client_cache_map[proto_host_port] = make_uniq<HTTPClientCache>();
 	}
@@ -432,7 +433,11 @@ unique_ptr<HTTPFileHandle> HTTPFileSystem::CreateHandle(const OpenFileInfo &file
 		}
 	}
 	auto handle = duckdb::make_uniq<HTTPFileHandle>(*this, file, flags, std::move(params));
-	handle->InitializeClientCache(*this);
+	if (handle) {
+		handle->InitializeClientCache(*this);
+	} else {
+		throw IOException("AAAA");
+	}
 	return handle;
 }
 

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -407,13 +407,12 @@ shared_ptr<HTTPClientCache> HTTPFileSystem::GetOrCreateClientCache(const string 
 	string identifier = path + " " + options.ToString();
 
 	lock_guard<mutex> lock(client_cache_map_lock);
-	std::cout << identifier << "\n";
 
 	auto retrived = lru_client_cache.Get(identifier);
 
 	if (!retrived) {
 		auto client_cache = make_shared_ptr<HTTPClientCache>();
-		lru_client_cache.Put(path, client_cache);
+		lru_client_cache.Put(identifier, client_cache);
 		return std::move(client_cache);
 	}
 

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -394,8 +394,12 @@ HTTPFileHandle::HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpe
 	}
 }
 
+shared_ptr<HTTPClientCache> HTTPFileSystem::GetOrCreateClientCache(const string &path) {
+	return make_uniq<HTTPClientCache>();
+}
+
 void HTTPFileHandle::InitializeClientCache(HTTPFileSystem &file_system) {
-	client_cache = make_uniq<HTTPClientCache>();
+	client_cache = file_system.GetOrCreateClientCache(path);
 }
 
 unique_ptr<HTTPFileHandle> HTTPFileSystem::CreateHandle(const OpenFileInfo &file, FileOpenFlags flags,

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -465,7 +465,6 @@ void HTTPFileSystem::FinalizeHandleCreate(unique_ptr<HTTPFileHandle> &handle, op
 }
 
 void HTTPFileSystem::FinalizeHandleCreate(HTTPFileHandle &handle, optional_ptr<FileOpener> opener) {
-	handle.http_params.state = nullptr;
 	ClientOptions options(handle);
 	if (!handle.client_cache) {
 		handle.InitializeClientCache(*this, options);

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -24,14 +24,14 @@
 
 namespace duckdb {
 
-	ClientOptions::ClientOptions(HTTPFileHandle &handle) {
-		identifier = "";
-		identifier += handle.params->http_proxy + " ";
-		identifier += handle.params->http_proxy_username + " ";
-		identifier += handle.params->http_proxy_password + " ";
-		//identifier += handle.params->http_proxy_port + " ";
-		identifier += handle.params->http_util.GetName();
-	}
+ClientOptions::ClientOptions(HTTPFileHandle &handle) {
+	identifier = "";
+	identifier += handle.params->http_proxy + " ";
+	identifier += handle.params->http_proxy_username + " ";
+	identifier += handle.params->http_proxy_password + " ";
+	// identifier += handle.params->http_proxy_port + " ";
+	identifier += handle.params->http_util.GetName();
+}
 
 shared_ptr<HTTPUtil> HTTPFSUtil::GetHTTPUtil(optional_ptr<FileOpener> opener) {
 	if (opener) {

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -395,7 +395,15 @@ HTTPFileHandle::HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpe
 }
 
 shared_ptr<HTTPClientCache> HTTPFileSystem::GetOrCreateClientCache(const string &path) {
-	return make_uniq<HTTPClientCache>();
+	lock_guard<mutex> lock(client_cache_map_lock);
+
+	string path_out, proto_host_port;
+	HTTPUtil::DecomposeURL(path, path_out, proto_host_port);
+	if (client_cache_map.count(proto_host_port) == 0) {
+		client_cache_map[proto_host_port] = make_uniq<HTTPClientCache>();
+	}
+
+	return client_cache_map[proto_host_port];
 }
 
 void HTTPFileHandle::InitializeClientCache(HTTPFileSystem &file_system) {

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -113,6 +113,9 @@ static idx_t httpfs_client_count = 0;
 
 class HTTPFSCurlClient : public HTTPClient {
 public:
+	void Cleanup () override {
+		state = nullptr;
+	}
 	HTTPFSCurlClient(HTTPFSParams &http_params, const string &proto_host_port) {
 		base_url = curl_url();
 		curl_url_set(base_url, CURLUPART_URL, proto_host_port.c_str(), 0);

--- a/src/httpfs_httplib_client.cpp
+++ b/src/httpfs_httplib_client.cpp
@@ -157,9 +157,13 @@ private:
 			return result;
 		}
 	}
-
+public:
+	void Cleanup() override {
+		state = nullptr;
+	}
 private:
 	unique_ptr<duckdb_httplib_openssl::Client> client;
+public:
 	optional_ptr<HTTPState> state;
 };
 

--- a/src/include/hffs.hpp
+++ b/src/include/hffs.hpp
@@ -62,7 +62,7 @@ public:
 	}
 	~HFFileHandle() override;
 
-	unique_ptr<HTTPClient> CreateClient() override;
+	string BaseUrl() const override;
 
 protected:
 	ParsedHFUrl parsed_url;

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "http_state.hpp"
+#include "duckdb/main/secret/secret.hpp"
 #include "duckdb/common/lru_cache.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/unordered_map.hpp"
@@ -14,6 +15,17 @@
 #include <mutex>
 
 namespace duckdb {
+
+class HTTPFileHandle;
+
+struct ClientOptions {
+	ClientOptions(HTTPFileHandle &handle);
+	string ToString() const {
+		return identifier;
+	}
+private:
+	string identifier;
+};
 
 class RangeRequestNotSupportedException {
 public:
@@ -108,7 +120,7 @@ public:
 	bool SkipBuffer() const {
 		return flags.DirectIO() || flags.RequireParallelAccess();
 	}
-	void InitializeClientCache(HTTPFileSystem &file_system);
+	void InitializeClientCache(HTTPFileSystem &file_system, const ClientOptions &opts);
 	virtual string BaseUrl() const;
 
 private:
@@ -207,7 +219,7 @@ public:
 
 	optional_ptr<HTTPMetadataCache> GetGlobalCache();
 	virtual HTTPException GetHTTPError(FileHandle &, const HTTPResponse &response, const string &url);
-	shared_ptr<HTTPClientCache> GetOrCreateClientCache(const string &path);
+	shared_ptr<HTTPClientCache> GetOrCreateClientCache(const string &path, const ClientOptions &options);
 
 	struct NopCleanup {
 		void operator()(unique_ptr<int> &) {

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -205,6 +205,9 @@ public:
 
 	optional_ptr<HTTPMetadataCache> GetGlobalCache();
 	virtual HTTPException GetHTTPError(FileHandle &, const HTTPResponse &response, const string &url);
+	shared_ptr<HTTPClientCache> GetOrCreateClientCache(const string &path);
+
+	map<string, shared_ptr<HTTPClientCache>> client_cache_map;
 
 protected:
 	unique_ptr<FileHandle> OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -23,6 +23,7 @@ struct ClientOptions {
 	string ToString() const {
 		return identifier;
 	}
+
 private:
 	string identifier;
 };

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -55,7 +55,7 @@ public:
 	virtual void Initialize(optional_ptr<FileOpener> opener);
 
 	// We keep an http client stored for connection reuse with keep-alive headers
-	HTTPClientCache client_cache;
+	shared_ptr<HTTPClientCache> client_cache;
 
 	unique_ptr<HTTPParams> params;
 	HTTPFSParams &http_params;
@@ -107,6 +107,7 @@ public:
 	bool SkipBuffer() const {
 		return flags.DirectIO() || flags.RequireParallelAccess();
 	}
+	void InitializeClientCache(HTTPFileSystem &file_system);
 
 private:
 	void AllocateReadBuffer(optional_ptr<FileOpener> opener);

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -229,8 +229,8 @@ public:
 
 	SharedLruCache<string, HTTPClientCache, DefaultPayload> lru_client_cache {256};
 	mutex client_cache_map_lock;
-	void FinalizeHandleCreate(duckdb::unique_ptr<HTTPFileHandle> &);
-	void FinalizeHandleCreate(HTTPFileHandle &);
+	void FinalizeHandleCreate(duckdb::unique_ptr<HTTPFileHandle> &, optional_ptr<FileOpener> opener);
+	void FinalizeHandleCreate(HTTPFileHandle &, optional_ptr<FileOpener> opener);
 
 protected:
 	unique_ptr<FileHandle> OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -208,6 +208,7 @@ public:
 	shared_ptr<HTTPClientCache> GetOrCreateClientCache(const string &path);
 
 	map<string, shared_ptr<HTTPClientCache>> client_cache_map;
+	mutext client_cache_map_lock;
 
 protected:
 	unique_ptr<FileHandle> OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -214,7 +214,7 @@ public:
 		}
 	};
 
-	SharedLruCache<string, HTTPClientCache, DefaultPayload> lru_client_cache {16};
+	SharedLruCache<string, HTTPClientCache, DefaultPayload> lru_client_cache {256};
 	mutex client_cache_map_lock;
 	void FinalizeHandleCreate(duckdb::unique_ptr<HTTPFileHandle> &);
 	void FinalizeHandleCreate(HTTPFileHandle &);

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -224,7 +224,7 @@ protected:
 protected:
 	virtual duckdb::unique_ptr<HTTPFileHandle> CreateHandle(const OpenFileInfo &file, FileOpenFlags flags,
 	                                                        optional_ptr<FileOpener> opener);
-
+	void FinalizeHandleCreate(duckdb::unique_ptr<HTTPFileHandle> &);
 private:
 	// Global cache
 	mutex global_cache_lock;

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -208,7 +208,7 @@ public:
 	shared_ptr<HTTPClientCache> GetOrCreateClientCache(const string &path);
 
 	map<string, shared_ptr<HTTPClientCache>> client_cache_map;
-	mutext client_cache_map_lock;
+	mutex client_cache_map_lock;
 
 protected:
 	unique_ptr<FileHandle> OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -189,7 +189,7 @@ protected:
 	atomic<bool> uploader_has_error {false};
 	std::exception_ptr upload_exception;
 
-	unique_ptr<HTTPClient> CreateClient() override;
+	string BaseUrl() const override;
 
 	//! Rethrow IO Exception originating from an upload thread
 	void RethrowIOError() {

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -332,7 +332,7 @@ S3FileHandle::~S3FileHandle() {
 
 void S3FileHandle::SetRegion(string region_p) {
 	auth_params.SetRegion(std::move(region_p));
-	client_cache.Clear();
+	client_cache->Clear();
 }
 
 S3ConfigParams S3ConfigParams::ReadFrom(optional_ptr<FileOpener> opener) {

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1165,7 +1165,8 @@ void S3FileSystem::RemoveFiles(const vector<string> &paths, optional_ptr<FileOpe
 
 void S3FileSystem::RemoveDirectory(const string &path, optional_ptr<FileOpener> opener) {
 	vector<string> files_to_remove;
-	ListFiles(path, [&](const string &file, bool is_dir) { files_to_remove.push_back(file); }, opener.get());
+	ListFiles(
+	    path, [&](const string &file, bool is_dir) { files_to_remove.push_back(file); }, opener.get());
 
 	RemoveFiles(files_to_remove, opener);
 }

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1162,8 +1162,7 @@ void S3FileSystem::RemoveFiles(const vector<string> &paths, optional_ptr<FileOpe
 
 void S3FileSystem::RemoveDirectory(const string &path, optional_ptr<FileOpener> opener) {
 	vector<string> files_to_remove;
-	ListFiles(
-	    path, [&](const string &file, bool is_dir) { files_to_remove.push_back(file); }, opener.get());
+	ListFiles(path, [&](const string &file, bool is_dir) { files_to_remove.push_back(file); }, opener.get());
 
 	RemoveFiles(files_to_remove, opener);
 }


### PR DESCRIPTION
Currently `HTTPClientCache`s are per FileHandle, after this PR they each FileHandle has a `shared_ptr<HTTPClientCache>` that allows to share the clients across the same base-url.

An LruCache is kept to reachable `HTTPClientCache`'s, that allows repeated network call, even across `FileHandle`'s, to avoid unnecessary network handshakes.

This builds on top of LruCache made available in `duckdb/duckdb` in https://github.com/duckdb/duckdb/pull/20157 (and generalized in https://github.com/duckdb/duckdb/pull/20757 and the infrastructure to re-initialized clients, recently touched on via https://github.com/duckdb/duckdb-httpfs/pull/232.

Ownership model is fully RAII, thanks to `shared_ptr`'s, note that this means that there might be still alive `HTTPClientCache`, say a very long lived `FileHandle`, but those are not reachable anymore.
This can be improved on, but for now PR to improve current status and add infrastructure.
Cache size is fixed at 256, arguably it should be configurable.

This should somewhat visibly improve performances of repeated operations to same `BaseUrl()`, but apart from timing this should not bring observable differences.
CI-wise, main goal here is checking whether it's a pass.