### PR TITLE
Clean-up S3 Multi Part Upload by moving implementation to separate files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,8 @@ set(HTTPFS_SOURCES
     crypto.cpp
     hash_functions.cpp
     create_secret_functions.cpp
-    httpfs_extension.cpp)
+    httpfs_extension.cpp
+    s3_multi_part_upload.cpp)
 if(NOT EMSCRIPTEN)
   set(HTTPFS_SOURCES ${HTTPFS_SOURCES} crypto.cpp httpfs_httplib_client.cpp
                      httpfs_curl_client.cpp)

--- a/src/include/s3_multi_part_upload.hpp
+++ b/src/include/s3_multi_part_upload.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "s3fs.hpp"
+#include "duckdb/execution/task_error_manager.hpp"
+
+namespace duckdb {
+
+// Holds the buffered data for 1 part of an S3 Multipart upload
+class S3WriteBuffer {
+public:
+	explicit S3WriteBuffer(idx_t buffer_start, size_t buffer_size, BufferHandle buffer_p)
+		: idx(0), buffer_start(buffer_start), buffer(std::move(buffer_p)) {
+		buffer_end = buffer_start + buffer_size;
+		part_no = buffer_start / buffer_size;
+		uploading = false;
+	}
+
+	void *Ptr() {
+		return buffer.Ptr();
+	}
+
+	// The S3 multipart part number. Note that internally we start at 0 but AWS S3 starts at 1
+	idx_t part_no;
+
+	idx_t idx;
+	idx_t buffer_start;
+	idx_t buffer_end;
+	BufferHandle buffer;
+	atomic<bool> uploading;
+};
+
+
+class S3MultiPartUpload {
+public:
+	S3MultiPartUpload(S3FileHandle &s3_file_handle);
+
+public:
+	shared_ptr<S3WriteBuffer> GetBuffer(uint16_t write_buffer_idx);
+	void Finalize();
+
+	S3FileSystem &s3fs;
+	S3FileHandle &s3_file_handle;
+	const S3ConfigParams config_params;
+
+	bool initialized_multipart_upload = false;
+	string multipart_upload_id;
+	size_t part_size;
+
+	//! Write buffers for this file
+	mutex write_buffers_lock;
+	unordered_map<uint16_t, shared_ptr<S3WriteBuffer>> write_buffers;
+
+	//! Synchronization for upload threads
+	mutex uploads_in_progress_lock;
+	std::condition_variable uploads_in_progress_cv;
+	std::condition_variable final_flush_cv;
+	uint16_t uploads_in_progress;
+
+	//! Etags are stored for each part
+	mutex part_etags_lock;
+	unordered_map<uint16_t, string> part_etags;
+
+	//! Info for upload
+	atomic<uint16_t> parts_uploaded;
+	bool upload_finalized = true;
+
+	//! Error handling in upload threads
+	atomic<bool> uploader_has_error {false};
+	std::exception_ptr upload_exception;
+};
+
+}

--- a/src/include/s3_multi_part_upload.hpp
+++ b/src/include/s3_multi_part_upload.hpp
@@ -35,6 +35,15 @@ public:
 	S3MultiPartUpload(S3FileHandle &s3_file_handle);
 
 public:
+	// Uploads the contents of write_buffer to S3.
+	// Note: caller is responsible to not call this method twice on the same buffer
+	static void UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer);
+	static void UploadSingleBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer);
+	static void UploadBufferImplementation(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer,
+										   string query_param, bool direct_throw);
+	void NotifyUploadsInProgress();
+
+public:
 	shared_ptr<S3WriteBuffer> GetBuffer(uint16_t write_buffer_idx);
 	void Finalize();
 

--- a/src/include/s3_multi_part_upload.hpp
+++ b/src/include/s3_multi_part_upload.hpp
@@ -41,7 +41,9 @@ public:
 	static void UploadBufferImplementation(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer,
 	                                       string query_param, bool direct_throw);
 	void NotifyUploadsInProgress();
+
 	string InitializeMultipartUpload();
+	void FinalizeMultipartUpload();
 
 public:
 	shared_ptr<S3WriteBuffer> GetBuffer(uint16_t write_buffer_idx);

--- a/src/include/s3_multi_part_upload.hpp
+++ b/src/include/s3_multi_part_upload.hpp
@@ -9,7 +9,7 @@ namespace duckdb {
 class S3WriteBuffer {
 public:
 	explicit S3WriteBuffer(idx_t buffer_start, size_t buffer_size, BufferHandle buffer_p)
-		: idx(0), buffer_start(buffer_start), buffer(std::move(buffer_p)) {
+	    : idx(0), buffer_start(buffer_start), buffer(std::move(buffer_p)) {
 		buffer_end = buffer_start + buffer_size;
 		part_no = buffer_start / buffer_size;
 		uploading = false;
@@ -29,7 +29,6 @@ public:
 	atomic<bool> uploading;
 };
 
-
 class S3MultiPartUpload {
 public:
 	S3MultiPartUpload(S3FileHandle &s3_file_handle);
@@ -40,8 +39,9 @@ public:
 	static void UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer);
 	static void UploadSingleBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer);
 	static void UploadBufferImplementation(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer,
-										   string query_param, bool direct_throw);
+	                                       string query_param, bool direct_throw);
 	void NotifyUploadsInProgress();
+	string InitializeMultipartUpload();
 
 public:
 	shared_ptr<S3WriteBuffer> GetBuffer(uint16_t write_buffer_idx);
@@ -49,6 +49,7 @@ public:
 
 	S3FileSystem &s3fs;
 	S3FileHandle &s3_file_handle;
+	string path;
 	const S3ConfigParams config_params;
 
 	bool initialized_multipart_upload = false;
@@ -78,4 +79,4 @@ public:
 	std::exception_ptr upload_exception;
 };
 
-}
+} // namespace duckdb

--- a/src/include/s3_multi_part_upload.hpp
+++ b/src/include/s3_multi_part_upload.hpp
@@ -45,6 +45,12 @@ public:
 	string InitializeMultipartUpload();
 	void FinalizeMultipartUpload();
 
+	void FlushBuffer(shared_ptr<S3WriteBuffer> write_buffer);
+	void FlushAllBuffers();
+
+	//! Rethrow IO Exception originating from an upload thread
+	void RethrowIOError();
+
 public:
 	shared_ptr<S3WriteBuffer> GetBuffer(uint16_t write_buffer_idx);
 	void Finalize();

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -178,7 +178,6 @@ public:
 	void FileSync(FileHandle &handle) override;
 	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 
-	string InitializeMultipartUpload(S3FileHandle &file_handle);
 	void FinalizeMultipartUpload(S3FileHandle &file_handle);
 
 	void FlushAllBuffers(S3FileHandle &handle);

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -178,8 +178,6 @@ public:
 	void FileSync(FileHandle &handle) override;
 	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 
-	void FinalizeMultipartUpload(S3FileHandle &file_handle);
-
 	void FlushAllBuffers(S3FileHandle &handle);
 
 	void ReadQueryParams(const string &url_query_param, S3AuthParams &params);

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -115,30 +115,8 @@ struct S3ConfigParams {
 };
 
 class S3FileSystem;
