### PR TITLE
Remove url+path constructor for GetRequestInfo

### DIFF
--- a/src/hffs.cpp
+++ b/src/hffs.cpp
@@ -59,7 +59,7 @@ string HuggingFaceFileSystem::ListHFRequest(ParsedHFUrl &url, HTTPFSParams &http
 		fragment_next_page_url = next_page_url.substr(url.endpoint.size());
 	}
 	GetRequestInfo get_request(
-	    url.endpoint, fragment_next_page_url, header_map, http_params,
+	    url.endpoint + "/" + fragment_next_page_url, header_map, http_params,
 	    [&](const HTTPResponse &response) {
 		    if (static_cast<int>(response.status) >= 400) {
 			    throw HTTPException(response, "HTTP GET error on '%s' (HTTP %d)", next_page_url, response.status);

--- a/src/hffs.cpp
+++ b/src/hffs.cpp
@@ -58,8 +58,11 @@ string HuggingFaceFileSystem::ListHFRequest(ParsedHFUrl &url, HTTPFSParams &http
 	if (StringUtil::StartsWith(next_page_url, url.endpoint)) {
 		fragment_next_page_url = next_page_url.substr(url.endpoint.size());
 	}
+	if (!StringUtil::StartsWith(fragment_next_page_url, "/")) {
+		fragment_next_page_url = "/" + fragment_next_page_url;
+	}
 	GetRequestInfo get_request(
-	    url.endpoint + "/" + fragment_next_page_url, header_map, http_params,
+	    url.endpoint + fragment_next_page_url, header_map, http_params,
 	    [&](const HTTPResponse &response) {
 		    if (static_cast<int>(response.status) >= 400) {
 			    throw HTTPException(response, "HTTP GET error on '%s' (HTTP %d)", next_page_url, response.status);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1354,10 +1354,18 @@ string AWSListObjectV2::Request(const string &path, HTTPParams &http_params, S3A
 		// Get requests use fresh connection
 		string full_host = parsed_url.http_proto + parsed_url.host;
 		string listobjectv2_url = req_path + "?" + encoded_params;
+		string actual_path = full_host;
+		if (StringUtil::StartsWith(listobjectv2_url, full_host)) {
+			actual_path = listobjectv2_url;
+		} else if (listobjectv2_url[0] == '/') {
+			actual_path += listobjectv2_url;
+		} else {
+			actual_path += "/" + listobjectv2_url;
+		}
 		std::stringstream response;
 		ErrorData error;
 		GetRequestInfo get_request(
-		    full_host + listobjectv2_url, header_map, http_params,
+		    actual_path, header_map, http_params,
 		    [&](const HTTPResponse &response) {
 			    if (static_cast<int>(response.status) >= 400) {
 				    string trimmed_path = path;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1357,7 +1357,7 @@ string AWSListObjectV2::Request(const string &path, HTTPParams &http_params, S3A
 		std::stringstream response;
 		ErrorData error;
 		GetRequestInfo get_request(
-		    full_host + "/" + listobjectv2_url, header_map, http_params,
+		    full_host + listobjectv2_url, header_map, http_params,
 		    [&](const HTTPResponse &response) {
 			    if (static_cast<int>(response.status) >= 400) {
 				    string trimmed_path = path;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1357,7 +1357,7 @@ string AWSListObjectV2::Request(const string &path, HTTPParams &http_params, S3A
 		std::stringstream response;
 		ErrorData error;
 		GetRequestInfo get_request(
-		    full_host, listobjectv2_url, header_map, http_params,
+		    full_host + "/" + listobjectv2_url, header_map, http_params,
 		    [&](const HTTPResponse &response) {
 			    if (static_cast<int>(response.status) >= 400) {
 				    string trimmed_path = path;


### PR DESCRIPTION
This should make so that GetRequestInfo is harder to misuse, fixing https://github.com/duckdb/duckdb/issues/21116.

Now we align GetRequestInfo to other similar constructor, that they take only the full URL.