### PR TITLE
S3 globs: Faster globs for limited number of files OR limited numbers of files per folders

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1064,6 +1064,7 @@ bool S3GlobResult::ExpandNextPath() const {
 	FileOpenerInfo info = {glob_pattern};
 	auto http_util = HTTPFSUtil::GetHTTPUtil(opener);
 	auto http_params = http_util->InitializeParameters(opener, info);
+	const vector<string> pattern_splits = StringUtil::Split(parsed_s3_url.key, "/");
 
 	vector<OpenFileInfo> s3_keys;
 	if (!current_common_prefix.empty()) {
@@ -1071,7 +1072,6 @@ bool S3GlobResult::ExpandNextPath() const {
 		auto prefix_path = parsed_s3_url.prefix + parsed_s3_url.bucket + '/' + current_common_prefix;
 
 		current_common_prefix = S3FileSystem::UrlDecode(current_common_prefix);
-		vector<string> pattern_splits = StringUtil::Split(parsed_s3_url.key, "/");
 		vector<string> key_splits = StringUtil::Split(current_common_prefix, "/");
 		const bool is_match =
 		    Match(key_splits.begin(), key_splits.end(), pattern_splits.begin(), pattern_splits.end(), false);
@@ -1110,12 +1110,49 @@ bool S3GlobResult::ExpandNextPath() const {
 			allow_s3_recursive_globbing = value.GetValue<bool>();
 		}
 
-		const bool use_recursive_glob = !StringUtil::Contains(parsed_s3_url.key, "**") && allow_s3_recursive_globbing;
+		const bool could_use_recursive_glob =
+		    !StringUtil::Contains(parsed_s3_url.key, "**") && allow_s3_recursive_globbing;
 		// issue the main request
-		string response_str = AWSListObjectV2::Request(shared_path, *http_params, s3_auth_params,
-		                                               main_continuation_token, use_recursive_glob);
+
+		// First perform listing once (default will get back up to 1000 elements)
+		string response_str =
+		    AWSListObjectV2::Request(shared_path, *http_params, s3_auth_params, main_continuation_token, false);
 		main_continuation_token = AWSListObjectV2::ParseContinuationToken(response_str);
+
 		AWSListObjectV2::ParseFileList(response_str, s3_keys);
+
+		// If we could have used recursive globbing AND there are more files, check selectivity
+		if (could_use_recursive_glob && !main_continuation_token.empty()) {
+			idx_t found = 0;
+			idx_t matching = 0;
+			for (auto &s3_key : s3_keys) {
+				vector<string> key_splits = StringUtil::Split(s3_key.path, "/");
+				bool is_match =
+				    Match(key_splits.begin(), key_splits.end(), pattern_splits.begin(), pattern_splits.end(), true);
+
+				if (is_match) {
+					matching++;
+				}
+				found++;
+			}
+			if (matching * 10 < found) {
+				// Filter is selective, less than 10% of files in the list are valid, let's pay the fixed price per
+				// folder of hierarchical glob
+
+				// Start from scratch:
+				// 1. clear keys
+				s3_keys.clear();
+				// 2. do request again, now passing true
+				response_str =
+				    AWSListObjectV2::Request(shared_path, *http_params, s3_auth_params, main_continuation_token, true);
+
+				// 3. add to the list any top level file we found
+				AWSListObjectV2::ParseFileList(response_str, s3_keys);
+
+				// 4. reset continuation
+				main_continuation_token = AWSListObjectV2::ParseContinuationToken(response_str);
+			}
+		}
 
 		// parse the list of common prefixes
 		common_prefixes = AWSListObjectV2::ParseCommonPrefix(response_str);
@@ -1131,7 +1168,6 @@ bool S3GlobResult::ExpandNextPath() const {
 		finished = true;
 	}
 
-	vector<string> pattern_splits = StringUtil::Split(parsed_s3_url.key, "/");
 	for (auto &s3_key : s3_keys) {
 
 		vector<string> key_splits = StringUtil::Split(s3_key.path, "/");

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1003,6 +1003,8 @@ static bool Match(vector<string>::const_iterator key, vector<string>::const_iter
 	return key == key_end && pattern == pattern_end;
 }
 
+enum GlobType { HIERARCHICAL, LISTING, UNKNOWN };
+
 struct S3GlobResult : public LazyMultiFileList {
 public:
 	S3GlobResult(S3FileSystem &fs, const string &path, optional_ptr<FileOpener> opener);
@@ -1021,6 +1023,7 @@ private:
 	mutable string current_common_prefix;
 	mutable string common_prefix_continuation_token;
 	mutable vector<string> common_prefixes;
+	mutable GlobType glob_type {UNKNOWN};
 };
 
 S3GlobResult::S3GlobResult(S3FileSystem &fs, const string &glob_pattern_p, optional_ptr<FileOpener> opener)
@@ -1110,49 +1113,58 @@ bool S3GlobResult::ExpandNextPath() const {
 			allow_s3_recursive_globbing = value.GetValue<bool>();
 		}
 
-		const bool could_use_recursive_glob =
-		    !StringUtil::Contains(parsed_s3_url.key, "**") && allow_s3_recursive_globbing;
+		const bool investigate_use_recursive_glob = !StringUtil::Contains(parsed_s3_url.key, "**") &&
+		                                            allow_s3_recursive_globbing && glob_type == GlobType::UNKNOWN;
 		// issue the main request
 
+		bool perform_listing = (glob_type != GlobType::HIERARCHICAL);
+
 		// First perform listing once (default will get back up to 1000 elements)
-		string response_str =
-		    AWSListObjectV2::Request(shared_path, *http_params, s3_auth_params, main_continuation_token, false);
-		main_continuation_token = AWSListObjectV2::ParseContinuationToken(response_str);
+		string response_str = AWSListObjectV2::Request(shared_path, *http_params, s3_auth_params,
+		                                               main_continuation_token, !perform_listing);
 
-		AWSListObjectV2::ParseFileList(response_str, s3_keys);
+		string next_continuation_token = AWSListObjectV2::ParseContinuationToken(response_str);
 
-		// If we could have used recursive globbing AND there are more files, check selectivity
-		if (could_use_recursive_glob && !main_continuation_token.empty()) {
+		// If we could have used recursive globbing AND there are more files, check average number of files per folder
+		if (investigate_use_recursive_glob && !next_continuation_token.empty()) {
+			vector<OpenFileInfo> s3_keys_tmp;
+			AWSListObjectV2::ParseFileList(response_str, s3_keys_tmp);
 			idx_t found = 0;
-			idx_t matching = 0;
-			for (auto &s3_key : s3_keys) {
+			unordered_set<string> my_set;
+			for (auto &s3_key : s3_keys_tmp) {
 				vector<string> key_splits = StringUtil::Split(s3_key.path, "/");
-				bool is_match =
-				    Match(key_splits.begin(), key_splits.end(), pattern_splits.begin(), pattern_splits.end(), true);
 
-				if (is_match) {
-					matching++;
-				}
 				found++;
+				string x = "";
+				key_splits.pop_back();
+				for (string y : key_splits) {
+					x += y + "/";
+				}
+				my_set.insert(x);
 			}
-			if (matching * 10 < found) {
-				// Filter is selective, less than 10% of files in the list are valid, let's pay the fixed price per
-				// folder of hierarchical glob
+
+			if (my_set.size() * 100 < found) {
+				// We have at least 100 files per folder, this should make so that hierarchical listing price is
+				// amortized folder of hierarchical glob
 
 				// Start from scratch:
 				// 1. clear keys
-				s3_keys.clear();
+				s3_keys_tmp.clear();
 				// 2. do request again, now passing true
 				response_str =
 				    AWSListObjectV2::Request(shared_path, *http_params, s3_auth_params, main_continuation_token, true);
 
-				// 3. add to the list any top level file we found
-				AWSListObjectV2::ParseFileList(response_str, s3_keys);
+				// 3. now set next_continuation_token
+				next_continuation_token = AWSListObjectV2::ParseContinuationToken(response_str);
 
-				// 4. reset continuation
-				main_continuation_token = AWSListObjectV2::ParseContinuationToken(response_str);
+				glob_type = GlobType::HIERARCHICAL;
+			} else {
+				glob_type = GlobType::LISTING;
 			}
 		}
+
+		main_continuation_token = next_continuation_token;
+		AWSListObjectV2::ParseFileList(response_str, s3_keys);
 
 		// parse the list of common prefixes
 		common_prefixes = AWSListObjectV2::ParseCommonPrefix(response_str);

--- a/test/sql/copy/parquet/parquet_glob_s3.test
+++ b/test/sql/copy/parquet/parquet_glob_s3.test
@@ -157,7 +157,7 @@ endloop
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM 's3://test-bucket/parquet_glob_s3/g*/*.parquet';
 ----
-analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 0.*GET\: 6.*PUT\: 0.*\#POST\: 0.*
+analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 0.*GET\: 4.*PUT\: 0.*\#POST\: 0.*
 
 statement ok
 SET s3_allow_recursive_globbing = false;

--- a/test/sql/copy/s3/glob_s3_paging.test_slow
+++ b/test/sql/copy/s3/glob_s3_paging.test_slow
@@ -116,7 +116,7 @@ endloop
 query IIIII
 FROM (FROM duckdb_logs_parsed('HTTP') SELECT count(*), sum(request.type == 'HEAD') head, sum(request.type == 'GET') get, sum(request.type == 'POST') post, sum(request.type == 'PUT') put GROUP BY context_id ORDER BY context_id) WHERE post == 0;
 ----
-3	0	3	0	0
+11	0	11	0	0
 11	0	11	0	0
 11	0	11	0	0
 11	0	11	0	0

--- a/test/sql/copy/s3/glob_s3_paging.test_slow
+++ b/test/sql/copy/s3/glob_s3_paging.test_slow
@@ -116,8 +116,8 @@ endloop
 query IIIII
 FROM (FROM duckdb_logs_parsed('HTTP') SELECT count(*), sum(request.type == 'HEAD') head, sum(request.type == 'GET') get, sum(request.type == 'POST') post, sum(request.type == 'PUT') put GROUP BY context_id ORDER BY context_id) WHERE post == 0;
 ----
-5	0	5	0	0
-13	0	13	0	0
+3	0	3	0	0
+11	0	11	0	0
 11	0	11	0	0
 11	0	11	0	0
 

--- a/test/sql/copy/s3/glob_s3_recursive.test_slow
+++ b/test/sql/copy/s3/glob_s3_recursive.test_slow
@@ -36,7 +36,7 @@ endloop
 query IIIII
 FROM duckdb_logs_parsed('HTTP') SELECT count(*), sum(request.type == 'HEAD'), sum(request.type == 'GET'), sum(request.type == 'POST'), sum(request.type == 'PUT') GROUP BY context_id ORDER BY context_id;
 ----
-3	0	3	0	0
+4	0	4	0	0
 46	0	46	0	0
 
 #

--- a/test/sql/copy/s3/glob_s3_recursive.test_slow
+++ b/test/sql/copy/s3/glob_s3_recursive.test_slow
@@ -61,7 +61,7 @@ endloop
 query IIIII
 FROM duckdb_logs_parsed('HTTP') SELECT count(*), sum(request.type == 'HEAD'), sum(request.type == 'GET'), sum(request.type == 'POST'), sum(request.type == 'PUT') GROUP BY context_id ORDER BY context_id;
 ----
-6	0	6	0	0
+7	0	7	0	0
 46	0	46	0	0
 
 #
@@ -86,7 +86,7 @@ endloop
 query IIIII
 FROM duckdb_logs_parsed('HTTP') SELECT count(*), sum(request.type == 'HEAD'), sum(request.type == 'GET'), sum(request.type == 'POST'), sum(request.type == 'PUT') GROUP BY context_id ORDER BY context_id;
 ----
-3	0	3	0	0
+4	0	4	0	0
 1	0	1	0	0
 
 #


### PR DESCRIPTION
I introduced a regression in S3 glob performances via https://github.com/duckdb/duckdb-httpfs/pull/218.

This has been reported in multiple issues, such as https://github.com/duckdb/duckdb/issues/21385, https://github.com/duckdb/duckdb/issues/21347, and similar ones that correctly pointed out that `SET s3_allow_recursive_globbing = false;` would solve the issue.

Issue is basically that hierarchical / recursive globbing as a worse case penality equal to number of folders in the bucket, and given S3 default it's usually returning up to 1000 files, single request will be enough most of the times.

This PR refine the logic:
- perform a single listing (up to 1000 files)
   - no continuation? then we are completed with a single roundtrip, great
   - we have a continuation? check how many files have been returned AND how many unique folders. If there are num_folders < num_files / 100
       - hierarchical globs (first resetting the list)
       - regular listing based globs (from the continuation we already have)

This makes so for buckets with many files per folders (estimated on the first 1000 or so returned files) hierarchical strategy is used, since the worse case overhead that is linear on number of folders will be bounded and small.
If folders contain less than 100 files per folder, then use regular listing.

This should make so we have the best of both words:
* number of files in bucket / 1000 using lists
* 1 + number of folders + size of result set / 1000 using hierarchical listing

Also small buckets (less that 1000 files) are guaranteed to be done in 1 roundtrip.