### PR TITLE
S3: Clear the client cache when setting the region

### DIFF
--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -35,6 +35,8 @@ public:
 	unique_ptr<HTTPClient> GetClient();
 	//! Store a client in the cache for reuse
 	void StoreClient(unique_ptr<HTTPClient> client);
+	//! Clear the stored clients
+	void Clear();
 
 protected:
 	//! The cached clients
@@ -200,6 +202,7 @@ public:
 	static void Verify();
 
 	optional_ptr<HTTPMetadataCache> GetGlobalCache();
+	virtual HTTPException GetHTTPError(FileHandle &, const HTTPResponse &response, const string &url);
 
 protected:
 	unique_ptr<FileHandle> OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,
@@ -208,7 +211,6 @@ protected:
 		return true;
 	}
 
-	virtual HTTPException GetHTTPError(FileHandle &, const HTTPResponse &response, const string &url);
 	bool TryRangeRequest(FileHandle &handle, string url, HTTPHeaders header_map, idx_t file_offset, char *buffer_out,
 	                     idx_t buffer_out_len);
 	bool ReadInternal(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location);

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -160,6 +160,7 @@ public:
 protected:
 	void InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cache_entry) override;
 	HTTPMetadataCacheEntry GetCacheEntry() const override;
+	void SetRegion(string region_p);
 
 protected:
 	string multipart_upload_id;
@@ -262,6 +263,7 @@ public:
 	static string GetGCSAuthError(const S3AuthParams &s3_auth_params);
 	static HTTPException GetS3Error(const S3AuthParams &s3_auth_params, const HTTPResponse &response,
 	                                const string &url);
+	HTTPException GetHTTPError(FileHandle &, const HTTPResponse &response, const string &url) override;
 
 protected:
 	bool ListFilesExtended(const string &directory, const std::function<void(OpenFileInfo &info)> &callback,
@@ -283,8 +285,6 @@ protected:
 
 	void FlushBuffer(S3FileHandle &handle, shared_ptr<S3WriteBuffer> write_buffer);
 	string GetPayloadHash(char *buffer, idx_t buffer_len);
-
-	HTTPException GetHTTPError(FileHandle &, const HTTPResponse &response, const string &url) override;
 };
 
 // Helper class to do s3 ListObjectV2 api call https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html

--- a/test/sql/copy/s3/download_config.test
+++ b/test/sql/copy/s3/download_config.test
@@ -113,7 +113,7 @@ COPY test TO 's3://test-bucket-public/root-dir/test2.parquet';
 statement error
 SELECT i FROM "http://test-bucket-public.${DUCKDB_S3_ENDPOINT}/root-dir/non-existent-file-ljaslkjdas.parquet" LIMIT 3
 ----
-Unable to connect to URL "http://test-bucket-public.
+404 Not Found
 
 # Connection error
 statement error
@@ -125,4 +125,4 @@ SELECT i FROM "http://test-bucket-public.duckdb-minio-non-existent-host.com:9000
 statement error
 SELECT * FROM parquet_scan('s3://this-aint-no-bucket/no-path/no-file');
 ----
-Unable to connect to URL "s3://this-aint-no-bucket/no-path/no-file"
+404 Not Found

--- a/test/sql/httpfs/globbing.test
+++ b/test/sql/httpfs/globbing.test
@@ -1,5 +1,5 @@
 # name: test/sql/httpfs/globbing.test
-# description: Ensure the HuggingFace filesystem works as expected
+# description: Test remote globbing
 # group: [httpfs]
 
 require parquet
@@ -17,7 +17,7 @@ SET allow_asterisks_in_http_paths = true;
 statement error
 select parse_path(filename), size, part, date from read_parquet('https://raw.githubusercontent.com/duckdb/duckdb/main/data/parquet-testing/hive-partitioning/simple/*/*/test.parquet') order by filename;
 ----
-HTTP Error: Unable to connect to URL
+404 Not Found
 
 statement ok
 SET allow_asterisks_in_http_paths = false;

--- a/test/sql/json/table/internal_issue_6807.test_slow
+++ b/test/sql/json/table/internal_issue_6807.test_slow
@@ -13,6 +13,6 @@ statement ok
 CREATE TABLE T AS FROM 'https://data.gharchive.org/2023-02-08-0.json.gz';
 
 query I
-SELECT count(*) FROM duckdb_logs_parsed('HTTP') WHERE request.type = 'GET' GROUP BY request.type;
+SELECT count(*) < 20 FROM duckdb_logs_parsed('HTTP') WHERE request.type = 'GET' GROUP BY request.type;
 ----
-8
+true


### PR DESCRIPTION
Follow-up fix from https://github.com/duckdb/duckdb-httpfs/pull/220 to ensure the new region is actually used in all cases