-
-// Holds the buffered data for 1 part of an S3 Multipart upload
-class S3WriteBuffer {
-public:
-	explicit S3WriteBuffer(idx_t buffer_start, size_t buffer_size, BufferHandle buffer_p)
-	    : idx(0), buffer_start(buffer_start), buffer(std::move(buffer_p)) {
-		buffer_end = buffer_start + buffer_size;
-		part_no = buffer_start / buffer_size;
-		uploading = false;
-	}
-
-	void *Ptr() {
-		return buffer.Ptr();
-	}
-
-	// The S3 multipart part number. Note that internally we start at 0 but AWS S3 starts at 1
-	idx_t part_no;
-
-	idx_t idx;
-	idx_t buffer_start;
-	idx_t buffer_end;
-	BufferHandle buffer;
-	atomic<bool> uploading;
-};
+class S3MultiPartUpload;
+class S3WriteBuffer;
 
 class S3FileHandle : public HTTPFileHandle {
 	friend class S3FileSystem;
@@ -150,13 +128,12 @@ public:
 
 	S3AuthParams auth_params;
 	const S3ConfigParams config_params;
-	bool initialized_multipart_upload {false};
+	shared_ptr<S3MultiPartUpload> multi_part_upload;
 
 public:
 	void Close() override;
 	void Initialize(optional_ptr<FileOpener> opener) override;
-
-	shared_ptr<S3WriteBuffer> GetBuffer(uint16_t write_buffer_idx);
+	void FinalizeUpload();
 
 protected:
 	void InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cache_entry) override;
@@ -164,39 +141,10 @@ protected:
 	void SetRegion(string region_p);
 
 protected:
-	string multipart_upload_id;
-	size_t part_size;
-
-	//! Write buffers for this file
-	mutex write_buffers_lock;
-	unordered_map<uint16_t, shared_ptr<S3WriteBuffer>> write_buffers;
-
-	//! Synchronization for upload threads
-	mutex uploads_in_progress_lock;
-	std::condition_variable uploads_in_progress_cv;
-	std::condition_variable final_flush_cv;
-	uint16_t uploads_in_progress;
-
-	//! Etags are stored for each part
-	mutex part_etags_lock;
-	unordered_map<uint16_t, string> part_etags;
-
-	//! Info for upload
-	atomic<uint16_t> parts_uploaded;
-	bool upload_finalized = true;
-
-	//! Error handling in upload threads
-	atomic<bool> uploader_has_error {false};
-	std::exception_ptr upload_exception;
-
 	unique_ptr<HTTPClient> CreateClient() override;
 
 	//! Rethrow IO Exception originating from an upload thread
-	void RethrowIOError() {
-		if (uploader_has_error) {
-			std::rethrow_exception(upload_exception);
-		}
-	}
+	void RethrowIOError();
 };
 
 class S3FileSystem : public HTTPFileSystem {

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -142,9 +142,6 @@ protected:
 
 protected:
 	unique_ptr<HTTPClient> CreateClient() override;
-
-	//! Rethrow IO Exception originating from an upload thread
-	void RethrowIOError();
 };
 
 class S3FileSystem : public HTTPFileSystem {
@@ -177,8 +174,6 @@ public:
 	void RemoveDirectory(const string &directory, optional_ptr<FileOpener> opener = nullptr) override;
 	void FileSync(FileHandle &handle) override;
 	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
-
-	void FlushAllBuffers(S3FileHandle &handle);
 
 	void ReadQueryParams(const string &url_query_param, S3AuthParams &params);
 	static ParsedS3Url S3UrlParse(string url, const S3AuthParams &params);
@@ -220,8 +215,6 @@ protected:
 	static string GetPrefix(const string &url);
 	duckdb::unique_ptr<HTTPFileHandle> CreateHandle(const OpenFileInfo &file, FileOpenFlags flags,
 	                                                optional_ptr<FileOpener> opener) override;
-
-	void FlushBuffer(S3FileHandle &handle, shared_ptr<S3WriteBuffer> write_buffer);
 	string GetPayloadHash(char *buffer, idx_t buffer_len);
 };
 

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -191,13 +191,6 @@ public:
 
 	static string TryGetPrefix(const string &url);
 
-	// Uploads the contents of write_buffer to S3.
-	// Note: caller is responsible to not call this method twice on the same buffer
-	static void UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer);
-	static void UploadSingleBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer);
-	static void UploadBufferImplementation(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer,
-	                                       string query_param, bool direct_throw);
-
 	//! Wrapper around BufferManager::Allocate to limit the number of buffers
 	BufferHandle Allocate(idx_t part_size, uint16_t max_threads);
 
@@ -227,7 +220,6 @@ protected:
 	}
 
 protected:
-	static void NotifyUploadsInProgress(S3FileHandle &file_handle);
 	static string GetPrefix(const string &url);
 	duckdb::unique_ptr<HTTPFileHandle> CreateHandle(const OpenFileInfo &file, FileOpenFlags flags,
 	                                                optional_ptr<FileOpener> opener) override;

--- a/src/s3_multi_part_upload.cpp
+++ b/src/s3_multi_part_upload.cpp
@@ -15,7 +15,7 @@ void S3MultiPartUpload::Finalize() {
 	}
 	s3fs.FlushAllBuffers(s3_file_handle);
 	if (parts_uploaded) {
-		s3fs.FinalizeMultipartUpload(s3_file_handle);
+		FinalizeMultipartUpload();
 	}
 }
 
