### PR TITLE
CURLOPT_ACCEPT_ENCODING set to NULL

### DIFF
--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -173,7 +173,7 @@ public:
 		// set connection timeout
 		curl_easy_setopt(*curl, CURLOPT_CONNECTTIMEOUT, http_params.timeout);
 		// accept content as-is (i.e no decompressing)
-		curl_easy_setopt(*curl, CURLOPT_ACCEPT_ENCODING, "identity");
+		curl_easy_setopt(*curl, CURLOPT_ACCEPT_ENCODING, NULL);
 		// follow redirects
 		curl_easy_setopt(*curl, CURLOPT_FOLLOWLOCATION, http_params.follow_location ? 1L : 0L);
 


### PR DESCRIPTION
Relevant documentation at https://curl.se/libcurl/c/CURLOPT_ACCEPT_ENCODING.html

I am considering whether having an option (that can be set user side), would be best here in case of regressions.

Fix was proposed by @ywelsch in the context of wider testing they performed where files uploaded to S3 like:
```
aws s3 cp file.json.gz s3://<bucket>/file.json.gz --content-type gzip
```
would be unzipped twice since information is not propagated between layers.