### PR TITLE
OneCyrus's add S3 version id pinning to httpfs [on main]

### DIFF
--- a/scripts/minio_s3.yml
+++ b/scripts/minio_s3.yml
@@ -47,6 +47,7 @@ services:
 
         /usr/bin/mc rb --force myminio/test-bucket
         /usr/bin/mc mb myminio/test-bucket
+        /usr/bin/mc version enable myminio/test-bucket
         /usr/bin/mc policy get myminio/test-bucket
 
         /usr/bin/mc rb --force myminio/test-bucket-2
@@ -55,7 +56,6 @@ services:
 
         /usr/bin/mc rb --force myminio/test-bucket-public
         /usr/bin/mc mb myminio/test-bucket-public
-        /usr/bin/mc version enable myminio/test-bucket-public
         /usr/bin/mc anonymous set public myminio/test-bucket-public
         /usr/bin/mc policy get myminio/test-bucket-public
 

--- a/scripts/minio_s3.yml
+++ b/scripts/minio_s3.yml
@@ -55,6 +55,7 @@ services:
 
         /usr/bin/mc rb --force myminio/test-bucket-public
         /usr/bin/mc mb myminio/test-bucket-public
+        /usr/bin/mc version enable myminio/test-bucket-public
         /usr/bin/mc anonymous set public myminio/test-bucket-public
         /usr/bin/mc policy get myminio/test-bucket-public
 

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -872,6 +872,8 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
 	length = cache_entry.length;
 	etag = cache_entry.etag;
 	version_id = cache_entry.version_id;
+
+	// TODO: handle properties
 }
 
 HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
@@ -879,6 +881,8 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
 	result.length = length;
 	result.last_modified = last_modified;
 	result.etag = etag;
+	result.version_id = version_id;
+	// TODO: handle properties
 	return result;
 }
 

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -60,6 +60,7 @@ unique_ptr<HTTPParams> HTTPFSUtil::InitializeParameters(optional_ptr<FileOpener>
 	FileOpener::TryGetCurrentSetting(opener, "ca_cert_file", result->ca_cert_file, info);
 	FileOpener::TryGetCurrentSetting(opener, "hf_max_per_page", result->hf_max_per_page, info);
 	FileOpener::TryGetCurrentSetting(opener, "unsafe_disable_etag_checks", result->unsafe_disable_etag_checks, info);
+	FileOpener::TryGetCurrentSetting(opener, "s3_version_id_pinning", result->s3_version_id_pinning, info);
 
 	{
 		auto db = FileOpener::TryGetDatabase(opener);
@@ -237,6 +238,9 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRequest(FileHandle &handle, string u
 			    }
 			    throw HTTPException(error);
 		    }
+		    if (hfh.http_params.s3_version_id_pinning && hfh.version_id.empty() && response.HasHeader("x-amz-version-id")) {
+			    hfh.version_id = response.GetHeaderValue("x-amz-version-id");
+		    }
 		    return true;
 	    },
 	    [&](const_data_ptr_t data, idx_t data_length) {
@@ -309,6 +313,10 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
 					        "unsafe_disable_etag_checks = true;`",
 					        handle.path, hfh.etag, response.GetHeaderValue("ETag"));
 				    }
+			    }
+
+			    if (hfh.http_params.s3_version_id_pinning && hfh.version_id.empty() && response.HasHeader("x-amz-version-id")) {
+				    hfh.version_id = response.GetHeaderValue("x-amz-version-id");
 			    }
 
 			    if (response.HasHeader("Content-Length")) {
@@ -831,6 +839,9 @@ void HTTPFileHandle::LoadFileInfo() {
 	if (res->headers.HasHeader("ETag")) {
 		etag = res->headers.GetHeaderValue("ETag");
 	}
+	if (http_params.s3_version_id_pinning && res->headers.HasHeader("x-amz-version-id")) {
+		version_id = res->headers.GetHeaderValue("x-amz-version-id");
+	}
 	initialized = true;
 }
 
@@ -858,6 +869,7 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
 	last_modified = cache_entry.last_modified;
 	length = cache_entry.length;
 	etag = cache_entry.etag;
+	version_id = cache_entry.version_id;
 }
 
 HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
