### PR TITLE
[minor] Remove unused variable

### DIFF
--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -63,7 +63,6 @@ static void LoadInternal(ExtensionLoader &loader) {
 		}
 		LocalFileSystem fs;
 		ClientContextFileOpener opener(context);
-		auto &config = DBConfig::GetConfig(context);
 		// Normalize ca_cert_file to absolute path
 		parameter = Value(fs.CanonicalizePath(value, opener));
 	};


### PR DESCRIPTION
I get the warning message as below
```sh
/home/vscode/duck-read-cache-fs/duckdb-httpfs/src/httpfs_extension.cpp: In lambda function:
/home/vscode/duck-read-cache-fs/duckdb-httpfs/src/httpfs_extension.cpp:66:23: warning: unused variable 'config' [-Wunused-variable]
   66 |                 auto &config = DBConfig::GetConfig(context);
      |                       ^~~~~~
```