### PR TITLE
Decouple `S3MultiPartUpload` from `S3FileHandle`

### DIFF
--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -143,39 +143,37 @@ static void AddUserAgentIfAvailable(HTTPFSParams &http_params, HTTPHeaders &head
 	}
 }
 
-static void AddHandleHeaders(HTTPFileHandle &handle, HTTPHeaders &header_map) {
+static void AddHandleHeaders(HTTPFSParams &http_params, HTTPHeaders &header_map) {
 	// Inject headers from the http param extra_headers into the request
-	for (auto &header : handle.http_params.extra_headers) {
+	for (auto &header : http_params.extra_headers) {
 		header_map[header.first] = header.second;
 	}
-	handle.http_params.pre_merged_headers = true;
+	http_params.pre_merged_headers = true;
 }
 
-unique_ptr<HTTPResponse> HTTPFileSystem::PostRequest(FileHandle &handle, string url, HTTPHeaders header_map,
+unique_ptr<HTTPResponse> HTTPFileSystem::PostRequest(HTTPInput &input, string url, HTTPHeaders header_map,
                                                      string &buffer_out, char *buffer_in, idx_t buffer_in_len,
                                                      string params) {
-	auto &hfh = handle.Cast<HTTPFileHandle>();
-	auto &http_util = hfh.http_params.http_util;
+	auto &http_util = input.http_params.http_util;
 
-	AddUserAgentIfAvailable(hfh.http_params, header_map);
-	AddHandleHeaders(hfh, header_map);
+	AddUserAgentIfAvailable(input.http_params, header_map);
+	AddHandleHeaders(input.http_params, header_map);
 
-	PostRequestInfo post_request(url, header_map, hfh.http_params, const_data_ptr_cast(buffer_in), buffer_in_len);
+	PostRequestInfo post_request(url, header_map, input.http_params, const_data_ptr_cast(buffer_in), buffer_in_len);
 	auto result = http_util.Request(post_request);
 	buffer_out = std::move(post_request.buffer_out);
 	return result;
 }
 
-unique_ptr<HTTPResponse> HTTPFileSystem::PutRequest(FileHandle &handle, string url, HTTPHeaders header_map,
+unique_ptr<HTTPResponse> HTTPFileSystem::PutRequest(HTTPInput &input, string url, HTTPHeaders header_map,
                                                     char *buffer_in, idx_t buffer_in_len, string params) {
-	auto &hfh = handle.Cast<HTTPFileHandle>();
-	auto &http_util = hfh.http_params.http_util;
+	auto &http_util = input.http_params.http_util;
 
-	AddUserAgentIfAvailable(hfh.http_params, header_map);
-	AddHandleHeaders(hfh, header_map);
+	AddUserAgentIfAvailable(input.http_params, header_map);
+	AddHandleHeaders(input.http_params, header_map);
 
 	string content_type = "application/octet-stream";
-	PutRequestInfo put_request(url, header_map, hfh.http_params, (const_data_ptr_t)buffer_in, buffer_in_len,
+	PutRequestInfo put_request(url, header_map, input.http_params, (const_data_ptr_t)buffer_in, buffer_in_len,
 	                           content_type);
 	return http_util.Request(put_request);
 }
@@ -185,7 +183,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::HeadRequest(FileHandle &handle, string 
 	auto &http_util = hfh.http_params.http_util;
 
 	AddUserAgentIfAvailable(hfh.http_params, header_map);
-	AddHandleHeaders(hfh, header_map);
+	AddHandleHeaders(hfh.http_params, header_map);
 
 	auto http_client = hfh.GetClient();
 
@@ -201,7 +199,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::DeleteRequest(FileHandle &handle, strin
 	auto &http_util = hfh.http_params.http_util;
 
 	AddUserAgentIfAvailable(hfh.http_params, header_map);
-	AddHandleHeaders(hfh, header_map);
+	AddHandleHeaders(hfh.http_params, header_map);
 
 	auto http_client = hfh.GetClient();
 	DeleteRequestInfo delete_request(url, header_map, hfh.http_params);
@@ -227,7 +225,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRequest(FileHandle &handle, string u
 	auto &http_util = hfh.http_params.http_util;
 
 	AddUserAgentIfAvailable(hfh.http_params, header_map);
-	AddHandleHeaders(hfh, header_map);
+	AddHandleHeaders(hfh.http_params, header_map);
 
 	D_ASSERT(hfh.cached_file_handle);
 
@@ -283,7 +281,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
 	auto &http_util = hfh.http_params.http_util;
 
 	AddUserAgentIfAvailable(hfh.http_params, header_map);
-	AddHandleHeaders(hfh, header_map);
+	AddHandleHeaders(hfh.http_params, header_map);
 
 	// send the Range header to read only subset of file
 	string range_expr = "bytes=" + to_string(file_offset) + "-" + to_string(file_offset + buffer_out_len - 1);
@@ -361,9 +359,13 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
 	return response;
 }
 
+HTTPInput::HTTPInput(unique_ptr<HTTPParams> params_p)
+    : params(std::move(params_p)), http_params(params->Cast<HTTPFSParams>()) {
+}
+
 HTTPFileHandle::HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags,
-                               unique_ptr<HTTPParams> params_p)
-    : FileHandle(fs, file.path, flags), params(std::move(params_p)), http_params(params->Cast<HTTPFSParams>()),
+                               shared_ptr<HTTPInput> input_p)
+    : FileHandle(fs, file.path, flags), http_input(std::move(input_p)), http_params(http_input->http_params),
       flags(flags), length(0), force_full_download(false), buffer_available(0), buffer_idx(0), file_offset(0),
       buffer_start(0), buffer_end(0) {
 	// check if the handle has extended properties that can be set directly in the handle
@@ -393,6 +395,12 @@ HTTPFileHandle::HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpe
 		}
 	}
 }
+
+HTTPFileHandle::HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags,
+                               unique_ptr<HTTPParams> params_p)
+    : HTTPFileHandle(fs, file, flags, make_shared_ptr<HTTPInput>(std::move(params_p))) {
+}
+
 unique_ptr<HTTPFileHandle> HTTPFileSystem::CreateHandle(const OpenFileInfo &file, FileOpenFlags flags,
                                                         optional_ptr<FileOpener> opener) {
 	D_ASSERT(flags.Compression() == FileCompressionType::UNCOMPRESSED);

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -45,11 +45,32 @@ protected:
 	mutex lock;
 };
 
+class HTTPInput {
+public:
+	HTTPInput(unique_ptr<HTTPParams> params_p);
+	virtual ~HTTPInput() = default;
+
+	unique_ptr<HTTPParams> params;
+	HTTPFSParams &http_params;
+
+	template <class TARGET>
+	TARGET &Cast() {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<TARGET &>(*this);
+	}
+	template <class TARGET>
+	const TARGET &Cast() const {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<const TARGET &>(*this);
+	}
+};
+
 class HTTPFileSystem;
 
 class HTTPFileHandle : public FileHandle {
 public:
 	HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags, unique_ptr<HTTPParams> params);
+	HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags, shared_ptr<HTTPInput> input);
 	~HTTPFileHandle() override;
 	// This two-phase construction allows subclasses more flexible setup.
 	virtual void Initialize(optional_ptr<FileOpener> opener);
@@ -57,7 +78,7 @@ public:
 	// We keep an http client stored for connection reuse with keep-alive headers
 	HTTPClientCache client_cache;
 
-	unique_ptr<HTTPParams> params;
+	shared_ptr<HTTPInput> http_input;
 	HTTPFSParams &http_params;
 
 	// File handle info
@@ -164,10 +185,10 @@ public:
 	// Get Request without a range (i.e., downloads full file)
 	virtual duckdb::unique_ptr<HTTPResponse> GetRequest(FileHandle &handle, string url, HTTPHeaders header_map);
 	// Post Request that can handle variable sized responses without a content-length header (needed for s3 multipart)
-	virtual duckdb::unique_ptr<HTTPResponse> PostRequest(FileHandle &handle, string url, HTTPHeaders header_map,
+	virtual duckdb::unique_ptr<HTTPResponse> PostRequest(HTTPInput &input, string url, HTTPHeaders header_map,
 	                                                     string &result, char *buffer_in, idx_t buffer_in_len,
 	                                                     string params = "");
-	virtual duckdb::unique_ptr<HTTPResponse> PutRequest(FileHandle &handle, string url, HTTPHeaders header_map,
+	virtual duckdb::unique_ptr<HTTPResponse> PutRequest(HTTPInput &input, string url, HTTPHeaders header_map,
 	                                                    char *buffer_in, idx_t buffer_in_len, string params = "");
 
 	virtual duckdb::unique_ptr<HTTPResponse> DeleteRequest(FileHandle &handle, string url, HTTPHeaders header_map);

--- a/src/include/s3_multi_part_upload.hpp
+++ b/src/include/s3_multi_part_upload.hpp
@@ -82,8 +82,7 @@ public:
 	bool upload_finalized = true;
 
 	//! Error handling in upload threads
-	atomic<bool> uploader_has_error {false};
-	std::exception_ptr upload_exception;
+	TaskErrorManager error_manager;
 };
 
 } // namespace duckdb

--- a/src/include/s3_multi_part_upload.hpp
+++ b/src/include/s3_multi_part_upload.hpp
@@ -29,17 +29,16 @@ public:
 	atomic<bool> uploading;
 };
 
