### PR TITLE
Reset CURLOPT_CUSTOMREQUEST in ResetRequestInfo and set CURLOPT_HTTPGET in GetRequests

### DIFF
--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -224,6 +224,7 @@ public:
 
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
 			curl_easy_setopt(*curl, CURLOPT_CURLU, url);
+			curl_easy_setopt(*curl, CURLOPT_HTTPGET, 1L);
 			curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers ? curl_headers.headers : nullptr);
 
 			res = curl->Execute();
@@ -441,6 +442,8 @@ private:
 		request_info->body = "";
 		request_info->url = "";
 		request_info->response_code = 0;
+		// reset customrequest, it will override CURLOPT otherwise
+		curl_easy_setopt(*curl, CURLOPT_CUSTOMREQUEST, nullptr);
 	}
 
 	unique_ptr<HTTPResponse> TransformResponseCurl(CURLcode res) {


### PR DESCRIPTION
If CURLOPT_CUSTOMREQUEST is not set to null it can override whatever request the handle makes next.

I.e if a delete request is made, `curl_easy_setopt(*curl, CURLOPT_CUSTOMREQUEST, "DELETE");` is called, 
If a POST is made after `curl_easy_setopt(*curl, CURLOPT_POST, 1L);` is called, but the custom request is used instead, so you end up sending a delete to a post url. 

This is currently an issue in Iceberg.  

I think this hasn't popped up because currently custome request types are either followed by a custom request type, or a HEAD request, which resets the request type with the code 
```
curl_easy_setopt(*curl, CURLOPT_NOBODY, 1L);
curl_easy_setopt(*curl, CURLOPT_HTTPGET, 0L);
```

I still need to investigate more scenarios, but the following patch worked for DuckDB-Iceberg.

It may also be worth is to call 
```
curl_easy_setopt(*curl, CURLOPT_POSTFIELDS, nullptr);
```
in `ResetRequestInfo()`. DuckDB-Iceberg, if it is not reset it's possible that another phantom post call will attempt to read memory at the original address (set by the call to `curl_easy_setopt(*curl, CURLOPT_POSTFIELDS, const_char_ptr_cast(info.buffer_in));` in Post()), which will lead to heap use after free errors