@@ -911,7 +923,7 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 			FullDownload(hfs, should_write_cache);
 		}
 		if (should_write_cache) {
-			current_cache->Insert(path, GetCacheEntry());
+			current_cache->Insert(path, {length, last_modified, etag, version_id});
 		}
 
 		if (!SkipBuffer()) {

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -238,7 +238,8 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRequest(FileHandle &handle, string u
 			    }
 			    throw HTTPException(error);
 		    }
-		    if (hfh.http_params.s3_version_id_pinning && hfh.version_id.empty() && response.HasHeader("x-amz-version-id")) {
+		    if (hfh.http_params.s3_version_id_pinning && hfh.version_id.empty() &&
+		        response.HasHeader("x-amz-version-id")) {
 			    hfh.version_id = response.GetHeaderValue("x-amz-version-id");
 		    }
 		    return true;
@@ -315,7 +316,8 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
 				    }
 			    }
 
-			    if (hfh.http_params.s3_version_id_pinning && hfh.version_id.empty() && response.HasHeader("x-amz-version-id")) {
+			    if (hfh.http_params.s3_version_id_pinning && hfh.version_id.empty() &&
+			        response.HasHeader("x-amz-version-id")) {
 				    hfh.version_id = response.GetHeaderValue("x-amz-version-id");
 			    }
 

--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -92,7 +92,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("unsafe_disable_etag_checks", "Disable checks on ETag consistency", LogicalType::BOOLEAN,
 	                          Value(false));
 	config.AddExtensionOption("s3_version_id_pinning", "Pin S3 reads to a specific object version for consistency",
-	                          LogicalType::BOOLEAN, Value(false));
+	                          LogicalType::BOOLEAN, Value(true));
 
 	// HuggingFace options
 	config.AddExtensionOption("hf_max_per_page", "Debug option to limit number of items returned in list requests",

--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -91,6 +91,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          Value(50));
 	config.AddExtensionOption("unsafe_disable_etag_checks", "Disable checks on ETag consistency", LogicalType::BOOLEAN,
 	                          Value(false));
+	config.AddExtensionOption("s3_version_id_pinning", "Pin S3 reads to a specific object version for consistency",
+	                          LogicalType::BOOLEAN, Value(false));
 
 	// HuggingFace options
 	config.AddExtensionOption("hf_max_per_page", "Debug option to limit number of items returned in list requests",

--- a/src/include/http_metadata_cache.hpp
+++ b/src/include/http_metadata_cache.hpp
@@ -19,6 +19,7 @@ struct HTTPMetadataCacheEntry {
 	idx_t length;
 	timestamp_t last_modified;
 	string etag;
+	string version_id;
 	unordered_map<string, string> properties;
 };
 

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -63,6 +63,7 @@ public:
 	idx_t length;
 	timestamp_t last_modified;
 	string etag;
+	string version_id;
 	bool force_full_download;
 	bool initialized = false;
 

--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -25,6 +25,7 @@ struct HTTPFSParams : public HTTPParams {
 	string ca_cert_file;
 	string bearer_token;
 	bool unsafe_disable_etag_checks {false};
+	bool s3_version_id_pinning {false};
 	shared_ptr<HTTPState> state;
 	string user_agent = {""};
 	bool pre_merged_headers = false;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -878,7 +878,6 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_
 		// Use existing S3 authentication
 		headers = CreateS3Header(parsed_s3_url.path, query_string, parsed_s3_url.host, "s3", "GET", auth_params, "", "",
 		                         "", "");
-
 	}
 
 	return HTTPFileSystem::GetRequest(handle, http_url, headers);
@@ -906,7 +905,6 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, strin
 		// Use existing S3 authentication
 		headers = CreateS3Header(parsed_s3_url.path, query_string, parsed_s3_url.host, "s3", "GET", auth_params, "", "",
 		                         "", "");
-
 	}
 
 	return HTTPFileSystem::GetRangeRequest(handle, http_url, headers, file_offset, buffer_out, buffer_out_len);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -858,9 +858,16 @@ unique_ptr<HTTPResponse> S3FileSystem::HeadRequest(FileHandle &handle, string s3
 }
 
 unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map) {
-	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
+	auto &s3_handle = handle.Cast<S3FileHandle>();
+	auto auth_params = s3_handle.auth_params;
 	auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
-	string http_url = parsed_s3_url.GetHTTPUrl(auth_params);
+
+	string query_string;
+	if (!s3_handle.version_id.empty()) {
+		query_string = "versionId=" + UrlEncode(s3_handle.version_id, true);
+	}
+
+	string http_url = parsed_s3_url.GetHTTPUrl(auth_params, query_string);
 
 	HTTPHeaders headers;
 	if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
@@ -869,7 +876,9 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_
 		headers["Host"] = parsed_s3_url.host;
 	} else {
 		// Use existing S3 authentication
-		headers = CreateS3Header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "GET", auth_params, "", "", "", "");
+		headers = CreateS3Header(parsed_s3_url.path, query_string, parsed_s3_url.host, "s3", "GET", auth_params, "", "",
+		                         "", "");
+
 	}
 
 	return HTTPFileSystem::GetRequest(handle, http_url, headers);