-class S3MultiPartUpload {
+class S3MultiPartUpload : public enable_shared_from_this<S3MultiPartUpload> {
 public:
 	S3MultiPartUpload(S3FileHandle &s3_file_handle);
 
 public:
 	// Uploads the contents of write_buffer to S3.
 	// Note: caller is responsible to not call this method twice on the same buffer
-	static void UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer);
-	static void UploadSingleBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer);
-	static void UploadBufferImplementation(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer,
-	                                       string query_param, bool direct_throw);
+	static void UploadBuffer(shared_ptr<S3MultiPartUpload> multi_part_upload, shared_ptr<S3WriteBuffer> write_buffer);
+	void UploadSingleBuffer(shared_ptr<S3WriteBuffer> write_buffer);
+	void UploadBufferImplementation(shared_ptr<S3WriteBuffer> write_buffer, string query_param, bool direct_throw);
 	void NotifyUploadsInProgress();
 
 	string InitializeMultipartUpload();
@@ -56,7 +55,7 @@ public:
 	void Finalize();
 
 	S3FileSystem &s3fs;
-	S3FileHandle &s3_file_handle;
+	shared_ptr<HTTPInput> http_input;
 	string path;
 	const S3ConfigParams config_params;
 

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -114,6 +114,16 @@ struct S3ConfigParams {
 	static S3ConfigParams ReadFrom(optional_ptr<FileOpener> opener);
 };
 
