### PR TITLE
Canonicalize ca_cert_file setting

### DIFF
--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -53,8 +53,15 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("enable_server_cert_verification", "Enable server side certificate verification.",
 	                          LogicalType::BOOLEAN, Value(false));
 	auto callback_ca_cert_file = [](ClientContext &context, SetScope scope, Value &parameter) {
-		LocalFileSystem fs;
+		if (parameter.IsNull()) {
+			throw InvalidInputException("NULL it's not a valid option for ca_cert_file");
+		}
 		string value = StringValue::Get(parameter);
+		if (value.empty()) {
+			parameter = Value("");
+			return;
+		}
+		LocalFileSystem fs;
 		ClientContextFileOpener opener(context);
 		auto &config = DBConfig::GetConfig(context);
 		// Normalize ca_cert_file to absolute path

--- a/test/sql/httpfs/ca_cert_file.test
+++ b/test/sql/httpfs/ca_cert_file.test
@@ -20,6 +20,10 @@ Invalid Input Error: NULL it's not a valid option for ca_cert_file
 statement ok
 SET ca_cert_file = 'README.md';
 
+# FIXME: There are some inconsistencies between curl global options set by spatial AND httpfs on Windows, to be investigated
+# Also, the test relies now on path that are inconsisten on Windows machines
+require notwindows
+
 query I
 SELECT current_setting('ca_cert_file') ILIKE '%/README.md';
 ----
@@ -51,9 +55,6 @@ SELECT current_setting('ca_cert_file');
 
 statement ok
 SET ca_cert_file = 'README.md';
-
-# FIXME: There are some inconsistencies between curl global options set by spatial AND httpfs on Windows, to be investigated
-require notwindows
 
 statement error
 FROM read_blob('https://duckdb.org/')

--- a/test/sql/httpfs/ca_cert_file.test
+++ b/test/sql/httpfs/ca_cert_file.test
@@ -4,8 +4,50 @@
 
 require httpfs
 
+query I
+SELECT current_setting('ca_cert_file');
+----
+(empty)
+
 statement ok
 SET enable_server_cert_verification = true;
+
+statement error
+SET ca_cert_file = NULL;
+----
+Invalid Input Error: NULL it's not a valid option for ca_cert_file
+
+statement ok
+SET ca_cert_file = 'README.md';
+
+query I
+SELECT current_setting('ca_cert_file') ILIKE '%/README.md';
+----
+true
+
+statement ok
+RESET ca_cert_file;
+
+query I
+SELECT current_setting('ca_cert_file');
+----
+(empty)
+
+statement ok
+SET ca_cert_file = 'README.md';
+
+query I
+SELECT current_setting('ca_cert_file') ILIKE '%/README.md';
+----
+true
+
+statement ok
+SET ca_cert_file = '';
+
+query I
+SELECT current_setting('ca_cert_file');
+----
+(empty)
 
 statement ok
 SET ca_cert_file = 'README.md';


### PR DESCRIPTION
This makes so:
```sql
SET ca_cert_file = '~/path/to/file';
```
it's properly normalized so to be usable by networking libraries.