### PR TITLE
Partial revert of 4680edd

### DIFF
--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -118,9 +118,6 @@ public:
 		curl_url_set(base_url, CURLUPART_URL, proto_host_port.c_str(), 0);
 		stored_bearer_token = "";
 		stored_cert_file_path = "";
-		if (StringUtil::StartsWith(proto_host_port, "https://")) {
-			https_connection = true;
-		}
 		Initialize(http_params);
 	}
 	void Initialize(HTTPParams &http_p) override {
@@ -162,7 +159,7 @@ public:
 			curl_easy_setopt(*curl, CURLOPT_FORBID_REUSE, 0L);
 		}
 
-		if (https_connection && http_params.enable_curl_server_cert_verification) {
+		if (http_params.enable_curl_server_cert_verification) {
 			curl_easy_setopt(*curl, CURLOPT_SSL_VERIFYPEER, 1L); // Verify the cert
 			curl_easy_setopt(*curl, CURLOPT_SSL_VERIFYHOST, 2L); // Verify that the cert matches the hostname
 		} else {
@@ -474,7 +471,6 @@ private:
 	CURLU *base_url = nullptr;
 	string stored_bearer_token;
 	string stored_cert_file_path;
-	bool https_connection = false;
 
 	static std::mutex &GetRefLock() {
 		static std::mutex mtx;

--- a/src/httpfs_httplib_client.cpp
+++ b/src/httpfs_httplib_client.cpp
@@ -9,9 +9,6 @@ class HTTPFSClient : public HTTPClient {
 public:
 	HTTPFSClient(HTTPFSParams &http_params, const string &proto_host_port) {
 		client = make_uniq<duckdb_httplib_openssl::Client>(proto_host_port);
-		if (StringUtil::StartsWith(proto_host_port, "https://")) {
-			https_connection = true;
-		}
 		Initialize(http_params);
 	}
 	void Initialize(HTTPParams &http_p) override {
@@ -21,7 +18,7 @@ public:
 		if (!http_params.ca_cert_file.empty()) {
 			client->set_ca_cert_path(http_params.ca_cert_file.c_str());
 		}
-		client->enable_server_certificate_verification(https_connection && http_params.enable_server_cert_verification);
+		client->enable_server_certificate_verification(http_params.enable_server_cert_verification);
 		client->set_write_timeout(http_params.timeout, http_params.timeout_usec);
 		client->set_read_timeout(http_params.timeout, http_params.timeout_usec);
 		client->set_connection_timeout(http_params.timeout, http_params.timeout_usec);
@@ -162,7 +159,6 @@ private:
 private:
 	unique_ptr<duckdb_httplib_openssl::Client> client;
 	optional_ptr<HTTPState> state;
-	bool https_connection = false;
 };
 
 unique_ptr<HTTPClient> HTTPFSUtil::InitializeClient(HTTPParams &http_params, const string &proto_host_port) {


### PR DESCRIPTION
This is now more closely modelled after CURL:
* http redirected to https -> SSL check is required
* http -> SSL check not required