+class S3HTTPInput : public HTTPInput {
+public:
+	S3HTTPInput(unique_ptr<HTTPParams> params, const S3AuthParams &auth_params_p,
+	            const S3ConfigParams &config_params_p);
+	~S3HTTPInput() override;
+
+	S3AuthParams auth_params;
+	S3ConfigParams config_params;
+};
+
 class S3FileSystem;
 class S3MultiPartUpload;
 class S3WriteBuffer;
@@ -126,8 +136,8 @@ public:
 	             const S3AuthParams &auth_params_p, const S3ConfigParams &config_params_p);
 	~S3FileHandle() override;
 
-	S3AuthParams auth_params;
-	const S3ConfigParams config_params;
+	S3AuthParams &auth_params;
+	const S3ConfigParams &config_params;
 	shared_ptr<S3MultiPartUpload> multi_part_upload;
 
 public:
@@ -158,10 +168,10 @@ public:
 	duckdb::unique_ptr<HTTPResponse> GetRangeRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
 	                                                 idx_t file_offset, char *buffer_out,
 	                                                 idx_t buffer_out_len) override;
-	duckdb::unique_ptr<HTTPResponse> PostRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
+	duckdb::unique_ptr<HTTPResponse> PostRequest(HTTPInput &input, string s3_url, HTTPHeaders header_map,
 	                                             string &buffer_out, char *buffer_in, idx_t buffer_in_len,
 	                                             string http_params = "") override;
