### PR TITLE
WIP: Fix incorrect hostname lookup error in curl backend

### DIFF
--- a/test/sql/curl_client/test_relative_path_parsing.test
+++ b/test/sql/curl_client/test_relative_path_parsing.test
@@ -1,6 +1,6 @@
 # name: test/sql/curl_client/test_relative_path_parsing.test
 # description: test that parsing http url parts like /.//file works with localhost
-# group: [sql, curl_client]
+# group: [curl_client]
 
 require httpfs
 

--- a/test/sql/curl_client/test_relative_path_parsing.test
+++ b/test/sql/curl_client/test_relative_path_parsing.test
@@ -1,0 +1,38 @@
+# name: test/sql/curl_client/test_relative_path_parsing.test
+# description: test that parsing http url parts like /.//file works with localhost
+# group: [sql, curl_client]
+
+require httpfs
+
+set ignore_error_messages
+
+require-env PYTHON_HTTP_SERVER_URL
+
+require-env PYTHON_HTTP_SERVER_DIR
+
+statement ok
+CREATE TABLE lineitem as (SELECT 1 FROM range(0,5));
+
+statement ok
+copy lineitem to '${PYTHON_HTTP_SERVER_DIR}/lineitem.csv'
+
+foreach httpfs_implementation curl httplib
+
+query I
+SELECT count(*) FROM '${PYTHON_HTTP_SERVER_URL}/lineitem.csv';
+----
+6
+
+foreach parts ./ // /./
+
+statement ok
+SET httpfs_client_implementation='${httpfs_implementation}';
+
+query I
+SELECT count(*) FROM '${PYTHON_HTTP_SERVER_URL}/${parts}lineitem.csv';
+----
+6
+
+endloop
+
+endloop


### PR DESCRIPTION
If curl backend for httpfs is enabled, requests to IPs with specific relative url paths like `//1.csv` fail in CURL with "couldn't resolve hostname" error.

There is more troubleshooting information available in https://github.com/vortex-data/vortex/pull/6627#issuecomment-3950388173, 
but in a nutshell, if you patch


```
diff --git a/src/httpfs_curl_client.cpp b/src/httpfs_curl_client.cpp
index 9d413e7..0e23432 100644
--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -322,7 +322,7 @@ public:
 
                        // Add headers if any
                        curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers ? curl_headers.headers : nullptr);
-
+            curl_easy_setopt(*curl, CURLOPT_VERBOSE, 1L);
                        // Execute HEAD request
                        res = curl->Execute();
                        curl_easy_setopt(*curl, CURLOPT_NOBODY, 0L);
```

And launch

```
~/duckdb-httpfs ./build/debug/duckdb -c "SELECT * FROM 'http://127.0.0.1:8000//1.csv';"
* Could not resolve host: 1.csv
* shutting down connection #0
<...>
IO Error:
Could not resolve hostname error for HTTP HEAD to 'http://127.0.0.1:8000//1.csv'
~/duckdb-httpfs ./build/debug/duckdb -c "SELECT * FROM 'http://127.0.0.1:8000/1.csv';"
*   Trying 127.0.0.1:8000...
* connect to 127.0.0.1 port 8000 from 127.0.0.1 port 50582 failed: Connection refused
* Failed to connect to 127.0.0.1 port 8000 after 0 ms: Could not connect to server
* closing connection #0
*   Trying 127.0.0.1:8000...
* connect to 127.0.0.1 port 8000 from 127.0.0.1 port 50596 failed: Connection refused
* Failed to connect to 127.0.0.1 port 8000 after 0 ms: Could not connect to server
* closing connection #0
*   Trying 127.0.0.1:8000...
* connect to 127.0.0.1 port 8000 from 127.0.0.1 port 50602 failed: Connection refused
<...>
IO Error:
Could not connect to server error for HTTP HEAD to 'http://127.0.0.1:8000/1.csv'
```

You'd see CURL incorrectly tries to query `1.csv` as host instead of localhost. If a server is running, the single-slash query works but double-slash fails, although it's a valid URL.

As a first step, I've added a test which fails in current implementation