### PR TITLE
Fix CURL client Post() not tracking total_bytes_received

### DIFF
--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -417,6 +417,12 @@ public:
 
 		curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, &request_info->response_code);
 		info.buffer_out = request_info->body;
+
+		const idx_t bytes_received = request_info->body.size();
+		if (state) {
+			state->total_bytes_received += bytes_received;
+		}
+
 		// Construct HTTPResponse
 		return TransformResponseCurl(res);
 	}


### PR DESCRIPTION
## Summary

- The CURL client's `Post()` method never updated `state->total_bytes_received`, causing HTTPFS profiling to always report `in: 0 bytes` for POST-only workloads
- Added the same `bytes_received` tracking pattern already used by `Get()` to `Post()`
- The HTTPLib client already tracks POST response bytes correctly via its `content_receiver` callback — only the CURL client was affected

## Test plan

- Run a workload that uses HTTP POST requests (e.g. an extension that communicates via POST)
- Use `EXPLAIN ANALYZE` to view the HTTPFS HTTP Stats profiling box
- Verify that `in:` now reflects the actual bytes received from POST responses instead of showing `0 bytes`

Fixes #271