### PR TITLE
Fix incorrect AWS list request in 1.4

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1244,8 +1244,13 @@ string AWSListObjectV2::Request(string &path, HTTPParams &http_params, S3AuthPar
 	// Get requests use fresh connection
 	string full_host = parsed_url.http_proto + parsed_url.host;
 	std::stringstream response;
+    // GetRequestInfo(host, path) calls BaseRequest::BaseRequest(host, path)
+    // which is incorrect -- it binds url to path only, not to host + path.
+    // Thus requests using request->url (i.e. curl requests) are incorrect,
+    // as they don't use the host. Fix this here by concatenating both parts
+    const string host_with_path = full_host + listobjectv2_url;
 	GetRequestInfo get_request(
-	    full_host, listobjectv2_url, header_map, http_params,
+	    host_with_path, header_map, http_params,
 	    [&](const HTTPResponse &response) {
 		    if (static_cast<int>(response.status) >= 400) {
 			    string trimmed_path = path;


### PR DESCRIPTION
If you use curl backend in v1.4, glob requests or generally everything involving S3 list request fails with something like

```
Other error: {"exception_type":"IO","exception_message":"URL using bad/illegal format or missing URL error for HTTP GET to '/?encoding-type=url&list-type=2&prefix=6685%2Fmerge%2F22445786768%2Ffineweb%2Fvortex-file-compressed%2F'"}
```

This doesn't happen with httplib backend.
The reason for this is that curl backend uses
`GetRequest->url` field for url propagation which is not set up correctly.

The flaw is actually in `BaseRequest(path, host)` constructor which initializes `url` to `path` only, ignoring `url`, but as it's in main DuckDB repo and the `url` is a `const string&` I can't change it here.

Fix this by manually concatenating host and path.

I couldn't reproduce this issue in v1.5, but there may be similar issues until `BaseRequest` is fixed.
I believe this fix should be backported to 1.4.