@@ -877,9 +886,16 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_
 
 unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
                                                        idx_t file_offset, char *buffer_out, idx_t buffer_out_len) {
-	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
+	auto &s3_handle = handle.Cast<S3FileHandle>();
+	auto auth_params = s3_handle.auth_params;
 	auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
-	string http_url = parsed_s3_url.GetHTTPUrl(auth_params);
+
+	string query_string;
+	if (!s3_handle.version_id.empty()) {
+		query_string = "versionId=" + UrlEncode(s3_handle.version_id, true);
+	}
+
+	string http_url = parsed_s3_url.GetHTTPUrl(auth_params, query_string);
 
 	HTTPHeaders headers;
 	if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
@@ -888,7 +904,9 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, strin
 		headers["Host"] = parsed_s3_url.host;
 	} else {
 		// Use existing S3 authentication
-		headers = CreateS3Header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "GET", auth_params, "", "", "", "");
+		headers = CreateS3Header(parsed_s3_url.path, query_string, parsed_s3_url.host, "s3", "GET", auth_params, "", "",
+		                         "", "");
+
 	}
 
 	return HTTPFileSystem::GetRangeRequest(handle, http_url, headers, file_offset, buffer_out, buffer_out_len);

--- a/test/sql/copy/s3/http_log.test
+++ b/test/sql/copy/s3/http_log.test
@@ -36,8 +36,9 @@ FROM 's3://test-bucket/http_log/test.parquet'
 ----
 value-1
 
+# due to versioning, the GET will have optionally a `?versionId=..` encoded in the url
 query II rowsort
-SELECT request.type, parse_filename(request.url) FROM duckdb_logs_parsed('HTTP');
+SELECT request.type, parse_filename(request.url) ILIKE 'test.parquet%' FROM duckdb_logs_parsed('HTTP');
 ----
-GET	test.parquet
-HEAD	test.parquet
+GET	1
+HEAD	1

