### PR TITLE
fix: remove unnecessary semicolon

### DIFF
--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -245,5 +245,5 @@ extern "C" {
 // Call the member function through the factory object
 DUCKDB_EXTENSION_API AESStateSSLFactory *CreateSSLFactory() {
 	return new AESStateSSLFactory();
-};
+}
 }

--- a/src/hffs.cpp
+++ b/src/hffs.cpp
@@ -42,7 +42,8 @@ static string ParseNextUrlFromLinkHeader(const string &link_header_content) {
 	throw IOException("Failed to parse Link header for paginated response, pagination support");
 }
 
-HFFileHandle::~HFFileHandle() {};
+HFFileHandle::~HFFileHandle() {
+}
 
 unique_ptr<HTTPClient> HFFileHandle::CreateClient() {
 	return http_params.http_util.InitializeClient(http_params, parsed_url.endpoint);

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -972,7 +972,7 @@ void HTTPFileHandle::StoreClient(unique_ptr<HTTPClient> client) {
 
 HTTPFileHandle::~HTTPFileHandle() {
 	DUCKDB_LOG_FILE_SYSTEM_CLOSE((*this));
-};
+}
 
 string HTTPFSUtil::GetName() const {
 	return "HTTPFS";


### PR DESCRIPTION
Removes compiler warning because of extra semicolon