@@ -73,6 +73,40 @@ string S3MultiPartUpload::InitializeMultipartUpload() {
 	initialized_multipart_upload = true;
 
 	return result.substr(open_tag_pos, close_tag_pos - open_tag_pos);
+}
+
+void S3MultiPartUpload::FinalizeMultipartUpload() {
+	if (upload_finalized) {
+		return;
+	}
+
+	upload_finalized = true;
+
+	std::stringstream ss;
+	ss << "<CompleteMultipartUpload xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">";
+
+	auto parts = parts_uploaded.load();
+	for (auto i = 0; i < parts; i++) {
+		auto etag_lookup = part_etags.find(i);
+		if (etag_lookup == part_etags.end()) {
+			throw IOException("Unknown part number");
+		}
+		ss << "<Part><ETag>" << etag_lookup->second << "</ETag><PartNumber>" << i + 1 << "</PartNumber></Part>";
+	}
+	ss << "</CompleteMultipartUpload>";
+	string body = ss.str();
+
+	// Response is around ~400 in AWS docs so this should be enough to not need a resize
+	string result;
+
+	string query_param = "uploadId=" + S3FileSystem::UrlEncode(multipart_upload_id, true);
+	auto res =
+		s3fs.PostRequest(s3_file_handle, path, {}, result, (char *)body.c_str(), body.length(), query_param);
+	auto open_tag_pos = result.find("<CompleteMultipartUploadResult", 0);
+	if (open_tag_pos == string::npos) {
+		throw HTTPException(*res, "Unexpected response during S3 multipart upload finalization: %d\n\n%s",
+							static_cast<int>(res->status), result);
+	}
 }
 
 void S3MultiPartUpload::UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer) {

--- a/src/s3_multi_part_upload.cpp
+++ b/src/s3_multi_part_upload.cpp
@@ -229,7 +229,7 @@ void S3MultiPartUpload::FlushBuffer(shared_ptr<S3WriteBuffer> write_buffer) {
 	}
 
 #ifdef SAME_THREAD_UPLOAD
-	UploadBuffer(file_handle, write_buffer);
+	UploadBuffer(s3_file_handle, write_buffer);
 	return;
 #endif
 

--- a/src/s3_multi_part_upload.cpp
+++ b/src/s3_multi_part_upload.cpp
@@ -1,5 +1,9 @@
 #include "s3_multi_part_upload.hpp"
 
+#include <thread>
+#ifdef EMSCRIPTEN
+#define SAME_THREAD_UPLOAD
+#endif
 namespace duckdb {
 
 S3MultiPartUpload::S3MultiPartUpload(S3FileHandle &s3_file_handle)
@@ -13,7 +17,7 @@ void S3MultiPartUpload::Finalize() {
 		// already finalized
 		return;
 	}
-	s3fs.FlushAllBuffers(s3_file_handle);
+	FlushAllBuffers();
 	if (parts_uploaded) {
 		FinalizeMultipartUpload();
 	}
@@ -100,12 +104,11 @@ void S3MultiPartUpload::FinalizeMultipartUpload() {
 	string result;
 
 	string query_param = "uploadId=" + S3FileSystem::UrlEncode(multipart_upload_id, true);
-	auto res =
-		s3fs.PostRequest(s3_file_handle, path, {}, result, (char *)body.c_str(), body.length(), query_param);
+	auto res = s3fs.PostRequest(s3_file_handle, path, {}, result, (char *)body.c_str(), body.length(), query_param);
 	auto open_tag_pos = result.find("<CompleteMultipartUploadResult", 0);
 	if (open_tag_pos == string::npos) {
 		throw HTTPException(*res, "Unexpected response during S3 multipart upload finalization: %d\n\n%s",
-							static_cast<int>(res->status), result);
+		                    static_cast<int>(res->status), result);
 	}
 }
 
@@ -187,6 +190,94 @@ void S3MultiPartUpload::NotifyUploadsInProgress() {
 	uploads_in_progress_cv.notify_one();
 	final_flush_cv.notify_one();
 #endif
+}
+
+void S3MultiPartUpload::FlushBuffer(shared_ptr<S3WriteBuffer> write_buffer) {
+	if (write_buffer->idx == 0) {
+		return;
+	}
+
+	auto uploading = write_buffer->uploading.load();
+	if (uploading) {
+		return;
+	}
+	bool can_upload = write_buffer->uploading.compare_exchange_strong(uploading, true);
+	if (!can_upload) {
+		return;
+	}
+
+	RethrowIOError();
+
+	{
+		unique_lock<mutex> lck(write_buffers_lock);
+		write_buffers.erase(write_buffer->part_no);
+	}
+
+	{
+		unique_lock<mutex> lck(uploads_in_progress_lock);
+		// check if there are upload threads available
+#ifndef SAME_THREAD_UPLOAD
+		if (uploads_in_progress >= config_params.max_upload_threads) {
+			// there are not - wait for one to become available
+			uploads_in_progress_cv.wait(lck, [&] { return uploads_in_progress < config_params.max_upload_threads; });
+		}
+#endif
+		uploads_in_progress++;
+	}
+	if (initialized_multipart_upload == false) {
+		multipart_upload_id = InitializeMultipartUpload();
+	}
+
+#ifdef SAME_THREAD_UPLOAD
+	UploadBuffer(file_handle, write_buffer);
+	return;
+#endif
+
+	std::thread upload_thread(S3MultiPartUpload::UploadBuffer, std::ref(s3_file_handle), write_buffer);
+	upload_thread.detach();
+}
+
+// Note that FlushAll currently does not allow to continue writing afterwards. Therefore, FinalizeMultipartUpload should
+// be called right after it!
+// TODO: we can fix this by keeping the last partially written buffer in memory and allow reuploading it with new data.
+void S3MultiPartUpload::FlushAllBuffers() {
+	//  Collect references to all buffers to check
+	vector<shared_ptr<S3WriteBuffer>> to_flush;
+	write_buffers_lock.lock();
+	for (auto &item : write_buffers) {
+		to_flush.push_back(item.second);
+	}
+	write_buffers_lock.unlock();
+
+	if (!initialized_multipart_upload) {
+		// TODO (carlo): unclear how to handle kms_key_id, but given currently they are custom, leave the multiupload
+		// codepath in that case
+		if (to_flush.size() == 1 && s3_file_handle.auth_params.kms_key_id.empty()) {
+			S3MultiPartUpload::UploadSingleBuffer(s3_file_handle, to_flush[0]);
+			upload_finalized = true;
+			return;
+		} else {
+			multipart_upload_id = InitializeMultipartUpload();
+		}
+	}
+	// Flush all buffers that aren't already uploading
+	for (auto &write_buffer : to_flush) {
+		if (!write_buffer->uploading) {
+			FlushBuffer(write_buffer);
+		}
+	}
+	unique_lock<mutex> lck(uploads_in_progress_lock);
+#ifndef SAME_THREAD_UPLOAD
+	final_flush_cv.wait(lck, [&] { return uploads_in_progress == 0; });
+#endif
+
+	RethrowIOError();
+}
+
+void S3MultiPartUpload::RethrowIOError() {
+	if (uploader_has_error) {
+		std::rethrow_exception(upload_exception);
+	}
 }
 
 } // namespace duckdb

--- a/src/s3_multi_part_upload.cpp
+++ b/src/s3_multi_part_upload.cpp
@@ -1,0 +1,51 @@
+#include "s3_multi_part_upload.hpp"
+
+namespace duckdb {
+
+
+S3MultiPartUpload::S3MultiPartUpload(S3FileHandle &s3_file_handle) : s3fs(s3_file_handle.file_system.Cast<S3FileSystem>()), s3_file_handle(s3_file_handle), config_params(s3_file_handle.config_params), uploads_in_progress(0), parts_uploaded(0), upload_finalized(false),
+	  uploader_has_error(false), upload_exception(nullptr) {
+}
+
+void S3MultiPartUpload::Finalize() {
+	if (upload_finalized) {
+		// already finalized
+		return;
+	}
+	s3fs.FlushAllBuffers(s3_file_handle);
+	if (parts_uploaded) {
+		s3fs.FinalizeMultipartUpload(s3_file_handle);
+	}
+}
+
+shared_ptr<S3WriteBuffer> S3MultiPartUpload::GetBuffer(uint16_t write_buffer_idx) {
+	// Check if write buffer already exists
+	{
+		unique_lock<mutex> lck(write_buffers_lock);
+		auto lookup_result = write_buffers.find(write_buffer_idx);
+		if (lookup_result != write_buffers.end()) {
+			shared_ptr<S3WriteBuffer> buffer = lookup_result->second;
+			return buffer;
+		}
+	}
+
+	auto buffer_handle = s3fs.Allocate(part_size, config_params.max_upload_threads);
+	auto new_write_buffer =
+		make_shared_ptr<S3WriteBuffer>(write_buffer_idx * part_size, part_size, std::move(buffer_handle));
+	{
+		unique_lock<mutex> lck(write_buffers_lock);
+		auto lookup_result = write_buffers.find(write_buffer_idx);
+
+		// Check if other thread has created the same buffer, if so we return theirs and drop ours.
+		if (lookup_result != write_buffers.end()) {
+			// write_buffer_idx << std::endl;
+			shared_ptr<S3WriteBuffer> write_buffer = lookup_result->second;
+			return write_buffer;
+		}
+		write_buffers.insert(pair<uint16_t, shared_ptr<S3WriteBuffer>>(write_buffer_idx, new_write_buffer));
+	}
+
+	return new_write_buffer;
+}
+
+}

--- a/src/s3_multi_part_upload.cpp
+++ b/src/s3_multi_part_upload.cpp
@@ -48,4 +48,85 @@ shared_ptr<S3WriteBuffer> S3MultiPartUpload::GetBuffer(uint16_t write_buffer_idx
 	return new_write_buffer;
 }
 
