### PR TITLE
[minor] Remove unused create s3 params

### DIFF
--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -86,7 +86,6 @@ struct AWSEnvironmentCredentialsProvider {
 
 	void SetExtensionOptionValue(string key, const char *env_var);
 	void SetAll();
-	S3AuthParams CreateParams();
 };
 
 struct ParsedS3Url {

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -173,22 +173,6 @@ void AWSEnvironmentCredentialsProvider::SetAll() {
 	this->SetExtensionOptionValue("s3_requester_pays", DUCKDB_REQUESTER_PAYS_ENV_VAR);
 }
 
-S3AuthParams AWSEnvironmentCredentialsProvider::CreateParams() {
-	S3AuthParams params;
-
-	params.region = DEFAULT_REGION_ENV_VAR;
-	params.region = REGION_ENV_VAR;
-	params.access_key_id = ACCESS_KEY_ENV_VAR;
-	params.secret_access_key = SECRET_KEY_ENV_VAR;
-	params.session_token = SESSION_TOKEN_ENV_VAR;
-	params.endpoint = DUCKDB_ENDPOINT_ENV_VAR;
-	params.kms_key_id = DUCKDB_KMS_KEY_ID_ENV_VAR;
-	params.use_ssl = DUCKDB_USE_SSL_ENV_VAR;
-	params.requester_pays = DUCKDB_REQUESTER_PAYS_ENV_VAR;
-
-	return params;
-}
-
 S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info) {
 
 	// Without a FileOpener we can not access settings nor secrets: return empty auth params


### PR DESCRIPTION
Hi team, I'm reading through the code and find this function seems to be unused anywhere.
```sh
[~/duckdb-httpfs] (hjiang/remove-unused=function) 
vscode@9a5948bd4884$ git grep "CreateParams("
src/include/s3fs.hpp:   S3AuthParams CreateParams();
src/s3fs.cpp:S3AuthParams AWSEnvironmentCredentialsProvider::CreateParams() {
```