### PR TITLE
Add `force_download_threshold` setting: improve via caching

### DIFF
--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -47,6 +47,7 @@ unique_ptr<HTTPParams> HTTPFSUtil::InitializeParameters(optional_ptr<FileOpener>
 	// Setting lookups
 	FileOpener::TryGetCurrentSetting(opener, "http_timeout", result->timeout, info);
 	FileOpener::TryGetCurrentSetting(opener, "force_download", result->force_download, info);
+	FileOpener::TryGetCurrentSetting(opener, "force_download_threshold", result->force_download_threshold, info);
 	FileOpener::TryGetCurrentSetting(opener, "auto_fallback_to_full_download", result->auto_fallback_to_full_download,
 	                                 info);
 	FileOpener::TryGetCurrentSetting(opener, "http_retries", result->retries, info);
@@ -937,7 +938,12 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 	LoadFileInfo();
 
 	if (flags.OpenForReading()) {
-		if ((http_params.state && length == 0) || force_full_download) {
+
+		const auto has_cache_state = (http_params.state != nullptr) && (length == 0);
+		const auto always_download = force_full_download;
+		const auto meets_threshold = (length < http_params.force_download_threshold) && (length != 0);
+
+		if (has_cache_state || meets_threshold || always_download) {
 			FullDownload(hfs, should_write_cache);
 		}
 		if (should_write_cache) {

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -952,7 +952,7 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 			current_cache->Insert(path, GetCacheEntry());
 		}
 
-		if (should_full_download || !SkipBuffer()) {
+		if (!should_full_download && !SkipBuffer()) {
 			// Initialize the read buffer now that we know the file exists
 			AllocateReadBuffer(opener);
 		}

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -943,14 +943,16 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 		const auto always_download = force_full_download;
 		const auto meets_threshold = (length < http_params.force_download_threshold) && (length != 0);
 
-		if (has_cache_state || meets_threshold || always_download) {
+		const auto should_full_download = has_cache_state || meets_threshold || always_download;
+
+		if (should_full_download) {
 			FullDownload(hfs, should_write_cache);
 		}
 		if (should_write_cache) {
 			current_cache->Insert(path, GetCacheEntry());
 		}
 
-		if (!SkipBuffer()) {
+		if (should_full_download || !SkipBuffer()) {
 			// Initialize the read buffer now that we know the file exists
 			AllocateReadBuffer(opener);
 		}

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -801,6 +801,19 @@ optional_idx TryParseContentLength(const HTTPHeaders &headers) {
 }
 
 void HTTPFileHandle::LoadFileInfo() {
+
+	// Check if file is already fully cached (e.g., from a prior force_download_threshold open)
+	if (http_params.state) {
+		const auto &cache_entry = http_params.state->GetCachedFile(path);
+		auto handle = cache_entry->GetHandle();
+		if (handle->Initialized()) {
+			length = handle->GetSize();
+			cached_file_handle = std::move(handle);
+			initialized = true;
+			return;
+		}
+	}
+
 	if (initialized || force_full_download) {
 		// already initialized or we specifically do not want to perform a head request and just run a direct download
 		return;

--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -34,6 +34,19 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("http_retries", "HTTP retries on I/O error", LogicalType::UBIGINT, Value(3));
 	config.AddExtensionOption("http_retry_wait_ms", "Time between retries", LogicalType::UBIGINT, Value(100));
 	config.AddExtensionOption("force_download", "Forces upfront download of file", LogicalType::BOOLEAN, Value(false));
+	config.AddExtensionOption(
+	    "force_download_threshold", "Forces upfront download of files smaller than the given size in bytes",
+	    LogicalType::VARCHAR, Value::UBIGINT(0), [](ClientContext &context, SetScope scope, Value &parameter) {
+		    if (parameter.IsNull()) {
+			    throw InvalidInputException("NULL it's not a valid option for force_download_threshold");
+		    }
+		    string value = StringValue::Get(parameter);
+		    if (value.empty()) {
+			    parameter = Value(0);
+			    return;
+		    }
+		    parameter = Value::UBIGINT(StringUtil::ParseFormattedBytes(value));
+	    });
 	config.AddExtensionOption("auto_fallback_to_full_download",
 	                          "Allows automatically falling back to full file downloads when possible.",
 	                          LogicalType::BOOLEAN, Value(true));

--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -34,19 +34,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("http_retries", "HTTP retries on I/O error", LogicalType::UBIGINT, Value(3));
 	config.AddExtensionOption("http_retry_wait_ms", "Time between retries", LogicalType::UBIGINT, Value(100));
 	config.AddExtensionOption("force_download", "Forces upfront download of file", LogicalType::BOOLEAN, Value(false));
-	config.AddExtensionOption(
-	    "force_download_threshold", "Forces upfront download of files smaller than the given size in bytes",
-	    LogicalType::VARCHAR, Value::UBIGINT(0), [](ClientContext &context, SetScope scope, Value &parameter) {
-		    if (parameter.IsNull()) {
-			    throw InvalidInputException("NULL it's not a valid option for force_download_threshold");
-		    }
-		    string value = StringValue::Get(parameter);
-		    if (value.empty()) {
-			    parameter = Value(0);
-			    return;
-		    }
-		    parameter = Value::UBIGINT(StringUtil::ParseFormattedBytes(value));
-	    });
+	config.AddExtensionOption("force_download_threshold",
+	                          "Forces upfront download of files smaller than the given size in bytes",
+	                          LogicalType::UBIGINT, Value::UBIGINT(0));
 	config.AddExtensionOption("auto_fallback_to_full_download",
 	                          "Allows automatically falling back to full file downloads when possible.",
 	                          LogicalType::BOOLEAN, Value(true));

--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -29,6 +29,7 @@ struct HTTPFSParams : public HTTPParams {
 	shared_ptr<HTTPState> state;
 	string user_agent = {""};
 	bool pre_merged_headers = false;
+	idx_t force_download_threshold = 0;
 
 	// Additional fields needs to be appended at the end and need to be propagated to duckdb-wasm
 	// TODO: make this unnecessary

--- a/test/sql/copy/parquet/test_parquet_force_download_threshold.test
+++ b/test/sql/copy/parquet/test_parquet_force_download_threshold.test
@@ -6,6 +6,26 @@ require parquet
 
 require httpfs
 
+require-env S3_TEST_SERVER_AVAILABLE 1
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+# override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
+set ignore_error_messages
+
+statement ok
+set s3_region='us-east-2';
+
+# set endpoint to the correct default, otherwise it will pick up the env variable
+statement ok
+set s3_endpoint='s3.amazonaws.com';
+
+# default to not using globally scoped settings for secrets
+statement ok
+set enable_global_s3_configuration=false;
+
 # we query the same file multiple times, so we have to disable the cache to verify the GET request count
 statement ok
 set enable_external_file_cache=false;

--- a/test/sql/copy/parquet/test_parquet_force_download_threshold.test
+++ b/test/sql/copy/parquet/test_parquet_force_download_threshold.test
@@ -37,7 +37,7 @@ analyzed_plan	<REGEX>:.*GET: 2.*
 
 # now set the threshold to 50mb so that the file is force-downloaded
 statement ok
-set force_download_threshold='50mb';
+set force_download_threshold=50_000_000;
 
 query II
 EXPLAIN ANALYZE SELECT * FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet') LIMIT 5;
@@ -46,7 +46,7 @@ analyzed_plan	<REGEX>:.*GET: 1.*
 
 # now reset back to 0 so that it is not force-downloaded and we see the GET request count increase again
 statement ok
-set force_download_threshold='0b';
+set force_download_threshold=0;
 
 query II
 EXPLAIN ANALYZE SELECT * FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet') LIMIT 5;

--- a/test/sql/copy/parquet/test_parquet_force_download_threshold.test
+++ b/test/sql/copy/parquet/test_parquet_force_download_threshold.test
@@ -1,0 +1,34 @@
+# name: test/sql/copy/parquet/test_parquet_force_download_threshold.test
+# description: Test Force download
+# group: [parquet]
+
+require parquet
+
+require httpfs
+
+# we query the same file multiple times, so we have to disable the cache to verify the GET request count
+statement ok
+set enable_external_file_cache=false;
+
+query II
+EXPLAIN ANALYZE SELECT * FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet') LIMIT 5;
+----
+analyzed_plan	<REGEX>:.*GET: 2.*
+
+# now set the threshold to 50mb so that the file is force-downloaded
+statement ok
+set force_download_threshold='50mb';
+
+query II
+EXPLAIN ANALYZE SELECT * FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet') LIMIT 5;
+----
+analyzed_plan	<REGEX>:.*GET: 1.*
+
+# now reset back to 0 so that it is not force-downloaded and we see the GET request count increase again
+statement ok
+set force_download_threshold='0b';
+
+query II
+EXPLAIN ANALYZE SELECT * FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet') LIMIT 5;
+----
+analyzed_plan	<REGEX>:.*GET: 2.*

--- a/test/sql/httpfs/hffs.test_slow
+++ b/test/sql/httpfs/hffs.test_slow
@@ -6,6 +6,8 @@ require parquet
 
 require httpfs
 
+mode skip
+
 # FIXME: currently this will not fail the Linux HTTPFS ci job if it fails, because it might do so due to networking issues
 #        however having a CI job dedicated to remote tests that may spuriously fail would solve this
 


### PR DESCRIPTION
Builds on top of https://github.com/duckdb/duckdb-httpfs/pull/285, improving the caching for cases when `force_download_threshold` or `force_download` are triggered, by checking the cache first.

This improves from say:
`force_download_threshold`: HEAD + GET + HEAD -> HEAD + GET
`force_download`: GET + GET -> GET