### PR TITLE
add S3 version id pinning to httpfs

### DIFF
--- a/scripts/minio_s3.yml
+++ b/scripts/minio_s3.yml
@@ -55,6 +55,7 @@ services:
 
         /usr/bin/mc rb --force myminio/test-bucket-public
         /usr/bin/mc mb myminio/test-bucket-public
+        /usr/bin/mc version enable myminio/test-bucket-public
         /usr/bin/mc policy set download myminio/test-bucket-public
         /usr/bin/mc policy get myminio/test-bucket-public
 

--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -72,6 +72,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          Value(50));
 	config.AddExtensionOption("unsafe_disable_etag_checks", "Disable checks on ETag consistency", LogicalType::BOOLEAN,
 	                          Value(false));
+	config.AddExtensionOption("s3_version_id_pinning", "Pin S3 reads to a specific object version for consistency",
+	                          LogicalType::BOOLEAN, Value(false));
 
 	// HuggingFace options
 	config.AddExtensionOption("hf_max_per_page", "Debug option to limit number of items returned in list requests",

--- a/src/include/http_metadata_cache.hpp
+++ b/src/include/http_metadata_cache.hpp
@@ -19,6 +19,7 @@ struct HTTPMetadataCacheEntry {
 	idx_t length;
 	timestamp_t last_modified;
 	string etag;
+	string version_id;
 };
 
 // Simple cache with a max age for an entry to be valid

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -63,6 +63,7 @@ public:
 	idx_t length;
 	timestamp_t last_modified;
 	string etag;
+	string version_id;
 	bool force_full_download;
 	bool initialized = false;
 

--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -25,6 +25,7 @@ struct HTTPFSParams : public HTTPParams {
 	string ca_cert_file;
 	string bearer_token;
 	bool unsafe_disable_etag_checks {false};
+	bool s3_version_id_pinning {false};
 	shared_ptr<HTTPState> state;
 	string user_agent = {""};
 	bool pre_merged_headers = false;

--- a/test/sql/copy/s3/version_id_pinning.test
+++ b/test/sql/copy/s3/version_id_pinning.test
@@ -1,0 +1,91 @@
+# name: test/sql/copy/s3/version_id_pinning.test
+# description: Test S3 version ID pinning: reads remain pinned to the original object version even after the file is overwritten.
+# group: [s3]
+
+require parquet
+
+require httpfs
+
+require-env S3_TEST_SERVER_AVAILABLE 1
+
+require-env AWS_DEFAULT_REGION
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+require-env DUCKDB_S3_ENDPOINT
+
+require-env DUCKDB_S3_USE_SSL
+
+# override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
+set ignore_error_messages
+
+# disable external file cache to avoid interference from locally cached file content
+statement ok
+SET enable_external_file_cache=false;
+
+# Create two tables with different row counts so we can distinguish them
+statement ok
+CREATE TABLE T1 AS SELECT i FROM range(100) tbl(i);
+
+statement ok
+CREATE TABLE T2 AS SELECT i FROM range(200) tbl(i);
+
+# Write T1 to S3 (bucket must have versioning enabled)
+statement ok
+COPY T1 TO 's3://test-bucket-public/root-dir/version_pinning/test.parquet';
+
+# Enable version pinning and the global metadata cache.
+# The global metadata cache persists version_id across queries.
+statement ok
+SET s3_version_id_pinning=true;
+
+statement ok
+SET enable_http_metadata_cache=true;
+
+# Read the file. This performs a HEAD request that captures version_id V1
+# and stores it in the global metadata cache.
+query I
+SELECT COUNT(*) FROM 's3://test-bucket-public/root-dir/version_pinning/test.parquet';
+----
+100
+
+# Disable the global metadata cache BEFORE overwriting.
+# This way the COPY TO below erases from the per-context cache only,
+# leaving the global cache entry (with V1's version_id) intact.
+statement ok
+SET enable_http_metadata_cache=false;
+
+# Overwrite the file with T2 (200 rows), creating a new version V2.
+# Because the global metadata cache is disabled, the write erases from
+# the per-context cache, not the global cache.
+statement ok
+COPY T2 TO 's3://test-bucket-public/root-dir/version_pinning/test.parquet';
+
+# Re-enable the global metadata cache. It still holds the V1 entry.
+statement ok
+SET enable_http_metadata_cache=true;
+
+# Read the file again. The global cache provides the V1 version_id,
+# so the GET request includes ?versionId=V1 and returns the original T1 data.
+query I
+SELECT COUNT(*) FROM 's3://test-bucket-public/root-dir/version_pinning/test.parquet';
+----
+100
+
+# --- Clearing the version pin ---
+# To read the latest version, we need to clear the cached version_id.
+# Disabling the global metadata cache and version pinning achieves this:
+# the per-context cache starts empty each query, and no version_id is captured.
+statement ok
+SET enable_http_metadata_cache=false;
+
+statement ok
+SET s3_version_id_pinning=false;
+
+# Now the read gets the latest version (V2 = T2 data).
+query I
+SELECT COUNT(*) FROM 's3://test-bucket-public/root-dir/version_pinning/test.parquet';
+----
+200


### PR DESCRIPTION
the current implementation in HTTPFS tries to always access the latest version of objects in S3. this might result in downloading parts of a file from different versions. This PRs fixes this by using the version id if versioning is enabled on the S3 bucket. It does this by storing the version id after the first request to the object. Subsequent file access uses this version id if available and can download the remaining parts even when the file changed mid download on S3.

basically it captures the `x-amz-version-id` http header:
```
HTTP/1.1 200 OK
x-amz-version-id: 3HL4kqCxf3vjVBH40Nrjfkd
ETag: "abc123..."
Content-Length: 987654321
```

and adds it as a query parameter to requests

```
GET /my-object.parquet?versionId=3HL4kqCxf3vjVBH40Nrjfkd HTTP/1.1
Host: my-bucket.s3.amazonaws.com
Range: bytes=0-1048575
```

I put this feature behind a feature flag which disabled by default. To try this enable the flag 
`SET s3_version_id_pinning = true;`

this fixes the issue https://github.com/duckdb/duckdb/issues/20533