### PR TITLE
Fix util name mismatch

### DIFF
--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -574,7 +574,7 @@ unordered_map<string, string> HTTPFSCurlUtil::ParseGetParameters(const string &t
 }
 
 string HTTPFSCurlUtil::GetName() const {
-	return "HTTPFSUtil-Curl";
+	return "HTTPFS-Curl";
 }
 
 } // namespace duckdb

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -574,7 +574,7 @@ unordered_map<string, string> HTTPFSCurlUtil::ParseGetParameters(const string &t
 }
 
 string HTTPFSCurlUtil::GetName() const {
-	return "HTTPFS-Curl";
+	return "HTTPFSUtil-Curl";
 }
 
 } // namespace duckdb

--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -119,16 +119,14 @@ static void LoadInternal(ExtensionLoader &loader) {
 			                            "`default` are currently supported for duckdb-wasm");
 		}
 #ifndef EMSCRIPTEN
+		// HTTP util classes are supposed to be cheap, which provides acces to the HTTP client, and generally don't
+		// store resources (i.e., connection pool).
 		if (value == "curl" || value == "default") {
-			if (http_util.GetName() != "HTTPFSUtil-Curl") {
-				config.SetHTTPUtil(make_shared_ptr<HTTPFSCurlUtil>());
-			}
+			config.SetHTTPUtil(make_shared_ptr<HTTPFSCurlUtil>());
 			return;
 		}
 		if (value == "httplib") {
-			if (http_util.GetName() != "HTTPFSUtil") {
-				config.SetHTTPUtil(make_shared_ptr<HTTPFSUtil>());
-			}
+			config.SetHTTPUtil(make_shared_ptr<HTTPFSUtil>());
 			return;
 		}
 #endif


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb-httpfs/issues/296

As described in the issue, I think we should use the same naming at both ends, otherwise new curl http util will be created every single switch.