### PR TITLE
Fixup curl_url_set to take a CURLUPART_PATH, url baseline should already be provided

### DIFF
--- a/src/hffs.cpp
+++ b/src/hffs.cpp
@@ -54,8 +54,12 @@ string HuggingFaceFileSystem::ListHFRequest(ParsedHFUrl &url, HTTPFSParams &http
 	string link_header_result;
 
 	std::stringstream response;
+	string fragment_next_page_url = next_page_url;
+	if (StringUtil::StartsWith(next_page_url, url.endpoint)) {
+		fragment_next_page_url = next_page_url.substr(url.endpoint.size());
+	}
 	GetRequestInfo get_request(
-	    url.endpoint, next_page_url, header_map, http_params,
+	    url.endpoint, fragment_next_page_url, header_map, http_params,
 	    [&](const HTTPResponse &response) {
 		    if (static_cast<int>(response.status) >= 400) {
 			    throw HTTPException(response, "HTTP GET error on '%s' (HTTP %d)", next_page_url, response.status);

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -218,7 +218,7 @@ public:
 		{
 			curl_easy_setopt(*curl, CURLOPT_NOBODY, 0L);
 			CURLU *url = curl_url_dup(base_url);
-			curl_url_set(url, CURLUPART_URL, info.path.c_str(), 0);
+			curl_url_set(url, CURLUPART_PATH, info.path.c_str(), 0);
 
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
 			curl_easy_setopt(*curl, CURLOPT_CURLU, url);
@@ -273,7 +273,7 @@ public:
 		CURLcode res;
 		{
 			CURLU *url = curl_url_dup(base_url);
-			curl_url_set(url, CURLUPART_URL, info.path.c_str(), 0);
+			curl_url_set(url, CURLUPART_PATH, info.path.c_str(), 0);
 
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
 			curl_easy_setopt(*curl, CURLOPT_CURLU, url);
@@ -315,7 +315,7 @@ public:
 			curl_easy_setopt(*curl, CURLOPT_HTTPGET, 0L);
 
 			CURLU *url = curl_url_dup(base_url);
-			curl_url_set(url, CURLUPART_URL, info.path.c_str(), 0);
+			curl_url_set(url, CURLUPART_PATH, info.path.c_str(), 0);
 
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
 			curl_easy_setopt(*curl, CURLOPT_CURLU, url);
@@ -347,7 +347,7 @@ public:
 		CURLcode res;
 		{
 			CURLU *url = curl_url_dup(base_url);
-			curl_url_set(url, CURLUPART_URL, info.path.c_str(), 0);
+			curl_url_set(url, CURLUPART_PATH, info.path.c_str(), 0);
 
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
 			curl_easy_setopt(*curl, CURLOPT_CURLU, url);
@@ -387,7 +387,7 @@ public:
 		CURLcode res;
 		{
 			CURLU *url = curl_url_dup(base_url);
-			curl_url_set(url, CURLUPART_URL, info.path.c_str(), 0);
+			curl_url_set(url, CURLUPART_PATH, info.path.c_str(), 0);
 
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
 			curl_easy_setopt(*curl, CURLOPT_CURLU, url);

--- a/test/sql/curl_client/test_relative_path_parsing.test
+++ b/test/sql/curl_client/test_relative_path_parsing.test
@@ -1,6 +1,6 @@
 # name: test/sql/curl_client/test_relative_path_parsing.test
 # description: test that parsing http url parts like /.//file works with localhost
-# group: [sql, curl_client]
+# group: [curl_client]
 
 require httpfs
 

--- a/test/sql/curl_client/test_relative_path_parsing.test
+++ b/test/sql/curl_client/test_relative_path_parsing.test
@@ -1,0 +1,38 @@
+# name: test/sql/curl_client/test_relative_path_parsing.test
+# description: test that parsing http url parts like /.//file works with localhost
+# group: [sql, curl_client]
+
+require httpfs
+
+set ignore_error_messages
+
+require-env PYTHON_HTTP_SERVER_URL
+
+require-env PYTHON_HTTP_SERVER_DIR
+
+statement ok
+CREATE TABLE lineitem as (SELECT 1 FROM range(0,5));
+
+statement ok
+copy lineitem to '${PYTHON_HTTP_SERVER_DIR}/lineitem.csv'
+
+foreach httpfs_implementation curl httplib
+
+query I
+SELECT count(*) FROM '${PYTHON_HTTP_SERVER_URL}/lineitem.csv';
+----
+6
+
+foreach parts ./ // /./
+
+statement ok
+SET httpfs_client_implementation='${httpfs_implementation}';
+
+query I
+SELECT count(*) FROM '${PYTHON_HTTP_SERVER_URL}/${parts}lineitem.csv';
+----
+6
+
+endloop
+
+endloop


### PR DESCRIPTION
There is an issue where we were misusing the CURL API for building URL incrementally, and that would be visible when double slashes are present (since that's interpreted as a full file), this should fix that behaviour, I've validated locally, but waiting for CI results and reviews.

Testcase it's from https://github.com/duckdb/duckdb-httpfs/pull/261, that it's a PR adding the failing testcase and doubles also as issue report.

Thanks @myrrc!