+
+void S3MultiPartUpload::UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer) {
+	auto &multi_file_upload = *file_handle.multi_part_upload;
+	string query_param = "partNumber=" + to_string(write_buffer->part_no + 1) + "&" +
+	                     "uploadId=" + S3FileSystem::UrlEncode(multi_file_upload.multipart_upload_id, true);
+
+	UploadBufferImplementation(file_handle, write_buffer, query_param, false);
+
+	multi_file_upload.NotifyUploadsInProgress();
+}
+
+void S3MultiPartUpload::UploadSingleBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer) {
+	UploadBufferImplementation(file_handle, write_buffer, "", true);
+}
+
+void S3MultiPartUpload::UploadBufferImplementation(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer,
+                                              string query_param, bool single_upload) {
+	auto &s3fs = (S3FileSystem &)file_handle.file_system;
+	auto &multi_file_upload = *file_handle.multi_part_upload;
+
+	unique_ptr<HTTPResponse> res;
+	string etag;
+
+	try {
+		res = s3fs.PutRequest(file_handle, file_handle.path, {}, (char *)write_buffer->Ptr(), write_buffer->idx,
+		                      query_param);
+
+		if (res->status != HTTPStatusCode::OK_200) {
+			throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", file_handle.path,
+			                    res->GetError(), static_cast<int>(res->status));
+		}
+
+		if (!res->headers.HasHeader("ETag")) {
+			throw IOException("Unexpected response when uploading part to S3");
+		}
+		etag = res->headers.GetHeaderValue("ETag");
+	} catch (std::exception &ex) {
+		if (single_upload) {
+			throw;
+		}
+		ErrorData error(ex);
+		if (error.Type() != ExceptionType::IO && error.Type() != ExceptionType::HTTP) {
+			throw;
+		}
+		// Ensure only one thread sets the exception
+		bool f = false;
+		auto exchanged = multi_file_upload.uploader_has_error.compare_exchange_strong(f, true);
+		if (exchanged) {
+			multi_file_upload.upload_exception = std::current_exception();
+		}
+
+		D_ASSERT(!single_upload); // If we are here we are in the multi-buffer situation
+		multi_file_upload.NotifyUploadsInProgress();
+		return;
+	}
+
+	// Insert etag
+	{
+		unique_lock<mutex> lck(multi_file_upload.part_etags_lock);
+		multi_file_upload.part_etags.insert(std::pair<uint16_t, string>(write_buffer->part_no, etag));
+	}
+
+	multi_file_upload.parts_uploaded++;
+
+	// Free up space for another thread to acquire an S3WriteBuffer
+	write_buffer.reset();
+}
+
+void S3MultiPartUpload::NotifyUploadsInProgress() {
+	{
+		unique_lock<mutex> lck(uploads_in_progress_lock);
+		uploads_in_progress--;
+	}
+	// Note that there are 2 cv's because otherwise we might deadlock when the final flushing thread is notified while
+	// another thread is still waiting for an upload thread
+#ifndef SAME_THREAD_UPLOAD
+	uploads_in_progress_cv.notify_one();
+	final_flush_cv.notify_one();
+#endif
+}
+
 }