--- a/test/sql/copy/s3/version_id_pinning.test
+++ b/test/sql/copy/s3/version_id_pinning.test
@@ -1,0 +1,91 @@
+# name: test/sql/copy/s3/version_id_pinning.test
+# description: Test S3 version ID pinning: reads remain pinned to the original object version even after the file is overwritten.
+# group: [s3]
+
+require parquet
+
+require httpfs
+
+require-env S3_TEST_SERVER_AVAILABLE 1
+
+require-env AWS_DEFAULT_REGION
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+require-env DUCKDB_S3_ENDPOINT
+
+require-env DUCKDB_S3_USE_SSL
+
+# override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
+set ignore_error_messages
+
+# disable external file cache to avoid interference from locally cached file content
+statement ok
+SET enable_external_file_cache=false;
+
+# Create two tables with different row counts so we can distinguish them
+statement ok
+CREATE TABLE T1 AS SELECT i FROM range(100) tbl(i);
+
+statement ok
+CREATE TABLE T2 AS SELECT i FROM range(200) tbl(i);
+
+# Write T1 to S3 (bucket must have versioning enabled)
+statement ok
+COPY T1 TO 's3://test-bucket-public/root-dir/version_pinning/test.parquet';
+
+# Enable version pinning and the global metadata cache.
+# The global metadata cache persists version_id across queries.
+statement ok
+SET s3_version_id_pinning=true;
+
+statement ok
+SET enable_http_metadata_cache=true;
+
+# Read the file. This performs a HEAD request that captures version_id V1
+# and stores it in the global metadata cache.
+query I
+SELECT COUNT(*) FROM 's3://test-bucket-public/root-dir/version_pinning/test.parquet';
+----
+100
+
+# Disable the global metadata cache BEFORE overwriting.
+# This way the COPY TO below erases from the per-context cache only,
+# leaving the global cache entry (with V1's version_id) intact.
+statement ok
+SET enable_http_metadata_cache=false;
+
+# Overwrite the file with T2 (200 rows), creating a new version V2.
+# Because the global metadata cache is disabled, the write erases from
+# the per-context cache, not the global cache.
+statement ok
+COPY T2 TO 's3://test-bucket-public/root-dir/version_pinning/test.parquet';
+
+# Re-enable the global metadata cache. It still holds the V1 entry.
+statement ok
+SET enable_http_metadata_cache=true;
+
+# Read the file again. The global cache provides the V1 version_id,
+# so the GET request includes ?versionId=V1 and returns the original T1 data.
+query I
+SELECT COUNT(*) FROM 's3://test-bucket-public/root-dir/version_pinning/test.parquet';
+----
+100
+
+# --- Clearing the version pin ---
+# To read the latest version, we need to clear the cached version_id.
+# Disabling the global metadata cache and version pinning achieves this:
+# the per-context cache starts empty each query, and no version_id is captured.
+statement ok
+SET enable_http_metadata_cache=false;
+
+statement ok
+SET s3_version_id_pinning=false;
+
+# Now the read gets the latest version (V2 = T2 data).
+query I
+SELECT COUNT(*) FROM 's3://test-bucket-public/root-dir/version_pinning/test.parquet';
+----
+200

--- a/test/sql/copy/s3/version_id_pinning.test
+++ b/test/sql/copy/s3/version_id_pinning.test
@@ -136,3 +136,24 @@ GET
 
 statement ok
 SET s3_version_id_pinning=true;
+
+statement ok
+COPY T1 TO 's3://test-bucket/root-dir/version_pinning/test.parquet';
+
+query I
+SELECT * FROM 's3://test-bucket/root-dir/version_pinning/test.parquet' LIMIT 5;
+----
+0
+1
+2
+3
+4
+
+query I
+SELECT request.type FROM (FROM duckdb_logs_parsed('HTTP') WHERE request.url ILIKE '%versionId=%');
+----
+GET
+GET
+GET
+GET
+GET

--- a/test/sql/copy/s3/version_id_pinning.test
+++ b/test/sql/copy/s3/version_id_pinning.test
@@ -25,16 +25,16 @@ set ignore_error_messages
 statement ok
 SET enable_external_file_cache=false;
 
-# Create two tables with different row counts so we can distinguish them
+# Create two tables with different content, so we can distinguish them
 statement ok
 CREATE TABLE T1 AS SELECT i FROM range(100) tbl(i);
 
 statement ok
-CREATE TABLE T2 AS SELECT i FROM range(200) tbl(i);
+CREATE TABLE T2 AS SELECT i*i FROM range(200) tbl(i);
 
 # Write T1 to S3 (bucket must have versioning enabled)
 statement ok
-COPY T1 TO 's3://test-bucket-public/root-dir/version_pinning/test.parquet';
+COPY T1 TO 's3://test-bucket/root-dir/version_pinning/test.parquet';
 
 # Enable version pinning and the global metadata cache.
 # The global metadata cache persists version_id across queries.
@@ -44,12 +44,21 @@ SET s3_version_id_pinning=true;
 statement ok
 SET enable_http_metadata_cache=true;
 
+statement ok
+CALL enable_logging('HTTP');
+
 # Read the file. This performs a HEAD request that captures version_id V1
 # and stores it in the global metadata cache.
 query I
-SELECT COUNT(*) FROM 's3://test-bucket-public/root-dir/version_pinning/test.parquet';
+SELECT COUNT(*) FROM 's3://test-bucket/root-dir/version_pinning/test.parquet';
 ----
 100
