### PR TITLE
Used cached handle with s3 region

### DIFF
--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -933,7 +933,7 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 			FullDownload(hfs, should_write_cache);
 		}
 		if (should_write_cache) {
-			current_cache->Insert(path, {length, last_modified, etag, version_id});
+			current_cache->Insert(path, GetCacheEntry());
 		}
 
 		if (!SkipBuffer()) {

--- a/test/sql/s3/incorrect_s3_region.test_slow
+++ b/test/sql/s3/incorrect_s3_region.test_slow
@@ -4,6 +4,8 @@
 
 require httpfs
 
+require parquet
+
 # override MinIO setup
 statement ok
 SET s3_access_key_id='';

--- a/test/sql/s3/incorrect_s3_region.test_slow
+++ b/test/sql/s3/incorrect_s3_region.test_slow
@@ -21,6 +21,9 @@ SELECT COUNT(*) FROM (FROM glob('s3://overturemaps-us-west-2/**/*.parquet') LIMI
 10
 
 statement ok
+FROM parquet_scan('s3://overturemaps-us-west-2/bridgefiles/2025-03-19.0-beta.0/dataset=Esri Community Maps/theme=buildings/type=building/part-00000-947c2149-23db-4abc-a7ee-3a892aac90ff.c000.snappy.parquet') LIMIT 1;
+
+statement ok
 SET s3_region='${s3_region}'
 
 endloop


### PR DESCRIPTION
Use cached entry so that corrected region parameter takes effect in subsequent request. 

Fixes https://github.com/duckdblabs/motherduck/issues/456