### PR TITLE
Enable CURL response decompression

### DIFF
--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -185,8 +185,8 @@ public:
 		curl_easy_setopt(*curl, CURLOPT_TIMEOUT, http_params.timeout);
 		// set connection timeout
 		curl_easy_setopt(*curl, CURLOPT_CONNECTTIMEOUT, http_params.timeout);
-		// accept content as-is (i.e no decompressing)
-		curl_easy_setopt(*curl, CURLOPT_ACCEPT_ENCODING, NULL);
+		// advertise supported compression encodings and let CURL decompress responses automatically
+		curl_easy_setopt(*curl, CURLOPT_ACCEPT_ENCODING, "");
 		// follow redirects
 		curl_easy_setopt(*curl, CURLOPT_FOLLOWLOCATION, http_params.follow_location ? 1L : 0L);
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,9 @@
 {
   "dependencies": [
     "openssl",
-    "curl"
+    {
+      "name": "curl",
+      "features": ["zstd"]
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Change `CURLOPT_ACCEPT_ENCODING` from `NULL` to `""` so CURL advertises all supported compression encodings (gzip, deflate, br, zstd) and automatically decompresses responses
- Reduces bandwidth usage for HTTP transfers with no behavioral change for callers

Fixes #277

## Test plan

- [ ] Verify CURL sends `Accept-Encoding` header with supported encodings
- [ ] Verify compressed responses are automatically decompressed
- [ ] Run existing httpfs test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)