+
+query I
+SELECT request.type FROM duckdb_logs_parsed('HTTP') WHERE response.headers['x-amz-version-id'] IS NOT NULL
+----
+HEAD
+GET
 
 # Disable the global metadata cache BEFORE overwriting.
 # This way the COPY TO below erases from the per-context cache only,
@@ -61,7 +70,7 @@ SET enable_http_metadata_cache=false;
 # Because the global metadata cache is disabled, the write erases from
 # the per-context cache, not the global cache.
 statement ok
-COPY T2 TO 's3://test-bucket-public/root-dir/version_pinning/test.parquet';
+COPY T2 TO 's3://test-bucket/root-dir/version_pinning/test.parquet';
 
 # Re-enable the global metadata cache. It still holds the V1 entry.
 statement ok
@@ -70,9 +79,13 @@ SET enable_http_metadata_cache=true;
 # Read the file again. The global cache provides the V1 version_id,
 # so the GET request includes ?versionId=V1 and returns the original T1 data.
 query I
-SELECT COUNT(*) FROM 's3://test-bucket-public/root-dir/version_pinning/test.parquet';
+SELECT * FROM 's3://test-bucket/root-dir/version_pinning/test.parquet' LIMIT 5;
 ----
-100
+0
+1
+2
+3
+4
 
 # --- Clearing the version pin ---
 # To read the latest version, we need to clear the cached version_id.
@@ -84,8 +97,25 @@ SET enable_http_metadata_cache=false;
 statement ok
 SET s3_version_id_pinning=false;
 
-# Now the read gets the latest version (V2 = T2 data).
+# Read the file again. The global cache provides the V1 version_id,
+# so the GET request includes ?versionId=V1 and returns the original T1 data.
 query I
-SELECT COUNT(*) FROM 's3://test-bucket-public/root-dir/version_pinning/test.parquet';
+SELECT * FROM 's3://test-bucket/root-dir/version_pinning/test.parquet' LIMIT 5;
 ----
-200
+0
+1
+4
+9
+16
+
+query II
+SELECT request.type FROM (FROM duckdb_logs_parsed('HTTP') WHERE response.headers['x-amz-version-id'] IS NOT NULL);
+----
+HEAD
+GET
+PUT
+GET
+GET
+HEAD
+GET
+GET

--- a/test/sql/copy/s3/version_id_pinning.test
+++ b/test/sql/copy/s3/version_id_pinning.test
@@ -97,6 +97,13 @@ SET enable_http_metadata_cache=false;
 statement ok
 SET s3_version_id_pinning=false;
 
+query I
+SELECT request.type FROM (FROM duckdb_logs_parsed('HTTP') WHERE request.url ILIKE '%versionId=%');
+----
+GET
+GET
+GET
+
 # Read the file again. The global cache provides the V1 version_id,
 # so the GET request includes ?versionId=V1 and returns the original T1 data.
 query I
@@ -108,7 +115,7 @@ SELECT * FROM 's3://test-bucket/root-dir/version_pinning/test.parquet' LIMIT 5;
 9
 16
 
-query II
+query I
 SELECT request.type FROM (FROM duckdb_logs_parsed('HTTP') WHERE response.headers['x-amz-version-id'] IS NOT NULL);
 ----
 HEAD
@@ -119,3 +126,13 @@ GET
 HEAD
 GET
 GET
+
+query I
+SELECT request.type FROM (FROM duckdb_logs_parsed('HTTP') WHERE request.url ILIKE '%versionId=%');
+----
+GET
+GET
+GET
+
+statement ok
+SET s3_version_id_pinning=true;

