### PR TITLE
Fix XML namespace attribute handling in S3 ListObjectsV2 response parsing

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1188,19 +1188,32 @@ bool S3FileSystem::ListFilesExtended(const string &directory, const std::functio
 }
 
 optional_idx FindTagContents(const string &response, const string &tag, idx_t cur_pos, string &result) {
-	string open_tag = "<" + tag + ">";
+	// Match "<tag>" or "<tag ...>" (handles XML attributes like xmlns="...")
+	string open_tag_prefix = "<" + tag;
 	string close_tag = "</" + tag + ">";
-	auto open_tag_pos = response.find(open_tag, cur_pos);
+	auto open_tag_pos = response.find(open_tag_prefix, cur_pos);
 	if (open_tag_pos == string::npos) {
 		// tag not found
 		return optional_idx();
 	}
-	auto close_tag_pos = response.find(close_tag, open_tag_pos + open_tag.size());
+	// Verify the match is a complete tag name (not a prefix of a longer tag)
+	auto after_name = open_tag_pos + open_tag_prefix.size();
+	if (after_name >= response.size() || (response[after_name] != '>' && response[after_name] != ' ')) {
+		// Not a valid tag match (e.g., matched <Prefix in <PrefixOther>)
+		return optional_idx();
+	}
+	// Find the end of the opening tag (handles attributes)
+	auto open_tag_end = response.find('>', open_tag_pos);
+	if (open_tag_end == string::npos) {
+		return optional_idx();
+	}
+	auto content_start = open_tag_end + 1;
+	auto close_tag_pos = response.find(close_tag, content_start);
 	if (close_tag_pos == string::npos) {
 		throw InternalException("Failed to parse S3 result: found open tag for %s but did not find matching close tag",
 		                        tag);
 	}
-	result = response.substr(open_tag_pos + open_tag.size(), close_tag_pos - open_tag_pos - open_tag.size());
+	result = response.substr(content_start, close_tag_pos - content_start);
 	return close_tag_pos + close_tag.size();
 }
 
@@ -1487,39 +1500,32 @@ void AWSListObjectV2::ParseFileList(string &aws_response, vector<OpenFileInfo> &
 }
 
 string AWSListObjectV2::ParseContinuationToken(string &aws_response) {
-
-	auto open_tag_pos = aws_response.find("<NextContinuationToken>");
-	if (open_tag_pos == string::npos) {
+	string result;
+	auto pos = FindTagContents(aws_response, "NextContinuationToken", 0, result);
+	if (!pos.IsValid()) {
 		return "";
-	} else {
-		auto close_tag_pos = aws_response.find("</NextContinuationToken>", open_tag_pos + 23);
-		if (close_tag_pos == string::npos) {
-			throw InternalException("Failed to parse S3 result");
-		}
-		return aws_response.substr(open_tag_pos + 23, close_tag_pos - open_tag_pos - 23);
 	}
+	return result;
 }
 
 vector<string> AWSListObjectV2::ParseCommonPrefix(string &aws_response) {
 	vector<string> s3_prefixes;
 	idx_t cur_pos = 0;
 	while (true) {
-		cur_pos = aws_response.find("<CommonPrefixes>", cur_pos);
-		if (cur_pos == string::npos) {
+		string common_prefix_contents;
+		auto next_pos = FindTagContents(aws_response, "CommonPrefixes", cur_pos, common_prefix_contents);
+		if (!next_pos.IsValid()) {
 			break;
 		}
-		auto next_open_tag_pos = aws_response.find("<Prefix>", cur_pos);
-		if (next_open_tag_pos == string::npos) {
-			throw InternalException("Parsing error while parsing s3 listobject result");
-		} else {
-			auto next_close_tag_pos = aws_response.find("</Prefix>", next_open_tag_pos + 8);
-			if (next_close_tag_pos == string::npos) {
-				throw InternalException("Failed to parse S3 result");
-			}
-			auto parsed_path = aws_response.substr(next_open_tag_pos + 8, next_close_tag_pos - next_open_tag_pos - 8);
-			s3_prefixes.push_back(parsed_path);
-			cur_pos = next_close_tag_pos + 6;
+		cur_pos = next_pos.GetIndex();
+
+		string prefix;
+		auto prefix_pos = FindTagContents(common_prefix_contents, "Prefix", 0, prefix);
+		if (!prefix_pos.IsValid()) {
+			throw InternalException("Parsing error while parsing s3 listobject result: Prefix not found in "
+			                        "CommonPrefixes");
 		}
+		s3_prefixes.push_back(prefix);
 	}
 	return s3_prefixes;
 }


### PR DESCRIPTION
## Summary

- `FindTagContents` now handles XML elements with attributes (e.g. `<Prefix xmlns="...">`) by matching the tag name prefix and scanning to `>`, instead of requiring an exact `<Tag>` match
- Refactors `ParseCommonPrefix` and `ParseContinuationToken` to use `FindTagContents`, consistent with `ParseFileList` which was already migrated — removes hardcoded tag-length offsets (`+8`, `+23`)

## Problem

Some S3-compatible backends (notably [Tigris](https://www.tigrisdata.com/)) add `xmlns` attributes on inner XML elements in `ListObjectsV2` responses:

```xml
<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
  <CommonPrefixes>
    <Prefix xmlns="http://s3.amazonaws.com/doc/2006-03-01/">path/to/prefix/</Prefix>
  </CommonPrefixes>
</ListBucketResult>
```

AWS S3 and Cloudflare R2 only set `xmlns` on the root element. While the Tigris response is technically valid XML (namespace inheritance makes the attribute redundant but legal), `ParseCommonPrefix` used `string::find("<Prefix>")` which doesn't match `<Prefix xmlns="...">`, causing an `InternalException`.

**Workaround:** `SET s3_allow_recursive_globbing = false` avoids sending `delimiter=/`, so no `<CommonPrefixes>` appear. But this disables the optimized glob path.

## Changes

**`FindTagContents`** (the shared helper):
- Matches `<tag` prefix instead of `<tag>` exact
- Verifies the character after the tag name is `>` or ` ` (prevents `<Prefix` matching `<PrefixOther>`)
- Finds the actual `>` to determine content start (handles any attributes)

**`ParseCommonPrefix`**: Refactored to use `FindTagContents` for both `<CommonPrefixes>` and `<Prefix>`, matching the pattern in `ParseFileList`.

**`ParseContinuationToken`**: Refactored to use `FindTagContents`, removing the hardcoded offset `+23`.

## Test plan

- [ ] Verify existing S3 glob tests pass (AWS S3 responses are unchanged — `<Tag>` still matches)
- [ ] Test against Tigris with `delimiter=/` glob patterns (previously crashed, now works)
- [ ] Verify `FindTagContents` doesn't false-match partial tag names (e.g. `<PrefixOther>` when searching for `Prefix`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)