### PR TITLE
Fix httplib client discarding response body on non-2xx status codes

### DIFF
--- a/src/httpfs_httplib_client.cpp
+++ b/src/httpfs_httplib_client.cpp
@@ -115,8 +115,11 @@ public:
 		// First assign body, this is the body that will be uploaded
 		req.body.assign(const_char_ptr_cast(info.buffer_in), info.buffer_in_len);
 		auto transformed_req = TransformResult(client->send(req));
-		// Then, after actual re-quest, re-assign body to the response value of the POST request
-		transformed_req->body.assign(const_char_ptr_cast(info.buffer_in), info.buffer_in_len);
+		// For non-2xx responses, httplib does not invoke content_receiver,
+		// so buffer_out will be empty. Fall back to the response body.
+		if (info.buffer_out.empty() && !transformed_req->body.empty()) {
+			info.buffer_out = transformed_req->body;
+		}
 		return transformed_req;
 	}
 


### PR DESCRIPTION
## Summary

- **Fix missing response body for non-2xx responses**: The httplib `Post()` method sets a `content_receiver` callback to populate `buffer_out`, but cpp-httplib only invokes `content_receiver` for 2xx responses. For error responses (4xx, 5xx), the body was silently discarded, making it impossible for callers to read structured error responses from the server. The fix falls back to the response body from the httplib response object when `content_receiver` was not invoked.

- **Fix response body overwritten with request body**: After the HTTP request completed, the code incorrectly overwrote `transformed_req->body` with the request payload (`info.buffer_in`), destroying the actual HTTP response data. This line has been removed.

The curl client implementation was already correct — its write callback fires for all status codes regardless.

## Motivation

Extensions that make HTTP POST requests need to read error response bodies (e.g., structured error payloads from REST APIs) to provide meaningful error messages. With the current code, any non-2xx response returns an empty body, forcing callers to handle errors blindly.