-	duckdb::unique_ptr<HTTPResponse> PutRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
+	duckdb::unique_ptr<HTTPResponse> PutRequest(HTTPInput &input, string s3_url, HTTPHeaders header_map,
 	                                            char *buffer_in, idx_t buffer_in_len, string http_params = "") override;
 	duckdb::unique_ptr<HTTPResponse> DeleteRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map) override;
 

--- a/src/s3_multi_part_upload.cpp
+++ b/src/s3_multi_part_upload.cpp
@@ -153,7 +153,6 @@ void S3MultiPartUpload::UploadBufferImplementation(shared_ptr<S3WriteBuffer> wri
 		error_manager.PushError(std::move(error));
 
 		D_ASSERT(!single_upload); // If we are here we are in the multi-buffer situation
-		NotifyUploadsInProgress();
 		return;
 	}
 

--- a/src/s3_multi_part_upload.cpp
+++ b/src/s3_multi_part_upload.cpp
@@ -171,6 +171,10 @@ void S3MultiPartUpload::UploadBufferImplementation(shared_ptr<S3WriteBuffer> wri
 void S3MultiPartUpload::NotifyUploadsInProgress() {
 	{
 		unique_lock<mutex> lck(uploads_in_progress_lock);
+		if (uploads_in_progress == 0) {
+			throw InternalException(
+			    "S3MultiPartUpload: uploads_in_progress decremented but no uploads are supposed to be active");
+		}
 		uploads_in_progress--;
 	}
 	// Note that there are 2 cv's because otherwise we might deadlock when the final flushing thread is notified while

--- a/src/s3_multi_part_upload.cpp
+++ b/src/s3_multi_part_upload.cpp
@@ -9,7 +9,7 @@ namespace duckdb {
 S3MultiPartUpload::S3MultiPartUpload(S3FileHandle &s3_file_handle)
     : s3fs(s3_file_handle.file_system.Cast<S3FileSystem>()), http_input(s3_file_handle.http_input),
       path(s3_file_handle.path), config_params(s3_file_handle.config_params), uploads_in_progress(0), parts_uploaded(0),
-      upload_finalized(false), uploader_has_error(false), upload_exception(nullptr) {
+      upload_finalized(false) {
 }
 
 void S3MultiPartUpload::Finalize() {
@@ -150,12 +150,7 @@ void S3MultiPartUpload::UploadBufferImplementation(shared_ptr<S3WriteBuffer> wri
 		if (error.Type() != ExceptionType::IO && error.Type() != ExceptionType::HTTP) {
 			throw;
 		}
-		// Ensure only one thread sets the exception
-		bool f = false;
-		auto exchanged = uploader_has_error.compare_exchange_strong(f, true);
-		if (exchanged) {
-			upload_exception = std::current_exception();
-		}
+		error_manager.PushError(std::move(error));
 
 		D_ASSERT(!single_upload); // If we are here we are in the multi-buffer situation
 		NotifyUploadsInProgress();
@@ -271,8 +266,8 @@ void S3MultiPartUpload::FlushAllBuffers() {
 }
 
 void S3MultiPartUpload::RethrowIOError() {
-	if (uploader_has_error) {
-		std::rethrow_exception(upload_exception);
+	if (error_manager.HasError()) {
+		error_manager.ThrowException();
 	}
 }
 

--- a/src/s3_multi_part_upload.cpp
+++ b/src/s3_multi_part_upload.cpp
@@ -58,7 +58,7 @@ string S3MultiPartUpload::InitializeMultipartUpload() {
 	// AWS response is around 300~ chars in docs so this should be enough to not need a resize
 	string result;
 	string query_param = "uploads=";
-	auto res = s3fs.PostRequest(s3_file_handle, path, {}, result, nullptr, 0, query_param);
+	auto res = s3fs.PostRequest(*s3_file_handle.http_input, path, {}, result, nullptr, 0, query_param);
 
 	if (res->status != HTTPStatusCode::OK_200) {
 		throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", path, res->GetError(),
@@ -104,7 +104,8 @@ void S3MultiPartUpload::FinalizeMultipartUpload() {
 	string result;
 
 	string query_param = "uploadId=" + S3FileSystem::UrlEncode(multipart_upload_id, true);
-	auto res = s3fs.PostRequest(s3_file_handle, path, {}, result, (char *)body.c_str(), body.length(), query_param);
+	auto res = s3fs.PostRequest(*s3_file_handle.http_input, path, {}, result, (char *)body.c_str(), body.length(),
+	                            query_param);
 	auto open_tag_pos = result.find("<CompleteMultipartUploadResult", 0);
 	if (open_tag_pos == string::npos) {
 		throw HTTPException(*res, "Unexpected response during S3 multipart upload finalization: %d\n\n%s",
@@ -135,8 +136,8 @@ void S3MultiPartUpload::UploadBufferImplementation(S3FileHandle &file_handle, sh
 	string etag;
 
 	try {
-		res = s3fs.PutRequest(file_handle, file_handle.path, {}, (char *)write_buffer->Ptr(), write_buffer->idx,
-		                      query_param);
+		res = s3fs.PutRequest(*file_handle.http_input, multi_file_upload.path, {}, (char *)write_buffer->Ptr(),
+		                      write_buffer->idx, query_param);
 
 		if (res->status != HTTPStatusCode::OK_200) {
 			throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", file_handle.path,

--- a/src/s3_multi_part_upload.cpp
+++ b/src/s3_multi_part_upload.cpp
@@ -7,9 +7,9 @@
 namespace duckdb {
 
 S3MultiPartUpload::S3MultiPartUpload(S3FileHandle &s3_file_handle)
-    : s3fs(s3_file_handle.file_system.Cast<S3FileSystem>()), s3_file_handle(s3_file_handle), path(s3_file_handle.path),
-      config_params(s3_file_handle.config_params), uploads_in_progress(0), parts_uploaded(0), upload_finalized(false),
-      uploader_has_error(false), upload_exception(nullptr) {
+    : s3fs(s3_file_handle.file_system.Cast<S3FileSystem>()), http_input(s3_file_handle.http_input),
+      path(s3_file_handle.path), config_params(s3_file_handle.config_params), uploads_in_progress(0), parts_uploaded(0),
+      upload_finalized(false), uploader_has_error(false), upload_exception(nullptr) {
 }
 
 void S3MultiPartUpload::Finalize() {
@@ -58,7 +58,7 @@ string S3MultiPartUpload::InitializeMultipartUpload() {
 	// AWS response is around 300~ chars in docs so this should be enough to not need a resize
 	string result;
 	string query_param = "uploads=";
-	auto res = s3fs.PostRequest(*s3_file_handle.http_input, path, {}, result, nullptr, 0, query_param);
+	auto res = s3fs.PostRequest(*http_input, path, {}, result, nullptr, 0, query_param);
 
 	if (res->status != HTTPStatusCode::OK_200) {
 		throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", path, res->GetError(),
@@ -104,8 +104,7 @@ void S3MultiPartUpload::FinalizeMultipartUpload() {
 	string result;
 
 	string query_param = "uploadId=" + S3FileSystem::UrlEncode(multipart_upload_id, true);
-	auto res = s3fs.PostRequest(*s3_file_handle.http_input, path, {}, result, (char *)body.c_str(), body.length(),
-	                            query_param);
+	auto res = s3fs.PostRequest(*http_input, path, {}, result, (char *)body.c_str(), body.length(), query_param);
 	auto open_tag_pos = result.find("<CompleteMultipartUploadResult", 0);
 	if (open_tag_pos == string::npos) {
 		throw HTTPException(*res, "Unexpected response during S3 multipart upload finalization: %d\n\n%s",
@@ -113,35 +112,30 @@ void S3MultiPartUpload::FinalizeMultipartUpload() {
 	}
 }
 
-void S3MultiPartUpload::UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer) {
-	auto &multi_file_upload = *file_handle.multi_part_upload;
+void S3MultiPartUpload::UploadBuffer(shared_ptr<S3MultiPartUpload> multi_part_upload,
+                                     shared_ptr<S3WriteBuffer> write_buffer) {
 	string query_param = "partNumber=" + to_string(write_buffer->part_no + 1) + "&" +
-	                     "uploadId=" + S3FileSystem::UrlEncode(multi_file_upload.multipart_upload_id, true);
+	                     "uploadId=" + S3FileSystem::UrlEncode(multi_part_upload->multipart_upload_id, true);
 
-	UploadBufferImplementation(file_handle, write_buffer, query_param, false);
-
-	multi_file_upload.NotifyUploadsInProgress();
+	multi_part_upload->UploadBufferImplementation(write_buffer, query_param, false);
+	multi_part_upload->NotifyUploadsInProgress();
 }
 
-void S3MultiPartUpload::UploadSingleBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer) {
-	UploadBufferImplementation(file_handle, write_buffer, "", true);
+void S3MultiPartUpload::UploadSingleBuffer(shared_ptr<S3WriteBuffer> write_buffer) {
+	UploadBufferImplementation(write_buffer, "", true);
 }
 
-void S3MultiPartUpload::UploadBufferImplementation(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer,
-                                                   string query_param, bool single_upload) {
-	auto &s3fs = (S3FileSystem &)file_handle.file_system;
-	auto &multi_file_upload = *file_handle.multi_part_upload;
-
+void S3MultiPartUpload::UploadBufferImplementation(shared_ptr<S3WriteBuffer> write_buffer, string query_param,
+                                                   bool single_upload) {
 	unique_ptr<HTTPResponse> res;
 	string etag;
 
 	try {
-		res = s3fs.PutRequest(*file_handle.http_input, multi_file_upload.path, {}, (char *)write_buffer->Ptr(),
-		                      write_buffer->idx, query_param);
+		res = s3fs.PutRequest(*http_input, path, {}, (char *)write_buffer->Ptr(), write_buffer->idx, query_param);
 
 		if (res->status != HTTPStatusCode::OK_200) {
-			throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", file_handle.path,
-			                    res->GetError(), static_cast<int>(res->status));
+			throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", path, res->GetError(),
+			                    static_cast<int>(res->status));
 		}
 
 		if (!res->headers.HasHeader("ETag")) {
@@ -158,23 +152,23 @@ void S3MultiPartUpload::UploadBufferImplementation(S3FileHandle &file_handle, sh
 		}
 		// Ensure only one thread sets the exception
 		bool f = false;
-		auto exchanged = multi_file_upload.uploader_has_error.compare_exchange_strong(f, true);
+		auto exchanged = uploader_has_error.compare_exchange_strong(f, true);
 		if (exchanged) {
-			multi_file_upload.upload_exception = std::current_exception();
+			upload_exception = std::current_exception();
 		}
 
 		D_ASSERT(!single_upload); // If we are here we are in the multi-buffer situation
-		multi_file_upload.NotifyUploadsInProgress();
+		NotifyUploadsInProgress();
 		return;
 	}
 
 	// Insert etag
 	{
-		unique_lock<mutex> lck(multi_file_upload.part_etags_lock);
-		multi_file_upload.part_etags.insert(std::pair<uint16_t, string>(write_buffer->part_no, etag));
+		unique_lock<mutex> lck(part_etags_lock);
+		part_etags.insert(std::pair<uint16_t, string>(write_buffer->part_no, etag));
 	}
 
-	multi_file_upload.parts_uploaded++;
+	parts_uploaded++;
 
 	// Free up space for another thread to acquire an S3WriteBuffer
 	write_buffer.reset();
@@ -230,11 +224,11 @@ void S3MultiPartUpload::FlushBuffer(shared_ptr<S3WriteBuffer> write_buffer) {
 	}
 
 #ifdef SAME_THREAD_UPLOAD
-	UploadBuffer(file_handle, write_buffer);
+	UploadBuffer(shared_from_this(), write_buffer);
 	return;
 #endif
 
-	std::thread upload_thread(S3MultiPartUpload::UploadBuffer, std::ref(s3_file_handle), write_buffer);
+	std::thread upload_thread(S3MultiPartUpload::UploadBuffer, shared_from_this(), write_buffer);
 	upload_thread.detach();
 }
 
@@ -253,8 +247,9 @@ void S3MultiPartUpload::FlushAllBuffers() {
 	if (!initialized_multipart_upload) {
 		// TODO (carlo): unclear how to handle kms_key_id, but given currently they are custom, leave the multiupload
 		// codepath in that case
-		if (to_flush.size() == 1 && s3_file_handle.auth_params.kms_key_id.empty()) {
-			S3MultiPartUpload::UploadSingleBuffer(s3_file_handle, to_flush[0]);
+		auto &s3_input = http_input->Cast<S3HTTPInput>();
+		if (to_flush.size() == 1 && s3_input.auth_params.kms_key_id.empty()) {
+			UploadSingleBuffer(to_flush[0]);
 			upload_finalized = true;
 			return;
 		} else {

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -294,11 +294,21 @@ unique_ptr<KeyValueSecret> CreateSecret(vector<string> &prefix_paths_p, string &
 	return return_value;
 }
 
+S3HTTPInput::S3HTTPInput(unique_ptr<HTTPParams> params_p, const S3AuthParams &auth_params_p,
+                         const S3ConfigParams &config_params_p)
+    : HTTPInput(std::move(params_p)), auth_params(auth_params_p), config_params(config_params_p) {
+}
+
+S3HTTPInput::~S3HTTPInput() {
+}
+
 S3FileHandle::S3FileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags,
                            unique_ptr<HTTPParams> http_params_p, const S3AuthParams &auth_params_p,
                            const S3ConfigParams &config_params_p)
-    : HTTPFileHandle(fs, file, flags, std::move(http_params_p)), auth_params(auth_params_p),
-      config_params(config_params_p) {
+    : HTTPFileHandle(fs, file, flags,
+                     make_shared_ptr<S3HTTPInput>(std::move(http_params_p), auth_params_p, config_params_p)),
+      auth_params(http_input->Cast<S3HTTPInput>().auth_params),
+      config_params(http_input->Cast<S3HTTPInput>().config_params) {
 	auto_fallback_to_full_file_download = false;
 	if (flags.OpenForReading() && flags.OpenForWriting()) {
 		throw NotImplementedException("Cannot open an HTTP file for both reading and writing");
@@ -541,10 +551,10 @@ string ParsedS3Url::GetHTTPUrl(S3AuthParams &auth_params, const string &http_que
 	return full_url;
 }
 
-unique_ptr<HTTPResponse> S3FileSystem::PostRequest(FileHandle &handle, string url, HTTPHeaders header_map,
-                                                   string &result, char *buffer_in, idx_t buffer_in_len,
-                                                   string http_params) {
-	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
+unique_ptr<HTTPResponse> S3FileSystem::PostRequest(HTTPInput &input, string url, HTTPHeaders header_map, string &result,
+                                                   char *buffer_in, idx_t buffer_in_len, string http_params) {
+	auto &s3_input = input.Cast<S3HTTPInput>();
+	auto auth_params = s3_input.auth_params;
 	auto parsed_s3_url = S3UrlParse(url, auth_params);
 	string http_url = parsed_s3_url.GetHTTPUrl(auth_params, http_params);
 
@@ -561,12 +571,13 @@ unique_ptr<HTTPResponse> S3FileSystem::PostRequest(FileHandle &handle, string ur
 		                         payload_hash, "application/octet-stream");
 	}
 
-	return HTTPFileSystem::PostRequest(handle, http_url, headers, result, buffer_in, buffer_in_len);
+	return HTTPFileSystem::PostRequest(input, http_url, headers, result, buffer_in, buffer_in_len);
 }
 
-unique_ptr<HTTPResponse> S3FileSystem::PutRequest(FileHandle &handle, string url, HTTPHeaders header_map,
-                                                  char *buffer_in, idx_t buffer_in_len, string http_params) {
-	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
+unique_ptr<HTTPResponse> S3FileSystem::PutRequest(HTTPInput &input, string url, HTTPHeaders header_map, char *buffer_in,
+                                                  idx_t buffer_in_len, string http_params) {
+	auto &s3_input = input.Cast<S3HTTPInput>();
+	auto auth_params = s3_input.auth_params;
 	auto parsed_s3_url = S3UrlParse(url, auth_params);
 	string http_url = parsed_s3_url.GetHTTPUrl(auth_params, http_params);
 	auto content_type = "application/octet-stream";
@@ -584,7 +595,7 @@ unique_ptr<HTTPResponse> S3FileSystem::PutRequest(FileHandle &handle, string url
 		                         payload_hash, content_type);
 	}
 
-	return HTTPFileSystem::PutRequest(handle, http_url, headers, buffer_in, buffer_in_len);
+	return HTTPFileSystem::PutRequest(input, http_url, headers, buffer_in, buffer_in_len);
 }
 
 unique_ptr<HTTPResponse> S3FileSystem::HeadRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map) {
@@ -884,9 +895,11 @@ void S3FileSystem::RemoveFiles(const vector<string> &paths, optional_ptr<FileOpe
 			string bucket_url = url_info.prefix + bucket + "/";
 			auto handle = OpenFile(bucket_url, FileFlags::FILE_FLAGS_READ, opener);
 
+			auto &s3_handle = handle->Cast<S3FileHandle>();
+
 			string result;
-			auto res = HTTPFileSystem::PostRequest(*handle, http_url, headers, result, const_cast<char *>(body.data()),
-			                                       body.length());
+			auto res = HTTPFileSystem::PostRequest(*s3_handle.http_input, http_url, headers, result,
+			                                       const_cast<char *>(body.data()), body.length());
 
 			if (res->status != HTTPStatusCode::OK_200) {
 				throw IOException("Failed to remove files: HTTP %d (%s)\n%s", static_cast<int>(res->status),


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb-httpfs/pull/269, implements the rest of https://github.com/duckdb/duckdb-httpfs/pull/79

This PR decouples the multi-part upload from the file handle. This makes it significantly easier to reason about life-times, as the background threads can now hold a shared pointer to the `S3MultiPartUpload` instead of having to implicitly rely on the `S3FileHandle` to be kept alive. This resolves some weird errors that could previously pop up especially during failed uploads.

In order to make this work, we need to be able to do Post/Put requests without a file-handle. This PR accomplishes this by wrapping the necessary information to make a request in a separate class (`HTTPInput`). 