--- a/test/sql/copy/s3/version_id_pinning_defaults.test
+++ b/test/sql/copy/s3/version_id_pinning_defaults.test
@@ -1,0 +1,117 @@
+# name: test/sql/copy/s3/version_id_pinning_defaults.test
+# description: Test S3 version ID pinning using regular defaults
+# group: [s3]
+
+require parquet
+
+require httpfs
+
+require-env S3_TEST_SERVER_AVAILABLE 1
+
+require-env AWS_DEFAULT_REGION
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+require-env DUCKDB_S3_ENDPOINT
+
+require-env DUCKDB_S3_USE_SSL
+
+# override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
+set ignore_error_messages
+
+# Create two tables with different content, so we can distinguish them
+statement ok
+CREATE TABLE T1 AS SELECT i FROM range(100) tbl(i);
+
+statement ok
+CREATE TABLE T2 AS SELECT i*i FROM range(200) tbl(i);
+
+# Write T1 to S3 (bucket must have versioning enabled)
+statement ok
+COPY T1 TO 's3://test-bucket/root-dir/version_pinning/test.parquet';
+
+statement ok
+CALL enable_logging('HTTP');
+
+# Read the file. This performs a HEAD request that captures version_id V1
+# and stores it in the global metadata cache.
+query I
+SELECT COUNT(*) FROM 's3://test-bucket/root-dir/version_pinning/test.parquet';
+----
+100
+
+query I
+SELECT request.type FROM duckdb_logs_parsed('HTTP') WHERE response.headers['x-amz-version-id'] IS NOT NULL
+----
+HEAD
+GET
+
+# Overwrite the file with T2 (200 rows), creating a new version V2.
+# Because the global metadata cache is disabled, the write erases from
+# the per-context cache, not the global cache.
+statement ok
+COPY T2 TO 's3://test-bucket/root-dir/version_pinning/test.parquet';
+
+# Read the file again. The global cache now has been cleaned by write provides the V2 version_id
+query I
+SELECT * FROM 's3://test-bucket/root-dir/version_pinning/test.parquet' LIMIT 5;
+----
+0
+1
+4
+9
+16
+
+query I
+SELECT request.type FROM (FROM duckdb_logs_parsed('HTTP') WHERE request.url ILIKE '%versionId=%');
+----
+GET
+GET
+
+# Read the file again. The global cache provides the V1 version_id,
+# so the GET request includes ?versionId=V1 and returns the original T1 data.
+query I
+SELECT * FROM 's3://test-bucket/root-dir/version_pinning/test.parquet' LIMIT 5;
+----
+0
+1
+4
+9
+16
+
+query I
+SELECT request.type FROM (FROM duckdb_logs_parsed('HTTP') WHERE response.headers['x-amz-version-id'] IS NOT NULL);
+----
+HEAD
+GET
+PUT
+HEAD
+GET
+HEAD
+
+query I
+SELECT request.type FROM (FROM duckdb_logs_parsed('HTTP') WHERE request.url ILIKE '%versionId=%');
+----
+GET
+GET
+
+statement ok
+COPY T1 TO 's3://test-bucket/root-dir/version_pinning/test.parquet';
+
+query I
+SELECT * FROM 's3://test-bucket/root-dir/version_pinning/test.parquet' LIMIT 5;
+----
+0
+1
+2
+3
+4
+
+query I
+SELECT request.type FROM (FROM duckdb_logs_parsed('HTTP') WHERE request.url ILIKE '%versionId=%');
+----
+GET
+GET
+GET


### PR DESCRIPTION
From the original PR, at https://github.com/duckdb/duckdb-httpfs/pull/243, with minor fixups to rebased to `main` that includes a bump in minio to latest available image (https://github.com/duckdb/duckdb-httpfs/pull/247)

-----

the current implementation in HTTPFS tries to always access the latest version of objects in S3. this might result in downloading parts of a file from different versions. This PRs fixes this by using the version id if versioning is enabled on the S3 bucket. It does this by storing the version id after the first request to the object. Subsequent file access uses this version id if available and can download the remaining parts even when the file changed mid download on S3.

basically it captures the `x-amz-version-id` http header:
```
HTTP/1.1 200 OK
x-amz-version-id: 3HL4kqCxf3vjVBH40Nrjfkd
ETag: "abc123..."
Content-Length: 987654321
```

and adds it as a query parameter to requests

```
GET /my-object.parquet?versionId=3HL4kqCxf3vjVBH40Nrjfkd HTTP/1.1
Host: my-bucket.s3.amazonaws.com
Range: bytes=0-1048575
```

I put this feature behind a feature flag which disabled by default. To try this enable the flag 
`SET s3_version_id_pinning = true;`

this fixes the issue https://github.com/duckdb/duckdb/issues/20533