### PR TITLE
Fix secret type count passed to key-value reader

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -197,7 +197,7 @@ S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerI
 	}
 
 	const char *secret_types[] = {"s3", "r2", "gcs", "aws"};
-	S3KeyValueReader secret_reader(*opener, info, secret_types, 3);
+	S3KeyValueReader secret_reader(*opener, info, secret_types, sizeof(secret_types) / sizeof(secret_types[0]));
 
 	return ReadFrom(secret_reader, info.file_path);
 }

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -197,7 +197,7 @@ S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerI
 	}
 
 	const char *secret_types[] = {"s3", "r2", "gcs", "aws"};
-	S3KeyValueReader secret_reader(*opener, info, secret_types, sizeof(secret_types) / sizeof(secret_types[0]));
+	S3KeyValueReader secret_reader(*opener, info, secret_types, 4);
 
 	return ReadFrom(secret_reader, info.file_path);
 }


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-httpfs/issues/299

I wish we could pass by `std::span`: https://en.cppreference.com/w/cpp/container/span.html