--- a/src/s3_multi_part_upload.cpp
+++ b/src/s3_multi_part_upload.cpp
@@ -2,9 +2,10 @@
 
 namespace duckdb {
 
-
-S3MultiPartUpload::S3MultiPartUpload(S3FileHandle &s3_file_handle) : s3fs(s3_file_handle.file_system.Cast<S3FileSystem>()), s3_file_handle(s3_file_handle), config_params(s3_file_handle.config_params), uploads_in_progress(0), parts_uploaded(0), upload_finalized(false),
-	  uploader_has_error(false), upload_exception(nullptr) {
+S3MultiPartUpload::S3MultiPartUpload(S3FileHandle &s3_file_handle)
+    : s3fs(s3_file_handle.file_system.Cast<S3FileSystem>()), s3_file_handle(s3_file_handle), path(s3_file_handle.path),
+      config_params(s3_file_handle.config_params), uploads_in_progress(0), parts_uploaded(0), upload_finalized(false),
+      uploader_has_error(false), upload_exception(nullptr) {
 }
 
 void S3MultiPartUpload::Finalize() {
@@ -31,7 +32,7 @@ shared_ptr<S3WriteBuffer> S3MultiPartUpload::GetBuffer(uint16_t write_buffer_idx
 
 	auto buffer_handle = s3fs.Allocate(part_size, config_params.max_upload_threads);
 	auto new_write_buffer =
-		make_shared_ptr<S3WriteBuffer>(write_buffer_idx * part_size, part_size, std::move(buffer_handle));
+	    make_shared_ptr<S3WriteBuffer>(write_buffer_idx * part_size, part_size, std::move(buffer_handle));
 	{
 		unique_lock<mutex> lck(write_buffers_lock);
 		auto lookup_result = write_buffers.find(write_buffer_idx);
@@ -48,6 +49,31 @@ shared_ptr<S3WriteBuffer> S3MultiPartUpload::GetBuffer(uint16_t write_buffer_idx
 	return new_write_buffer;
 }
 
+// Opens the multipart upload and returns the ID
+string S3MultiPartUpload::InitializeMultipartUpload() {
+	// AWS response is around 300~ chars in docs so this should be enough to not need a resize
+	string result;
+	string query_param = "uploads=";
+	auto res = s3fs.PostRequest(s3_file_handle, path, {}, result, nullptr, 0, query_param);
+
+	if (res->status != HTTPStatusCode::OK_200) {
+		throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", path, res->GetError(),
+		                    static_cast<int>(res->status));
+	}
+
+	auto open_tag_pos = result.find("<UploadId>", 0);
+	auto close_tag_pos = result.find("</UploadId>", open_tag_pos);
+
+	if (open_tag_pos == string::npos || close_tag_pos == string::npos) {
+		throw HTTPException("Unexpected response while initializing S3 multipart upload");
+	}
+
+	open_tag_pos += 10; // Skip open tag
+
+	initialized_multipart_upload = true;
+
+	return result.substr(open_tag_pos, close_tag_pos - open_tag_pos);
+}
 
 void S3MultiPartUpload::UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer) {
 	auto &multi_file_upload = *file_handle.multi_part_upload;
@@ -64,7 +90,7 @@ void S3MultiPartUpload::UploadSingleBuffer(S3FileHandle &file_handle, shared_ptr
 }
 
 void S3MultiPartUpload::UploadBufferImplementation(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer,
-                                              string query_param, bool single_upload) {
+                                                   string query_param, bool single_upload) {
 	auto &s3fs = (S3FileSystem &)file_handle.file_system;
 	auto &multi_file_upload = *file_handle.multi_part_upload;
 
@@ -129,4 +155,4 @@ void S3MultiPartUpload::NotifyUploadsInProgress() {
 #endif
 }
 
-}
+} // namespace duckdb

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -474,42 +474,6 @@ void S3FileHandle::RethrowIOError() {
 	}
 }
 
-void S3FileSystem::FinalizeMultipartUpload(S3FileHandle &file_handle) {
-	auto &s3fs = (S3FileSystem &)file_handle.file_system;
-	auto &multi_file_upload = *file_handle.multi_part_upload;
-	if (multi_file_upload.upload_finalized) {
-		return;
-	}
-
-	multi_file_upload.upload_finalized = true;
-
-	std::stringstream ss;
-	ss << "<CompleteMultipartUpload xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">";
-
-	auto parts = multi_file_upload.parts_uploaded.load();
-	for (auto i = 0; i < parts; i++) {
-		auto etag_lookup = multi_file_upload.part_etags.find(i);
-		if (etag_lookup == multi_file_upload.part_etags.end()) {
-			throw IOException("Unknown part number");
-		}
-		ss << "<Part><ETag>" << etag_lookup->second << "</ETag><PartNumber>" << i + 1 << "</PartNumber></Part>";
-	}
-	ss << "</CompleteMultipartUpload>";
-	string body = ss.str();
-
-	// Response is around ~400 in AWS docs so this should be enough to not need a resize
-	string result;
-
-	string query_param = "uploadId=" + S3FileSystem::UrlEncode(multi_file_upload.multipart_upload_id, true);
-	auto res =
-	    s3fs.PostRequest(file_handle, file_handle.path, {}, result, (char *)body.c_str(), body.length(), query_param);
-	auto open_tag_pos = result.find("<CompleteMultipartUploadResult", 0);
-	if (open_tag_pos == string::npos) {
-		throw HTTPException(*res, "Unexpected response during S3 multipart upload finalization: %d\n\n%s",
-		                    static_cast<int>(res->status), result);
-	}
-}
-
 // Wrapper around the BufferManager::Allocate to that allows limiting the number of buffers that will be handed out
 BufferHandle S3FileSystem::Allocate(idx_t part_size, uint16_t max_threads) {
 	return buffer_manager.Allocate(MemoryTag::EXTENSION, part_size);
@@ -1045,10 +1009,7 @@ void S3FileSystem::RemoveDirectory(const string &path, optional_ptr<FileOpener> 
 
 void S3FileSystem::FileSync(FileHandle &handle) {
 	auto &s3fh = handle.Cast<S3FileHandle>();
-	if (!s3fh.multi_part_upload->upload_finalized) {
-		FlushAllBuffers(s3fh);
-		FinalizeMultipartUpload(s3fh);
-	}
+	s3fh.FinalizeUpload();
 }
 
 void S3FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1,5 +1,4 @@
 #include "s3fs.hpp"
-
 #include "crypto.hpp"
 #include "duckdb.hpp"
 #include "duckdb/common/exception/http_exception.hpp"
@@ -18,6 +17,7 @@
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 #include "duckdb/common/multi_file/multi_file_list.hpp"
+#include "s3_multi_part_upload.hpp"
 
 #include "create_secret_functions.hpp"
 
@@ -302,8 +302,7 @@ S3FileHandle::S3FileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFla
                            unique_ptr<HTTPParams> http_params_p, const S3AuthParams &auth_params_p,
                            const S3ConfigParams &config_params_p)
     : HTTPFileHandle(fs, file, flags, std::move(http_params_p)), auth_params(auth_params_p),
-      config_params(config_params_p), uploads_in_progress(0), parts_uploaded(0), upload_finalized(false),
-      uploader_has_error(false), upload_exception(nullptr) {
+      config_params(config_params_p) {
 	auto_fallback_to_full_file_download = false;
 	if (flags.OpenForReading() && flags.OpenForWriting()) {
 		throw NotImplementedException("Cannot open an HTTP file for both reading and writing");
@@ -315,6 +314,9 @@ S3FileHandle::S3FileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFla
 		if (entry != file.extended_info->options.end()) {
 			SetRegion(entry->second.ToString());
 		}
+	}
+	if (flags.OpenForWriting()) {
+		multi_part_upload = make_shared_ptr<S3MultiPartUpload>(*this);
 	}
 }
 
@@ -363,12 +365,13 @@ S3ConfigParams S3ConfigParams::ReadFrom(optional_ptr<FileOpener> opener) {
 }
 
 void S3FileHandle::Close() {
+	FinalizeUpload();
+}
+
+void S3FileHandle::FinalizeUpload() {
 	auto &s3fs = (S3FileSystem &)file_system;
-	if (flags.OpenForWriting() && !upload_finalized) {
-		s3fs.FlushAllBuffers(*this);
-		if (parts_uploaded) {
-			s3fs.FinalizeMultipartUpload(*this);
-		}
+	if (flags.OpenForWriting() && multi_part_upload) {
+		multi_part_upload->Finalize();
 	}
 }
 
@@ -402,27 +405,29 @@ string S3FileSystem::InitializeMultipartUpload(S3FileHandle &file_handle) {
 
 	open_tag_pos += 10; // Skip open tag
 
-	file_handle.initialized_multipart_upload = true;
+	file_handle.multi_part_upload->initialized_multipart_upload = true;
 
 	return result.substr(open_tag_pos, close_tag_pos - open_tag_pos);
 }
 
 void S3FileSystem::NotifyUploadsInProgress(S3FileHandle &file_handle) {
+	auto &multi_file_upload = *file_handle.multi_part_upload;
 	{
-		unique_lock<mutex> lck(file_handle.uploads_in_progress_lock);
-		file_handle.uploads_in_progress--;
+		unique_lock<mutex> lck(multi_file_upload.uploads_in_progress_lock);
+		multi_file_upload.uploads_in_progress--;
 	}
 	// Note that there are 2 cv's because otherwise we might deadlock when the final flushing thread is notified while
 	// another thread is still waiting for an upload thread
 #ifndef SAME_THREAD_UPLOAD
-	file_handle.uploads_in_progress_cv.notify_one();
-	file_handle.final_flush_cv.notify_one();
+	multi_file_upload.uploads_in_progress_cv.notify_one();
+	multi_file_upload.final_flush_cv.notify_one();
 #endif
 }
 
 void S3FileSystem::UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer) {
+	auto &multi_file_upload = *file_handle.multi_part_upload;
 	string query_param = "partNumber=" + to_string(write_buffer->part_no + 1) + "&" +
-	                     "uploadId=" + S3FileSystem::UrlEncode(file_handle.multipart_upload_id, true);
+	                     "uploadId=" + S3FileSystem::UrlEncode(multi_file_upload.multipart_upload_id, true);
 
 	UploadBufferImplementation(file_handle, write_buffer, query_param, false);
 
@@ -436,6 +441,7 @@ void S3FileSystem::UploadSingleBuffer(S3FileHandle &file_handle, shared_ptr<S3Wr
 void S3FileSystem::UploadBufferImplementation(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer,
                                               string query_param, bool single_upload) {
 	auto &s3fs = (S3FileSystem &)file_handle.file_system;
+	auto &multi_file_upload = *file_handle.multi_part_upload;
 
 	unique_ptr<HTTPResponse> res;
 	string etag;
@@ -463,9 +469,9 @@ void S3FileSystem::UploadBufferImplementation(S3FileHandle &file_handle, shared_
 		}
 		// Ensure only one thread sets the exception
 		bool f = false;
-		auto exchanged = file_handle.uploader_has_error.compare_exchange_strong(f, true);
+		auto exchanged = multi_file_upload.uploader_has_error.compare_exchange_strong(f, true);
 		if (exchanged) {
-			file_handle.upload_exception = std::current_exception();
+			multi_file_upload.upload_exception = std::current_exception();
 		}
 
 		D_ASSERT(!single_upload); // If we are here we are in the multi-buffer situation
@@ -475,11 +481,11 @@ void S3FileSystem::UploadBufferImplementation(S3FileHandle &file_handle, shared_
 
 	// Insert etag
 	{
-		unique_lock<mutex> lck(file_handle.part_etags_lock);
-		file_handle.part_etags.insert(std::pair<uint16_t, string>(write_buffer->part_no, etag));
+		unique_lock<mutex> lck(multi_file_upload.part_etags_lock);
+		multi_file_upload.part_etags.insert(std::pair<uint16_t, string>(write_buffer->part_no, etag));
 	}
 
-	file_handle.parts_uploaded++;
+	multi_file_upload.parts_uploaded++;
 
 	// Free up space for another thread to acquire an S3WriteBuffer
 	write_buffer.reset();
@@ -498,29 +504,30 @@ void S3FileSystem::FlushBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuff
 	if (!can_upload) {
 		return;
 	}
+	auto &multi_file_upload = *file_handle.multi_part_upload;
 
 	file_handle.RethrowIOError();
 
 	{
-		unique_lock<mutex> lck(file_handle.write_buffers_lock);
-		file_handle.write_buffers.erase(write_buffer->part_no);
+		unique_lock<mutex> lck(multi_file_upload.write_buffers_lock);
+		multi_file_upload.write_buffers.erase(write_buffer->part_no);
 	}
 
 	{
-		unique_lock<mutex> lck(file_handle.uploads_in_progress_lock);
+		unique_lock<mutex> lck(multi_file_upload.uploads_in_progress_lock);
 		// check if there are upload threads available
 #ifndef SAME_THREAD_UPLOAD
-		if (file_handle.uploads_in_progress >= file_handle.config_params.max_upload_threads) {
+		if (multi_file_upload.uploads_in_progress >= file_handle.config_params.max_upload_threads) {
 			// there are not - wait for one to become available
-			file_handle.uploads_in_progress_cv.wait(lck, [&file_handle] {
-				return file_handle.uploads_in_progress < file_handle.config_params.max_upload_threads;
+			multi_file_upload.uploads_in_progress_cv.wait(lck, [&] {
+				return multi_file_upload.uploads_in_progress < file_handle.config_params.max_upload_threads;
 			});
 		}
 #endif
-		file_handle.uploads_in_progress++;
+		multi_file_upload.uploads_in_progress++;
 	}
-	if (file_handle.initialized_multipart_upload == false) {
-		file_handle.multipart_upload_id = InitializeMultipartUpload(file_handle);
+	if (multi_file_upload.initialized_multipart_upload == false) {
+		multi_file_upload.multipart_upload_id = InitializeMultipartUpload(file_handle);
 	}
 
 #ifdef SAME_THREAD_UPLOAD
@@ -536,23 +543,24 @@ void S3FileSystem::FlushBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuff
 // be called right after it!
 // TODO: we can fix this by keeping the last partially written buffer in memory and allow reuploading it with new data.
 void S3FileSystem::FlushAllBuffers(S3FileHandle &file_handle) {
+	auto &multi_file_upload = *file_handle.multi_part_upload;
 	//  Collect references to all buffers to check
 	vector<shared_ptr<S3WriteBuffer>> to_flush;
-	file_handle.write_buffers_lock.lock();
-	for (auto &item : file_handle.write_buffers) {
+	multi_file_upload.write_buffers_lock.lock();
+	for (auto &item : multi_file_upload.write_buffers) {
 		to_flush.push_back(item.second);
 	}
-	file_handle.write_buffers_lock.unlock();
+	multi_file_upload.write_buffers_lock.unlock();
 
-	if (file_handle.initialized_multipart_upload == false) {
+	if (multi_file_upload.initialized_multipart_upload == false) {
 		// TODO (carlo): unclear how to handle kms_key_id, but given currently they are custom, leave the multiupload
 		// codepath in that case
 		if (to_flush.size() == 1 && file_handle.auth_params.kms_key_id.empty()) {
 			UploadSingleBuffer(file_handle, to_flush[0]);
-			file_handle.upload_finalized = true;
+			multi_file_upload.upload_finalized = true;
 			return;
 		} else {
-			file_handle.multipart_upload_id = InitializeMultipartUpload(file_handle);
+			multi_file_upload.multipart_upload_id = InitializeMultipartUpload(file_handle);
 		}
 	}
 	// Flush all buffers that aren't already uploading
@@ -561,29 +569,36 @@ void S3FileSystem::FlushAllBuffers(S3FileHandle &file_handle) {
 			FlushBuffer(file_handle, write_buffer);
 		}
 	}
-	unique_lock<mutex> lck(file_handle.uploads_in_progress_lock);
+	unique_lock<mutex> lck(multi_file_upload.uploads_in_progress_lock);
 #ifndef SAME_THREAD_UPLOAD
-	file_handle.final_flush_cv.wait(lck, [&file_handle] { return file_handle.uploads_in_progress == 0; });
+	multi_file_upload.final_flush_cv.wait(lck, [&] { return multi_file_upload.uploads_in_progress == 0; });
 #endif
 
 	file_handle.RethrowIOError();
 }
 
+void S3FileHandle::RethrowIOError() {
+	if (multi_part_upload->uploader_has_error) {
+		std::rethrow_exception(multi_part_upload->upload_exception);
+	}
+}
+
 void S3FileSystem::FinalizeMultipartUpload(S3FileHandle &file_handle) {
 	auto &s3fs = (S3FileSystem &)file_handle.file_system;
-	if (file_handle.upload_finalized) {
+	auto &multi_file_upload = *file_handle.multi_part_upload;
+	if (multi_file_upload.upload_finalized) {
 		return;
 	}
 
-	file_handle.upload_finalized = true;
+	multi_file_upload.upload_finalized = true;
 
 	std::stringstream ss;
 	ss << "<CompleteMultipartUpload xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">";
 
-	auto parts = file_handle.parts_uploaded.load();
+	auto parts = multi_file_upload.parts_uploaded.load();
 	for (auto i = 0; i < parts; i++) {
-		auto etag_lookup = file_handle.part_etags.find(i);
-		if (etag_lookup == file_handle.part_etags.end()) {
+		auto etag_lookup = multi_file_upload.part_etags.find(i);
+		if (etag_lookup == multi_file_upload.part_etags.end()) {
 			throw IOException("Unknown part number");
 		}
 		ss << "<Part><ETag>" << etag_lookup->second << "</ETag><PartNumber>" << i + 1 << "</PartNumber></Part>";
@@ -594,7 +609,7 @@ void S3FileSystem::FinalizeMultipartUpload(S3FileHandle &file_handle) {
 	// Response is around ~400 in AWS docs so this should be enough to not need a resize
 	string result;
 
-	string query_param = "uploadId=" + S3FileSystem::UrlEncode(file_handle.multipart_upload_id, true);
+	string query_param = "uploadId=" + S3FileSystem::UrlEncode(multi_file_upload.multipart_upload_id, true);
 	auto res =
 	    s3fs.PostRequest(file_handle, file_handle.path, {}, result, (char *)body.c_str(), body.length(), query_param);
 	auto open_tag_pos = result.find("<CompleteMultipartUploadResult", 0);
@@ -607,38 +622,6 @@ void S3FileSystem::FinalizeMultipartUpload(S3FileHandle &file_handle) {
 // Wrapper around the BufferManager::Allocate to that allows limiting the number of buffers that will be handed out
 BufferHandle S3FileSystem::Allocate(idx_t part_size, uint16_t max_threads) {
 	return buffer_manager.Allocate(MemoryTag::EXTENSION, part_size);
-}
-
-shared_ptr<S3WriteBuffer> S3FileHandle::GetBuffer(uint16_t write_buffer_idx) {
-	auto &s3fs = (S3FileSystem &)file_system;
-
-	// Check if write buffer already exists
-	{
-		unique_lock<mutex> lck(write_buffers_lock);
-		auto lookup_result = write_buffers.find(write_buffer_idx);
-		if (lookup_result != write_buffers.end()) {
-			shared_ptr<S3WriteBuffer> buffer = lookup_result->second;
-			return buffer;
-		}
-	}
-
-	auto buffer_handle = s3fs.Allocate(part_size, config_params.max_upload_threads);
-	auto new_write_buffer =
-	    make_shared_ptr<S3WriteBuffer>(write_buffer_idx * part_size, part_size, std::move(buffer_handle));
-	{
-		unique_lock<mutex> lck(write_buffers_lock);
-		auto lookup_result = write_buffers.find(write_buffer_idx);
-
-		// Check if other thread has created the same buffer, if so we return theirs and drop ours.
-		if (lookup_result != write_buffers.end()) {
-			// write_buffer_idx << std::endl;
-			shared_ptr<S3WriteBuffer> write_buffer = lookup_result->second;
-			return write_buffer;
-		}
-		write_buffers.insert(pair<uint16_t, shared_ptr<S3WriteBuffer>>(write_buffer_idx, new_write_buffer));
-	}
-
-	return new_write_buffer;
 }
 
 void GetQueryParam(const string &key, string &param, unordered_map<string, string> &query_params) {
@@ -1033,9 +1016,9 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 		auto minimum_part_size = MaxValue<idx_t>(aws_minimum_part_size, required_part_size);
 
 		// Round part size up to multiple of Storage::DEFAULT_BLOCK_SIZE
-		part_size = ((minimum_part_size + Storage::DEFAULT_BLOCK_SIZE - 1) / Storage::DEFAULT_BLOCK_SIZE) *
+		multi_part_upload->part_size = ((minimum_part_size + Storage::DEFAULT_BLOCK_SIZE - 1) / Storage::DEFAULT_BLOCK_SIZE) *
 		            Storage::DEFAULT_BLOCK_SIZE;
-		D_ASSERT(part_size * max_part_count >= config_params.max_file_size);
+		D_ASSERT(multi_part_upload->part_size * max_part_count >= config_params.max_file_size);
 	}
 }
 
@@ -1170,7 +1153,7 @@ void S3FileSystem::RemoveDirectory(const string &path, optional_ptr<FileOpener> 
 
 void S3FileSystem::FileSync(FileHandle &handle) {
 	auto &s3fh = handle.Cast<S3FileHandle>();
-	if (!s3fh.upload_finalized) {
+	if (!s3fh.multi_part_upload->upload_finalized) {
 		FlushAllBuffers(s3fh);
 		FinalizeMultipartUpload(s3fh);
 	}
@@ -1191,19 +1174,20 @@ void S3FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx
 		}
 
 		// Find buffer for writing
-		auto write_buffer_idx = curr_location / s3fh.part_size;
+		auto part_size = s3fh.multi_part_upload->part_size;
+		auto write_buffer_idx = curr_location / part_size;
 
 		// Get write buffer, may block until buffer is available
-		auto write_buffer = s3fh.GetBuffer(write_buffer_idx);
+		auto write_buffer = s3fh.multi_part_upload->GetBuffer(write_buffer_idx);
 
 		// Writing to buffer
 		auto idx_to_write = curr_location - write_buffer->buffer_start;
-		auto bytes_to_write = MinValue<idx_t>(nr_bytes - bytes_written, s3fh.part_size - idx_to_write);
+		auto bytes_to_write = MinValue<idx_t>(nr_bytes - bytes_written, part_size - idx_to_write);
 		memcpy((char *)write_buffer->Ptr() + idx_to_write, (char *)buffer + bytes_written, bytes_to_write);
 		write_buffer->idx += bytes_to_write;
 
 		// Flush to HTTP if full
-		if (write_buffer->idx >= s3fh.part_size) {
+		if (write_buffer->idx >= part_size) {
 			FlushBuffer(s3fh, write_buffer);
 		}
 		s3fh.file_offset += bytes_to_write;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -23,10 +23,6 @@
 
 #include <iostream>
 #include <iostream>
-#include <thread>
-#ifdef EMSCRIPTEN
-#define SAME_THREAD_UPLOAD
-#endif
 
 namespace duckdb {
 
@@ -380,98 +376,6 @@ unique_ptr<HTTPClient> S3FileHandle::CreateClient() {
 
 	string proto_host_port = parsed_url.http_proto + parsed_url.host;
 	return http_params.http_util.InitializeClient(http_params, proto_host_port);
-}
-
-void S3FileSystem::FlushBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer) {
-	if (write_buffer->idx == 0) {
-		return;
-	}
-
-	auto uploading = write_buffer->uploading.load();
-	if (uploading) {
-		return;
-	}
-	bool can_upload = write_buffer->uploading.compare_exchange_strong(uploading, true);
-	if (!can_upload) {
-		return;
-	}
-	auto &multi_file_upload = *file_handle.multi_part_upload;
-
-	file_handle.RethrowIOError();
-
-	{
-		unique_lock<mutex> lck(multi_file_upload.write_buffers_lock);
-		multi_file_upload.write_buffers.erase(write_buffer->part_no);
-	}
-
-	{
-		unique_lock<mutex> lck(multi_file_upload.uploads_in_progress_lock);
-		// check if there are upload threads available
-#ifndef SAME_THREAD_UPLOAD
-		if (multi_file_upload.uploads_in_progress >= file_handle.config_params.max_upload_threads) {
-			// there are not - wait for one to become available
-			multi_file_upload.uploads_in_progress_cv.wait(lck, [&] {
-				return multi_file_upload.uploads_in_progress < file_handle.config_params.max_upload_threads;
-			});
-		}
-#endif
-		multi_file_upload.uploads_in_progress++;
-	}
-	if (multi_file_upload.initialized_multipart_upload == false) {
-		multi_file_upload.multipart_upload_id = multi_file_upload.InitializeMultipartUpload();
-	}
-
-#ifdef SAME_THREAD_UPLOAD
-	UploadBuffer(file_handle, write_buffer);
-	return;
-#endif
-
-	thread upload_thread(S3MultiPartUpload::UploadBuffer, std::ref(file_handle), write_buffer);
-	upload_thread.detach();
-}
-
-// Note that FlushAll currently does not allow to continue writing afterwards. Therefore, FinalizeMultipartUpload should
-// be called right after it!
-// TODO: we can fix this by keeping the last partially written buffer in memory and allow reuploading it with new data.
-void S3FileSystem::FlushAllBuffers(S3FileHandle &file_handle) {
-	auto &multi_file_upload = *file_handle.multi_part_upload;
-	//  Collect references to all buffers to check
-	vector<shared_ptr<S3WriteBuffer>> to_flush;
-	multi_file_upload.write_buffers_lock.lock();
-	for (auto &item : multi_file_upload.write_buffers) {
-		to_flush.push_back(item.second);
-	}
-	multi_file_upload.write_buffers_lock.unlock();
-
-	if (multi_file_upload.initialized_multipart_upload == false) {
-		// TODO (carlo): unclear how to handle kms_key_id, but given currently they are custom, leave the multiupload
-		// codepath in that case
-		if (to_flush.size() == 1 && file_handle.auth_params.kms_key_id.empty()) {
-			S3MultiPartUpload::UploadSingleBuffer(file_handle, to_flush[0]);
-			multi_file_upload.upload_finalized = true;
-			return;
-		} else {
-			multi_file_upload.multipart_upload_id = multi_file_upload.InitializeMultipartUpload();
-		}
-	}
-	// Flush all buffers that aren't already uploading
-	for (auto &write_buffer : to_flush) {
-		if (!write_buffer->uploading) {
-			FlushBuffer(file_handle, write_buffer);
-		}
-	}
-	unique_lock<mutex> lck(multi_file_upload.uploads_in_progress_lock);
-#ifndef SAME_THREAD_UPLOAD
-	multi_file_upload.final_flush_cv.wait(lck, [&] { return multi_file_upload.uploads_in_progress == 0; });
-#endif
-
-	file_handle.RethrowIOError();
-}
-
-void S3FileHandle::RethrowIOError() {
-	if (multi_part_upload->uploader_has_error) {
-		std::rethrow_exception(multi_part_upload->upload_exception);
-	}
 }
 
 // Wrapper around the BufferManager::Allocate to that allows limiting the number of buffers that will be handed out
@@ -1041,7 +945,7 @@ void S3FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx
 
 		// Flush to HTTP if full
 		if (write_buffer->idx >= part_size) {
-			FlushBuffer(s3fh, write_buffer);
+			s3fh.multi_part_upload->FlushBuffer(write_buffer);
 		}
 		s3fh.file_offset += bytes_to_write;
 		s3fh.length += bytes_to_write;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -382,34 +382,6 @@ unique_ptr<HTTPClient> S3FileHandle::CreateClient() {
 	return http_params.http_util.InitializeClient(http_params, proto_host_port);
 }
 
-// Opens the multipart upload and returns the ID
-string S3FileSystem::InitializeMultipartUpload(S3FileHandle &file_handle) {
-	auto &s3fs = (S3FileSystem &)file_handle.file_system;
-
-	// AWS response is around 300~ chars in docs so this should be enough to not need a resize
-	string result;
-	string query_param = "uploads=";
-	auto res = s3fs.PostRequest(file_handle, file_handle.path, {}, result, nullptr, 0, query_param);
-
-	if (res->status != HTTPStatusCode::OK_200) {
-		throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", file_handle.path, res->GetError(),
-		                    static_cast<int>(res->status));
-	}
-
-	auto open_tag_pos = result.find("<UploadId>", 0);
-	auto close_tag_pos = result.find("</UploadId>", open_tag_pos);
-
-	if (open_tag_pos == string::npos || close_tag_pos == string::npos) {
-		throw HTTPException("Unexpected response while initializing S3 multipart upload");
-	}
-
-	open_tag_pos += 10; // Skip open tag
-
-	file_handle.multi_part_upload->initialized_multipart_upload = true;
-
-	return result.substr(open_tag_pos, close_tag_pos - open_tag_pos);
-}
-
 void S3FileSystem::FlushBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer) {
 	if (write_buffer->idx == 0) {
 		return;
@@ -446,7 +418,7 @@ void S3FileSystem::FlushBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuff
 		multi_file_upload.uploads_in_progress++;
 	}
 	if (multi_file_upload.initialized_multipart_upload == false) {
-		multi_file_upload.multipart_upload_id = InitializeMultipartUpload(file_handle);
+		multi_file_upload.multipart_upload_id = multi_file_upload.InitializeMultipartUpload();
 	}
 
 #ifdef SAME_THREAD_UPLOAD
@@ -479,7 +451,7 @@ void S3FileSystem::FlushAllBuffers(S3FileHandle &file_handle) {
 			multi_file_upload.upload_finalized = true;
 			return;
 		} else {
-			multi_file_upload.multipart_upload_id = InitializeMultipartUpload(file_handle);
+			multi_file_upload.multipart_upload_id = multi_file_upload.InitializeMultipartUpload();
 		}
 	}
 	// Flush all buffers that aren't already uploading
@@ -935,8 +907,9 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 		auto minimum_part_size = MaxValue<idx_t>(aws_minimum_part_size, required_part_size);
 
 		// Round part size up to multiple of Storage::DEFAULT_BLOCK_SIZE
-		multi_part_upload->part_size = ((minimum_part_size + Storage::DEFAULT_BLOCK_SIZE - 1) / Storage::DEFAULT_BLOCK_SIZE) *
-		            Storage::DEFAULT_BLOCK_SIZE;
+		multi_part_upload->part_size =
+		    ((minimum_part_size + Storage::DEFAULT_BLOCK_SIZE - 1) / Storage::DEFAULT_BLOCK_SIZE) *
+		    Storage::DEFAULT_BLOCK_SIZE;
 		D_ASSERT(multi_part_upload->part_size * max_part_count >= config_params.max_file_size);
 	}
 }

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -410,87 +410,6 @@ string S3FileSystem::InitializeMultipartUpload(S3FileHandle &file_handle) {
 	return result.substr(open_tag_pos, close_tag_pos - open_tag_pos);
 }
 
-void S3FileSystem::NotifyUploadsInProgress(S3FileHandle &file_handle) {
-	auto &multi_file_upload = *file_handle.multi_part_upload;
-	{
-		unique_lock<mutex> lck(multi_file_upload.uploads_in_progress_lock);
-		multi_file_upload.uploads_in_progress--;
-	}
-	// Note that there are 2 cv's because otherwise we might deadlock when the final flushing thread is notified while
-	// another thread is still waiting for an upload thread
-#ifndef SAME_THREAD_UPLOAD
-	multi_file_upload.uploads_in_progress_cv.notify_one();
-	multi_file_upload.final_flush_cv.notify_one();
-#endif
-}
-
-void S3FileSystem::UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer) {
-	auto &multi_file_upload = *file_handle.multi_part_upload;
-	string query_param = "partNumber=" + to_string(write_buffer->part_no + 1) + "&" +
-	                     "uploadId=" + S3FileSystem::UrlEncode(multi_file_upload.multipart_upload_id, true);
-
-	UploadBufferImplementation(file_handle, write_buffer, query_param, false);
-
-	NotifyUploadsInProgress(file_handle);
-}
-
-void S3FileSystem::UploadSingleBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer) {
-	UploadBufferImplementation(file_handle, write_buffer, "", true);
-}
-
-void S3FileSystem::UploadBufferImplementation(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer,
-                                              string query_param, bool single_upload) {
-	auto &s3fs = (S3FileSystem &)file_handle.file_system;
-	auto &multi_file_upload = *file_handle.multi_part_upload;
-
-	unique_ptr<HTTPResponse> res;
-	string etag;
-
-	try {
-		res = s3fs.PutRequest(file_handle, file_handle.path, {}, (char *)write_buffer->Ptr(), write_buffer->idx,
-		                      query_param);
-
-		if (res->status != HTTPStatusCode::OK_200) {
-			throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", file_handle.path,
-			                    res->GetError(), static_cast<int>(res->status));
-		}
-
-		if (!res->headers.HasHeader("ETag")) {
-			throw IOException("Unexpected response when uploading part to S3");
-		}
-		etag = res->headers.GetHeaderValue("ETag");
-	} catch (std::exception &ex) {
-		if (single_upload) {
-			throw;
-		}
-		ErrorData error(ex);
-		if (error.Type() != ExceptionType::IO && error.Type() != ExceptionType::HTTP) {
-			throw;
-		}
-		// Ensure only one thread sets the exception
-		bool f = false;
-		auto exchanged = multi_file_upload.uploader_has_error.compare_exchange_strong(f, true);
-		if (exchanged) {
-			multi_file_upload.upload_exception = std::current_exception();
-		}
-
-		D_ASSERT(!single_upload); // If we are here we are in the multi-buffer situation
-		NotifyUploadsInProgress(file_handle);
-		return;
-	}
-
-	// Insert etag
-	{
-		unique_lock<mutex> lck(multi_file_upload.part_etags_lock);
-		multi_file_upload.part_etags.insert(std::pair<uint16_t, string>(write_buffer->part_no, etag));
-	}
-
-	multi_file_upload.parts_uploaded++;
-
-	// Free up space for another thread to acquire an S3WriteBuffer
-	write_buffer.reset();
-}
-
 void S3FileSystem::FlushBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer) {
 	if (write_buffer->idx == 0) {
 		return;
@@ -535,7 +454,7 @@ void S3FileSystem::FlushBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuff
 	return;
 #endif
 
-	thread upload_thread(UploadBuffer, std::ref(file_handle), write_buffer);
+	thread upload_thread(S3MultiPartUpload::UploadBuffer, std::ref(file_handle), write_buffer);
 	upload_thread.detach();
 }
 
@@ -556,7 +475,7 @@ void S3FileSystem::FlushAllBuffers(S3FileHandle &file_handle) {
 		// TODO (carlo): unclear how to handle kms_key_id, but given currently they are custom, leave the multiupload
 		// codepath in that case
 		if (to_flush.size() == 1 && file_handle.auth_params.kms_key_id.empty()) {
-			UploadSingleBuffer(file_handle, to_flush[0]);
+			S3MultiPartUpload::UploadSingleBuffer(file_handle, to_flush[0]);
 			multi_file_upload.upload_finalized = true;
 			return;
 		} else {


### PR DESCRIPTION
This partially implements https://github.com/duckdb/duckdb-httpfs/pull/79 again, but only the "nop" code-cleanup part that does not change any behavior. We simply move the implementation of the various S3 multi-part upload methods to a separate class (`S3MultiPartUpload`). This changes no behavior and is just moving code around. In a follow-up we will make the actual improvements done by that PR.