### PR TITLE
Enable connection caching/reuse via `SET httpfs_connection_caching=true;`

### DIFF
--- a/.github/workflows/IntegrationTests.yml
+++ b/.github/workflows/IntegrationTests.yml
@@ -88,3 +88,4 @@ jobs:
           ./build/release/test/unittest "*" --skip-error-messages "[]"
           ./build/release/test/unittest "*" --skip-error-messages "[]" --statically-loaded-extensions "[httpfs,parquet,core_functions]" --on-init "SET httpfs_client_implementation='curl';" || true
           ./build/release/test/unittest "*" --skip-error-messages "[]" --statically-loaded-extensions "[httpfs,parquet,core_functions]" --on-init "SET httpfs_client_implementation='httplib';" || true
+          ./build/release/test/unittest "*" --skip-error-messages "[]" --statically-loaded-extensions "[httpfs,parquet,core_functions]" --on-init "SET httpfs_client_implementation='connection-caching';" || true

--- a/.github/workflows/IntegrationTests.yml
+++ b/.github/workflows/IntegrationTests.yml
@@ -88,4 +88,4 @@ jobs:
           ./build/release/test/unittest "*" --skip-error-messages "[]"
           ./build/release/test/unittest "*" --skip-error-messages "[]" --statically-loaded-extensions "[httpfs,parquet,core_functions]" --on-init "SET httpfs_client_implementation='curl';" || true
           ./build/release/test/unittest "*" --skip-error-messages "[]" --statically-loaded-extensions "[httpfs,parquet,core_functions]" --on-init "SET httpfs_client_implementation='httplib';" || true
-          ./build/release/test/unittest "*" --skip-error-messages "[]" --statically-loaded-extensions "[httpfs,parquet,core_functions]" --on-init "SET httpfs_client_implementation='connection-caching';" || true
+          ./build/release/test/unittest "*" --skip-error-messages "[]" --statically-loaded-extensions "[httpfs,parquet,core_functions]" --on-init "SET httpfs_connection_caching=true;" || true

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
     with:
       extension_name: httpfs
-      duckdb_version: v1.5.1
+      duckdb_version: 0fab542c84ca94657616e519cd679334dcbd86b1
       ci_tools_version: v1.5-variegata
 
   duckdb-stable-deploy:
@@ -27,7 +27,7 @@ jobs:
     secrets: inherit
     with:
       extension_name: httpfs
-      duckdb_version: v1.5.1
+      duckdb_version: 0fab542c84ca94657616e519cd679334dcbd86b1
       ci_tools_version: v1.5-variegata
       deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') }}
       deploy_versioned: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}
@@ -37,7 +37,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@v1.5-variegata
     with:
       extension_name: httpfs
-      duckdb_version: v1.5.1
+      duckdb_version: 0fab542c84ca94657616e519cd679334dcbd86b1
       ci_tools_version: v1.5-variegata
       extra_toolchains: 'python3'
       format_checks: 'format'

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,9 +9,8 @@ set(HTTPFS_SOURCES
     httpfs_extension.cpp
     s3_multi_part_upload.cpp)
 if(NOT EMSCRIPTEN)
-  set(HTTPFS_SOURCES
-      ${HTTPFS_SOURCES} crypto.cpp httpfs_httplib_client.cpp
-      httpfs_connection_caching.cpp httpfs_curl_client.cpp)
+  set(HTTPFS_SOURCES ${HTTPFS_SOURCES} crypto.cpp httpfs_httplib_client.cpp
+                     httpfs_connection_caching.cpp httpfs_curl_client.cpp)
 else()
   set(HTTPFS_SOURCES ${HTTPFS_SOURCES} httpfs_client_wasm.cpp)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,8 +9,9 @@ set(HTTPFS_SOURCES
     httpfs_extension.cpp
     s3_multi_part_upload.cpp)
 if(NOT EMSCRIPTEN)
-  set(HTTPFS_SOURCES ${HTTPFS_SOURCES} crypto.cpp httpfs_httplib_client.cpp httpfs_connection_caching_client.cpp
-                     httpfs_curl_client.cpp)
+  set(HTTPFS_SOURCES
+      ${HTTPFS_SOURCES} crypto.cpp httpfs_httplib_client.cpp
+      httpfs_connection_caching_client.cpp httpfs_curl_client.cpp)
 else()
   set(HTTPFS_SOURCES ${HTTPFS_SOURCES} httpfs_client_wasm.cpp)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,7 @@ set(HTTPFS_SOURCES
     httpfs_extension.cpp
     s3_multi_part_upload.cpp)
 if(NOT EMSCRIPTEN)
-  set(HTTPFS_SOURCES ${HTTPFS_SOURCES} crypto.cpp httpfs_httplib_client.cpp
+  set(HTTPFS_SOURCES ${HTTPFS_SOURCES} crypto.cpp httpfs_httplib_client.cpp httpfs_connection_caching_client.cpp
                      httpfs_curl_client.cpp)
 else()
   set(HTTPFS_SOURCES ${HTTPFS_SOURCES} httpfs_client_wasm.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ set(HTTPFS_SOURCES
 if(NOT EMSCRIPTEN)
   set(HTTPFS_SOURCES
       ${HTTPFS_SOURCES} crypto.cpp httpfs_httplib_client.cpp
-      httpfs_connection_caching_client.cpp httpfs_curl_client.cpp)
+      httpfs_connection_caching.cpp httpfs_curl_client.cpp)
 else()
   set(HTTPFS_SOURCES ${HTTPFS_SOURCES} httpfs_client_wasm.cpp)
 endif()

--- a/src/hffs.cpp
+++ b/src/hffs.cpp
@@ -46,6 +46,7 @@ HFFileHandle::~HFFileHandle() {
 }
 
 unique_ptr<HTTPClient> HFFileHandle::CreateClient() {
+	cached_proto_host_port = parsed_url.endpoint;
 	return http_params.http_util.InitializeClient(http_params, parsed_url.endpoint);
 }
 

--- a/src/hffs.cpp
+++ b/src/hffs.cpp
@@ -46,7 +46,6 @@ HFFileHandle::~HFFileHandle() {
 }
 
 unique_ptr<HTTPClient> HFFileHandle::CreateClient() {
-	cached_proto_host_port = parsed_url.endpoint;
 	return http_params.http_util.InitializeClient(http_params, parsed_url.endpoint);
 }
 

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -15,10 +15,8 @@
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "http_state.hpp"
 
-#include <chrono>
 #include <map>
 #include <string>
-#include <thread>
 
 #include "s3fs.hpp"
 
@@ -557,7 +555,7 @@ bool HTTPFileSystem::ReadInternal(FileHandle &handle, void *buffer, int64_t nr_b
 		DUCKDB_LOG_FILE_SYSTEM_READ(handle, nr_bytes, location);
 		// Update handle status within critical section for parallel access.
 		if (hfh.flags.RequireParallelAccess()) {
-			std::lock_guard<std::mutex> lck(hfh.mu);
+			std::lock_guard<mutex> lck(hfh.mu);
 			hfh.buffer_available = 0;
 			hfh.buffer_idx = 0;
 			hfh.file_offset = location + nr_bytes;

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -1029,6 +1029,10 @@ HTTPFileHandle::~HTTPFileHandle() {
 	}
 }
 
+void HTTPFSUtil::ClearCachedConnections() {
+	// no-op by default
+}
+
 string HTTPFSUtil::GetName() const {
 	return "HTTPFS";
 }

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -1011,9 +1011,9 @@ unique_ptr<HTTPClient> HTTPFileHandle::GetClient() {
 }
 
 unique_ptr<HTTPClient> HTTPFileHandle::CreateClient() {
-	// Create a new client
 	string path_out, proto_host_port;
 	HTTPUtil::DecomposeURL(path, path_out, proto_host_port);
+	cached_proto_host_port = proto_host_port;
 	return http_params.http_util.InitializeClient(http_params, proto_host_port);
 }
 
@@ -1023,6 +1023,18 @@ void HTTPFileHandle::StoreClient(unique_ptr<HTTPClient> client) {
 
 HTTPFileHandle::~HTTPFileHandle() {
 	DUCKDB_LOG_FILE_SYSTEM_CLOSE((*this));
+	if (!cached_proto_host_port.empty()) {
+		auto &httpfs_util = static_cast<HTTPFSUtil &>(http_params.http_util);
+		auto client = client_cache.GetClient();
+		while (client) {
+			httpfs_util.CloseClient(cached_proto_host_port, std::move(client));
+			client = client_cache.GetClient();
+		}
+	}
+}
+
+void HTTPFSUtil::CloseClient(const string &, unique_ptr<HTTPClient> &&) {
+	// no-op by default, client destroyed via RAII
 }
 
 string HTTPFSUtil::GetName() const {

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -1013,7 +1013,6 @@ unique_ptr<HTTPClient> HTTPFileHandle::GetClient() {
 unique_ptr<HTTPClient> HTTPFileHandle::CreateClient() {
 	string path_out, proto_host_port;
 	HTTPUtil::DecomposeURL(path, path_out, proto_host_port);
-	cached_proto_host_port = proto_host_port;
 	return http_params.http_util.InitializeClient(http_params, proto_host_port);
 }
 
@@ -1023,18 +1022,11 @@ void HTTPFileHandle::StoreClient(unique_ptr<HTTPClient> client) {
 
 HTTPFileHandle::~HTTPFileHandle() {
 	DUCKDB_LOG_FILE_SYSTEM_CLOSE((*this));
-	if (!cached_proto_host_port.empty()) {
-		auto &httpfs_util = static_cast<HTTPFSUtil &>(http_params.http_util);
-		auto client = client_cache.GetClient();
-		while (client) {
-			httpfs_util.CloseClient(cached_proto_host_port, std::move(client));
-			client = client_cache.GetClient();
-		}
+	auto client = client_cache.GetClient();
+	while (client) {
+		http_params.http_util.CloseClient(std::move(client));
+		client = client_cache.GetClient();
 	}
-}
-
-void HTTPFSUtil::CloseClient(const string &, unique_ptr<HTTPClient> &&) {
-	// no-op by default, client destroyed via RAII
 }
 
 string HTTPFSUtil::GetName() const {

--- a/src/httpfs_connection_caching.cpp
+++ b/src/httpfs_connection_caching.cpp
@@ -14,9 +14,9 @@ unique_ptr<HTTPClient> HTTPClientConnectionCache::Find(const string &base_url) {
 		return nullptr;
 	}
 	if (auto lock = std::unique_lock<std::mutex>(mutex, std::try_to_lock)) {
-		for (idx_t i = 0; i < entries.size(); i++) {
-			if (entries[i] && entries[i]->GetBaseUrl() == base_url) {
-				return std::move(entries[i]);
+		for (auto &entry : entries) {
+			if (entry && entry->GetBaseUrl() == base_url) {
+				return std::move(entry);
 			}
 		}
 	}
@@ -32,9 +32,9 @@ void HTTPClientConnectionCache::Store(unique_ptr<HTTPClient> &&client) {
 			entries.resize(64);
 		}
 		// First prefer an empty slot
-		for (idx_t i = 0; i < entries.size(); i++) {
-			if (!entries[i]) {
-				entries[i] = std::move(client);
+		for (auto &entry : entries) {
+			if (!entry) {
+				entry = std::move(client);
 				return;
 			}
 		}

--- a/src/httpfs_connection_caching.cpp
+++ b/src/httpfs_connection_caching.cpp
@@ -15,7 +15,7 @@ unique_ptr<HTTPClient> HTTPClientConnectionCache::Find(const string &base_url) {
 	}
 	if (auto lock = std::unique_lock<std::mutex>(mutex, std::try_to_lock)) {
 		for (idx_t i = 0; i < entries.size(); i++) {
-			if (entries[i] && entries[i]->base_url == base_url) {
+			if (entries[i] && entries[i]->GetBaseUrl() == base_url) {
 				return std::move(entries[i]);
 			}
 		}
@@ -24,7 +24,7 @@ unique_ptr<HTTPClient> HTTPClientConnectionCache::Find(const string &base_url) {
 }
 
 void HTTPClientConnectionCache::Store(unique_ptr<HTTPClient> &&client) {
-	if (!client || client->base_url.empty()) {
+	if (!client || client->GetBaseUrl().empty()) {
 		return;
 	}
 	if (auto lock = std::unique_lock<std::mutex>(mutex, std::try_to_lock)) {

--- a/src/httpfs_connection_caching.cpp
+++ b/src/httpfs_connection_caching.cpp
@@ -14,7 +14,7 @@ unique_ptr<HTTPClient> HTTPClientConnectionCache::Find(const string &base_url) {
 	if (base_url.empty()) {
 		return nullptr;
 	}
-	if (auto lock = unique_lock<std::mutex>(mutex, std::try_to_lock)) {
+	if (auto lock = unique_lock<mutex>(cache_lock, std::try_to_lock)) {
 		for (auto &entry : entries) {
 			if (entry && entry->GetBaseUrl() == base_url) {
 				return std::move(entry);
@@ -28,7 +28,7 @@ void HTTPClientConnectionCache::Store(unique_ptr<HTTPClient> &&client) {
 	if (!client || client->GetBaseUrl().empty()) {
 		return;
 	}
-	if (auto lock = unique_lock<std::mutex>(mutex, std::try_to_lock)) {
+	if (auto lock = unique_lock<mutex>(cache_lock, std::try_to_lock)) {
 		if (entries.empty()) {
 			entries.resize(64);
 		}
@@ -49,7 +49,7 @@ void HTTPClientConnectionCache::Store(unique_ptr<HTTPClient> &&client) {
 }
 
 void HTTPClientConnectionCache::Clear() {
-	lock_guard<std::mutex> lck(mutex);
+	lock_guard<mutex> lck(cache_lock);
 	entries.clear();
 }
 

--- a/src/httpfs_connection_caching.cpp
+++ b/src/httpfs_connection_caching.cpp
@@ -1,4 +1,5 @@
 #include "httpfs_client.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/random_engine.hpp"
 #include "duckdb/logging/log_type.hpp"
 #include "duckdb/logging/logger.hpp"
@@ -13,7 +14,7 @@ unique_ptr<HTTPClient> HTTPClientConnectionCache::Find(const string &base_url) {
 	if (base_url.empty()) {
 		return nullptr;
 	}
-	if (auto lock = std::unique_lock<std::mutex>(mutex, std::try_to_lock)) {
+	if (auto lock = unique_lock<std::mutex>(mutex, std::try_to_lock)) {
 		for (auto &entry : entries) {
 			if (entry && entry->GetBaseUrl() == base_url) {
 				return std::move(entry);
@@ -27,7 +28,7 @@ void HTTPClientConnectionCache::Store(unique_ptr<HTTPClient> &&client) {
 	if (!client || client->GetBaseUrl().empty()) {
 		return;
 	}
-	if (auto lock = std::unique_lock<std::mutex>(mutex, std::try_to_lock)) {
+	if (auto lock = unique_lock<std::mutex>(mutex, std::try_to_lock)) {
 		if (entries.empty()) {
 			entries.resize(64);
 		}

--- a/src/httpfs_connection_caching_client.cpp
+++ b/src/httpfs_connection_caching_client.cpp
@@ -71,16 +71,20 @@ unique_ptr<HTTPResponse> HTTPFSCachedUtil::SendRequest(BaseRequest &request, uni
 	if (!client && caching) {
 		auto cached_client = FindCachedCandidate(request.proto_host_port);
 		if (cached_client) {
-			if (request.params.logger && request.params.logger->ShouldLog(HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL)) {
-				request.params.logger->WriteLog(HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL,
-				                                HTTPFSInfoLogType::ConstructLogMessage("connection_cache_hit", request.proto_host_port));
+			if (request.params.logger &&
+			    request.params.logger->ShouldLog(HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL)) {
+				request.params.logger->WriteLog(
+				    HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL,
+				    HTTPFSInfoLogType::ConstructLogMessage("connection_cache_hit", request.proto_host_port));
 			}
 			cached_client->Initialize(request.params);
 			client = std::move(cached_client);
 		} else {
-			if (request.params.logger && request.params.logger->ShouldLog(HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL)) {
-				request.params.logger->WriteLog(HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL,
-				                                HTTPFSInfoLogType::ConstructLogMessage("connection_cache_miss", request.proto_host_port));
+			if (request.params.logger &&
+			    request.params.logger->ShouldLog(HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL)) {
+				request.params.logger->WriteLog(
+				    HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL,
+				    HTTPFSInfoLogType::ConstructLogMessage("connection_cache_miss", request.proto_host_port));
 			}
 		}
 	}

--- a/src/httpfs_connection_caching_client.cpp
+++ b/src/httpfs_connection_caching_client.cpp
@@ -55,6 +55,7 @@ unique_ptr<HTTPClient> HTTPFSCachedUtil::InitializeClient(HTTPParams &http_param
 }
 
 void HTTPFSCachedUtil::CloseClient(const string &proto_host_port, unique_ptr<HTTPClient> &&client) {
+	// TODO: would be nice to log connection_cache_store here, but no logger is available at this call site
 	StoreCachedCandidate(proto_host_port, std::move(client));
 }
 
@@ -70,11 +71,17 @@ unique_ptr<HTTPResponse> HTTPFSCachedUtil::SendRequest(BaseRequest &request, uni
 	if (!client && caching) {
 		auto cached_client = FindCachedCandidate(request.proto_host_port);
 		if (cached_client) {
-			// fprintf(stderr, "SendRequest: reusing cached client for %s\n", request.proto_host_port.c_str());
+			if (request.params.logger && request.params.logger->ShouldLog(HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL)) {
+				request.params.logger->WriteLog(HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL,
+				                                HTTPFSInfoLogType::ConstructLogMessage("connection_cache_hit", request.proto_host_port));
+			}
 			cached_client->Initialize(request.params);
 			client = std::move(cached_client);
 		} else {
-			// fprintf(stderr, "SendRequest: no cached client for %s\n", request.proto_host_port.c_str());
+			if (request.params.logger && request.params.logger->ShouldLog(HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL)) {
+				request.params.logger->WriteLog(HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL,
+				                                HTTPFSInfoLogType::ConstructLogMessage("connection_cache_miss", request.proto_host_port));
+			}
 		}
 	}
 	if (!client) {

--- a/src/httpfs_connection_caching_client.cpp
+++ b/src/httpfs_connection_caching_client.cpp
@@ -55,6 +55,11 @@ bool HTTPFSCurlUtil::EnableCaching(BaseRequest &request) {
 	return true;
 }
 
+void HTTPFSCurlUtil::ClearCachedConnections() {
+	lock_guard<std::mutex> lck(cached_httpclients_mutex);
+	cached_httpclients.clear();
+}
+
 void HTTPFSCurlUtil::CloseClient(unique_ptr<HTTPClient> &&client) {
 	if (connection_caching_enabled) {
 		// TODO: would be nice to log connection_cache_store here, but no logger is available at this call site

--- a/src/httpfs_connection_caching_client.cpp
+++ b/src/httpfs_connection_caching_client.cpp
@@ -1,0 +1,124 @@
+#include "httpfs_client.hpp"
+#include "duckdb/common/random_engine.hpp"
+#include "duckdb/logging/log_type.hpp"
+#include "duckdb/logging/logger.hpp"
+
+namespace duckdb {
+
+unique_ptr<HTTPClient> HTTPFSCachedUtil::FindCachedCandidate(const string &proto_host_port) {
+	if (proto_host_port.empty()) {
+		return nullptr;
+	}
+	if (auto lock = std::unique_lock<std::mutex>(cached_httpclients_mutex, std::try_to_lock)) {
+		for (idx_t i = 0; i < cached_httpclients.size(); i++) {
+			if (cached_httpclients[i].proto_host_port == proto_host_port && cached_httpclients[i].cached_client) {
+				return std::move(cached_httpclients[i].cached_client);
+			}
+		}
+	}
+	return nullptr;
+}
+
+void HTTPFSCachedUtil::StoreCachedCandidate(const string &proto_host_port, unique_ptr<HTTPClient> &&client) {
+	if (proto_host_port.empty()) {
+		return;
+	}
+	if (auto lock = std::unique_lock<std::mutex>(cached_httpclients_mutex, std::try_to_lock)) {
+		if (cached_httpclients.empty()) {
+			cached_httpclients.resize(64);
+		}
+		// First prefer an empty slot
+		for (idx_t i = 0; i < cached_httpclients.size(); i++) {
+			if (!cached_httpclients[i].cached_client) {
+				cached_httpclients[i].cached_client = std::move(client);
+				cached_httpclients[i].proto_host_port = proto_host_port;
+				return;
+			}
+		}
+		// Else evict one at random
+		{
+			RandomEngine engine;
+			size_t index = engine.NextRandomInteger() % cached_httpclients.size();
+			cached_httpclients[index].cached_client = std::move(client);
+			cached_httpclients[index].proto_host_port = proto_host_port;
+		}
+	}
+}
+
+unique_ptr<HTTPClient> HTTPFSCachedUtil::InitializeClient(HTTPParams &http_params, const string &proto_host_port) {
+	auto client = FindCachedCandidate(proto_host_port);
+	if (client) {
+		client->Initialize(http_params);
+		return client;
+	}
+	return HTTPFSCurlUtil::InitializeClient(http_params, proto_host_port);
+}
+
+void HTTPFSCachedUtil::CloseClient(const string &proto_host_port, unique_ptr<HTTPClient> &&client) {
+	StoreCachedCandidate(proto_host_port, std::move(client));
+}
+
+bool HTTPFSCachedUtil::EnableCaching(BaseRequest &request) {
+	// TODO: return false for proxied connections
+	return true;
+}
+
+unique_ptr<HTTPResponse> HTTPFSCachedUtil::SendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client) {
+	bool caller_owns_client = client != nullptr;
+	bool caching = EnableCaching(request);
+
+	if (!client && caching) {
+		auto cached_client = FindCachedCandidate(request.proto_host_port);
+		if (cached_client) {
+			// fprintf(stderr, "SendRequest: reusing cached client for %s\n", request.proto_host_port.c_str());
+			cached_client->Initialize(request.params);
+			client = std::move(cached_client);
+		} else {
+			// fprintf(stderr, "SendRequest: no cached client for %s\n", request.proto_host_port.c_str());
+		}
+	}
+	if (!client) {
+		client = InitializeClient(request.params, request.proto_host_port);
+	}
+
+	std::function<unique_ptr<HTTPResponse>(void)> on_request([&]() {
+		unique_ptr<HTTPResponse> response;
+
+		if (request.params.logger) {
+			request.have_request_timing = request.params.logger->ShouldLog(HTTPLogType::NAME, HTTPLogType::LEVEL);
+		}
+
+		try {
+			if (request.have_request_timing) {
+				request.request_start = Timestamp::GetCurrentTimestamp();
+			}
+			response = client->Request(request);
+		} catch (...) {
+			if (request.have_request_timing) {
+				request.request_end = Timestamp::GetCurrentTimestamp();
+			}
+			LogRequest(request, nullptr);
+			throw;
+		}
+		if (request.have_request_timing) {
+			request.request_end = Timestamp::GetCurrentTimestamp();
+		}
+		LogRequest(request, response ? response.get() : nullptr);
+		return response;
+	});
+
+	std::function<void(void)> on_retry([&]() { client = InitializeClient(request.params, request.proto_host_port); });
+
+	auto r = RunRequestWithRetry(on_request, request, on_retry);
+	// Only cache if the caller didn't provide the client — otherwise the caller manages its lifecycle
+	if (caching && !caller_owns_client) {
+		StoreCachedCandidate(request.proto_host_port, std::move(client));
+	}
+	return std::move(r);
+}
+
+string HTTPFSCachedUtil::GetName() const {
+	return "HTTPFS-CachedConnection";
+}
+
+} // namespace duckdb

--- a/src/httpfs_connection_caching_client.cpp
+++ b/src/httpfs_connection_caching_client.cpp
@@ -54,9 +54,9 @@ unique_ptr<HTTPClient> HTTPFSCachedUtil::InitializeClient(HTTPParams &http_param
 	return HTTPFSCurlUtil::InitializeClient(http_params, proto_host_port);
 }
 
-void HTTPFSCachedUtil::CloseClient(const string &proto_host_port, unique_ptr<HTTPClient> &&client) {
+void HTTPFSCachedUtil::CloseClient(unique_ptr<HTTPClient> &&client) {
 	// TODO: would be nice to log connection_cache_store here, but no logger is available at this call site
-	StoreCachedCandidate(proto_host_port, std::move(client));
+	StoreCachedCandidate(client->base_url, std::move(client));
 }
 
 bool HTTPFSCachedUtil::EnableCaching(BaseRequest &request) {

--- a/src/httpfs_connection_caching_client.cpp
+++ b/src/httpfs_connection_caching_client.cpp
@@ -5,45 +5,56 @@
 
 namespace duckdb {
 
-unique_ptr<HTTPClient> HTTPFSCurlUtil::FindCachedCandidate(const string &proto_host_port) {
-	if (proto_host_port.empty()) {
+//===--------------------------------------------------------------------===//
+// HTTPClientConnectionCache
+//===--------------------------------------------------------------------===//
+
+unique_ptr<HTTPClient> HTTPClientConnectionCache::Find(const string &base_url) {
+	if (base_url.empty()) {
 		return nullptr;
 	}
-	if (auto lock = std::unique_lock<std::mutex>(cached_httpclients_mutex, std::try_to_lock)) {
-		for (idx_t i = 0; i < cached_httpclients.size(); i++) {
-			if (cached_httpclients[i].proto_host_port == proto_host_port && cached_httpclients[i].cached_client) {
-				return std::move(cached_httpclients[i].cached_client);
+	if (auto lock = std::unique_lock<std::mutex>(mutex, std::try_to_lock)) {
+		for (idx_t i = 0; i < entries.size(); i++) {
+			if (entries[i] && entries[i]->base_url == base_url) {
+				return std::move(entries[i]);
 			}
 		}
 	}
 	return nullptr;
 }
 
-void HTTPFSCurlUtil::StoreCachedCandidate(const string &proto_host_port, unique_ptr<HTTPClient> &&client) {
-	if (proto_host_port.empty()) {
+void HTTPClientConnectionCache::Store(unique_ptr<HTTPClient> &&client) {
+	if (!client || client->base_url.empty()) {
 		return;
 	}
-	if (auto lock = std::unique_lock<std::mutex>(cached_httpclients_mutex, std::try_to_lock)) {
-		if (cached_httpclients.empty()) {
-			cached_httpclients.resize(64);
+	if (auto lock = std::unique_lock<std::mutex>(mutex, std::try_to_lock)) {
+		if (entries.empty()) {
+			entries.resize(64);
 		}
 		// First prefer an empty slot
-		for (idx_t i = 0; i < cached_httpclients.size(); i++) {
-			if (!cached_httpclients[i].cached_client) {
-				cached_httpclients[i].cached_client = std::move(client);
-				cached_httpclients[i].proto_host_port = proto_host_port;
+		for (idx_t i = 0; i < entries.size(); i++) {
+			if (!entries[i]) {
+				entries[i] = std::move(client);
 				return;
 			}
 		}
 		// Else evict one at random
 		{
 			RandomEngine engine;
-			size_t index = engine.NextRandomInteger() % cached_httpclients.size();
-			cached_httpclients[index].cached_client = std::move(client);
-			cached_httpclients[index].proto_host_port = proto_host_port;
+			size_t index = engine.NextRandomInteger() % entries.size();
+			entries[index] = std::move(client);
 		}
 	}
 }
+
+void HTTPClientConnectionCache::Clear() {
+	lock_guard<std::mutex> lck(mutex);
+	entries.clear();
+}
+
+//===--------------------------------------------------------------------===//
+// HTTPFSCurlUtil — connection caching
+//===--------------------------------------------------------------------===//
 
 bool HTTPFSCurlUtil::EnableCaching(BaseRequest &request) {
 	if (!connection_caching_enabled) {
@@ -56,14 +67,13 @@ bool HTTPFSCurlUtil::EnableCaching(BaseRequest &request) {
 }
 
 void HTTPFSCurlUtil::ClearCachedConnections() {
-	lock_guard<std::mutex> lck(cached_httpclients_mutex);
-	cached_httpclients.clear();
+	connection_cache.Clear();
 }
 
 void HTTPFSCurlUtil::CloseClient(unique_ptr<HTTPClient> &&client) {
 	if (connection_caching_enabled) {
 		// TODO: would be nice to log connection_cache_store here, but no logger is available at this call site
-		StoreCachedCandidate(client->base_url, std::move(client));
+		connection_cache.Store(std::move(client));
 	}
 }
 
@@ -75,7 +85,7 @@ unique_ptr<HTTPResponse> HTTPFSCurlUtil::CachingSendRequest(BaseRequest &request
 	bool caller_owns_client = client != nullptr;
 
 	if (!client) {
-		auto cached_client = FindCachedCandidate(request.proto_host_port);
+		auto cached_client = connection_cache.Find(request.proto_host_port);
 		if (cached_client) {
 			if (request.params.logger &&
 			    request.params.logger->ShouldLog(HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL)) {
@@ -99,7 +109,7 @@ unique_ptr<HTTPResponse> HTTPFSCurlUtil::CachingSendRequest(BaseRequest &request
 
 	// Only cache if the caller didn't provide the client — otherwise the caller manages its lifecycle
 	if (!caller_owns_client) {
-		StoreCachedCandidate(request.proto_host_port, std::move(client));
+		connection_cache.Store(std::move(client));
 	}
 	return std::move(r);
 }

--- a/src/httpfs_connection_caching_client.cpp
+++ b/src/httpfs_connection_caching_client.cpp
@@ -5,7 +5,7 @@
 
 namespace duckdb {
 
-unique_ptr<HTTPClient> HTTPFSCachedUtil::FindCachedCandidate(const string &proto_host_port) {
+unique_ptr<HTTPClient> HTTPFSCurlUtil::FindCachedCandidate(const string &proto_host_port) {
 	if (proto_host_port.empty()) {
 		return nullptr;
 	}
@@ -19,7 +19,7 @@ unique_ptr<HTTPClient> HTTPFSCachedUtil::FindCachedCandidate(const string &proto
 	return nullptr;
 }
 
-void HTTPFSCachedUtil::StoreCachedCandidate(const string &proto_host_port, unique_ptr<HTTPClient> &&client) {
+void HTTPFSCurlUtil::StoreCachedCandidate(const string &proto_host_port, unique_ptr<HTTPClient> &&client) {
 	if (proto_host_port.empty()) {
 		return;
 	}
@@ -45,30 +45,31 @@ void HTTPFSCachedUtil::StoreCachedCandidate(const string &proto_host_port, uniqu
 	}
 }
 
-unique_ptr<HTTPClient> HTTPFSCachedUtil::InitializeClient(HTTPParams &http_params, const string &proto_host_port) {
-	auto client = FindCachedCandidate(proto_host_port);
-	if (client) {
-		client->Initialize(http_params);
-		return client;
+bool HTTPFSCurlUtil::EnableCaching(BaseRequest &request) {
+	if (!connection_caching_enabled) {
+		return false;
 	}
-	return HTTPFSCurlUtil::InitializeClient(http_params, proto_host_port);
-}
-
-void HTTPFSCachedUtil::CloseClient(unique_ptr<HTTPClient> &&client) {
-	// TODO: would be nice to log connection_cache_store here, but no logger is available at this call site
-	StoreCachedCandidate(client->base_url, std::move(client));
-}
-
-bool HTTPFSCachedUtil::EnableCaching(BaseRequest &request) {
-	// TODO: return false for proxied connections
+	if (!request.params.http_proxy.empty()) {
+		return false;
+	}
 	return true;
 }
 
-unique_ptr<HTTPResponse> HTTPFSCachedUtil::SendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client) {
-	bool caller_owns_client = client != nullptr;
-	bool caching = EnableCaching(request);
+void HTTPFSCurlUtil::CloseClient(unique_ptr<HTTPClient> &&client) {
+	if (connection_caching_enabled) {
+		// TODO: would be nice to log connection_cache_store here, but no logger is available at this call site
+		StoreCachedCandidate(client->base_url, std::move(client));
+	}
+}
 
-	if (!client && caching) {
+unique_ptr<HTTPResponse> HTTPFSCurlUtil::BaseSendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client) {
+	return HTTPUtil::SendRequest(request, client);
+}
+
+unique_ptr<HTTPResponse> HTTPFSCurlUtil::CachingSendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client) {
+	bool caller_owns_client = client != nullptr;
+
+	if (!client) {
 		auto cached_client = FindCachedCandidate(request.proto_host_port);
 		if (cached_client) {
 			if (request.params.logger &&
@@ -88,48 +89,21 @@ unique_ptr<HTTPResponse> HTTPFSCachedUtil::SendRequest(BaseRequest &request, uni
 			}
 		}
 	}
-	if (!client) {
-		client = InitializeClient(request.params, request.proto_host_port);
-	}
 
-	std::function<unique_ptr<HTTPResponse>(void)> on_request([&]() {
-		unique_ptr<HTTPResponse> response;
+	auto r = BaseSendRequest(request, client);
 
-		if (request.params.logger) {
-			request.have_request_timing = request.params.logger->ShouldLog(HTTPLogType::NAME, HTTPLogType::LEVEL);
-		}
-
-		try {
-			if (request.have_request_timing) {
-				request.request_start = Timestamp::GetCurrentTimestamp();
-			}
-			response = client->Request(request);
-		} catch (...) {
-			if (request.have_request_timing) {
-				request.request_end = Timestamp::GetCurrentTimestamp();
-			}
-			LogRequest(request, nullptr);
-			throw;
-		}
-		if (request.have_request_timing) {
-			request.request_end = Timestamp::GetCurrentTimestamp();
-		}
-		LogRequest(request, response ? response.get() : nullptr);
-		return response;
-	});
-
-	std::function<void(void)> on_retry([&]() { client = InitializeClient(request.params, request.proto_host_port); });
-
-	auto r = RunRequestWithRetry(on_request, request, on_retry);
 	// Only cache if the caller didn't provide the client — otherwise the caller manages its lifecycle
-	if (caching && !caller_owns_client) {
+	if (!caller_owns_client) {
 		StoreCachedCandidate(request.proto_host_port, std::move(client));
 	}
 	return std::move(r);
 }
 
-string HTTPFSCachedUtil::GetName() const {
-	return "HTTPFS-CachedConnection";
+unique_ptr<HTTPResponse> HTTPFSCurlUtil::SendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client) {
+	if (EnableCaching(request)) {
+		return CachingSendRequest(request, client);
+	}
+	return BaseSendRequest(request, client);
 }
 
 } // namespace duckdb

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -230,6 +230,7 @@ public:
 		CURLcode res;
 		{
 			curl_easy_setopt(*curl, CURLOPT_NOBODY, 0L);
+			curl_easy_setopt(*curl, CURLOPT_HTTPGET, 1L);
 			CURLU *url = curl_url_dup(base_url);
 
 			string normalized_path = NormalizePathToBeAdded(info.path);

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -559,8 +559,7 @@ unique_ptr<HTTPClient> HTTPFSCurlUtil::InitializeClient(HTTPParams &http_params,
 			client->Initialize(http_params);
 			return client;
 		}
-		if (http_params.logger &&
-		    http_params.logger->ShouldLog(HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL)) {
+		if (http_params.logger && http_params.logger->ShouldLog(HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL)) {
 			http_params.logger->WriteLog(
 			    HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL,
 			    HTTPFSInfoLogType::ConstructLogMessage("connection_cache_miss", proto_host_port));

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -126,9 +126,10 @@ public:
 		return added_path;
 	}
 	HTTPFSCurlClient(HTTPFSParams &http_params, const string &proto_host_port) {
-		base_url = curl_url();
+		base_url = proto_host_port;
+		curl_base_url = curl_url();
 		string normalized_path = NormalizePathToBeAdded(proto_host_port);
-		curl_url_set(base_url, CURLUPART_URL, normalized_path.c_str(), 0);
+		curl_url_set(curl_base_url, CURLUPART_URL, normalized_path.c_str(), 0);
 		stored_bearer_token = "";
 		stored_cert_file_path = "";
 		Initialize(http_params);
@@ -214,7 +215,7 @@ public:
 	}
 
 	~HTTPFSCurlClient() {
-		curl_url_cleanup(base_url);
+		curl_url_cleanup(curl_base_url);
 		DestroyCurlGlobal();
 	}
 
@@ -231,7 +232,7 @@ public:
 		{
 			curl_easy_setopt(*curl, CURLOPT_NOBODY, 0L);
 			curl_easy_setopt(*curl, CURLOPT_HTTPGET, 1L);
-			CURLU *url = curl_url_dup(base_url);
+			CURLU *url = curl_url_dup(curl_base_url);
 
 			string normalized_path = NormalizePathToBeAdded(info.path);
 			curl_url_set(url, CURLUPART_URL, normalized_path.c_str(), 0);
@@ -291,7 +292,7 @@ public:
 
 		CURLcode res;
 		{
-			CURLU *url = curl_url_dup(base_url);
+			CURLU *url = curl_url_dup(curl_base_url);
 
 			string normalized_path = NormalizePathToBeAdded(info.path);
 			curl_url_set(url, CURLUPART_URL, normalized_path.c_str(), 0);
@@ -341,7 +342,7 @@ public:
 			curl_easy_setopt(*curl, CURLOPT_NOBODY, 1L);
 			curl_easy_setopt(*curl, CURLOPT_HTTPGET, 0L);
 
-			CURLU *url = curl_url_dup(base_url);
+			CURLU *url = curl_url_dup(curl_base_url);
 
 			string normalized_path = NormalizePathToBeAdded(info.path);
 			curl_url_set(url, CURLUPART_URL, normalized_path.c_str(), 0);
@@ -374,7 +375,7 @@ public:
 
 		CURLcode res;
 		{
-			CURLU *url = curl_url_dup(base_url);
+			CURLU *url = curl_url_dup(curl_base_url);
 
 			string normalized_path = NormalizePathToBeAdded(info.path);
 			curl_url_set(url, CURLUPART_URL, normalized_path.c_str(), 0);
@@ -416,7 +417,7 @@ public:
 
 		CURLcode res;
 		{
-			CURLU *url = curl_url_dup(base_url);
+			CURLU *url = curl_url_dup(curl_base_url);
 
 			string normalized_path = NormalizePathToBeAdded(info.path);
 			curl_url_set(url, CURLUPART_URL, normalized_path.c_str(), 0);
@@ -513,7 +514,7 @@ private:
 	unique_ptr<CURLHandle> curl;
 	optional_ptr<HTTPState> state;
 	unique_ptr<RequestInfo> request_info;
-	CURLU *base_url = nullptr;
+	CURLU *curl_base_url = nullptr;
 	string stored_bearer_token;
 	string stored_cert_file_path;
 

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -1,5 +1,6 @@
 #include "httpfs_client.hpp"
 #include "http_state.hpp"
+#include "duckdb/logging/logger.hpp"
 
 #define CPPHTTPLIB_OPENSSL_SUPPORT
 
@@ -546,6 +547,25 @@ private:
 };
 
 unique_ptr<HTTPClient> HTTPFSCurlUtil::InitializeClient(HTTPParams &http_params, const string &proto_host_port) {
+	if (connection_caching_enabled) {
+		auto client = FindCachedCandidate(proto_host_port);
+		if (client) {
+			if (http_params.logger &&
+			    http_params.logger->ShouldLog(HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL)) {
+				http_params.logger->WriteLog(
+				    HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL,
+				    HTTPFSInfoLogType::ConstructLogMessage("connection_cache_hit", proto_host_port));
+			}
+			client->Initialize(http_params);
+			return client;
+		}
+		if (http_params.logger &&
+		    http_params.logger->ShouldLog(HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL)) {
+			http_params.logger->WriteLog(
+			    HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL,
+			    HTTPFSInfoLogType::ConstructLogMessage("connection_cache_miss", proto_host_port));
+		}
+	}
 	auto client = make_uniq<HTTPFSCurlClient>(http_params.Cast<HTTPFSParams>(), proto_host_port);
 	return std::move(client);
 }

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -126,8 +126,7 @@ public:
 
 		return added_path;
 	}
-	HTTPFSCurlClient(HTTPFSParams &http_params, const string &proto_host_port) {
-		base_url = proto_host_port;
+	HTTPFSCurlClient(HTTPFSParams &http_params, const string &proto_host_port) : HTTPClient(proto_host_port) {
 		curl_base_url = curl_url();
 		string normalized_path = NormalizePathToBeAdded(proto_host_port);
 		curl_url_set(curl_base_url, CURLUPART_URL, normalized_path.c_str(), 0);

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -518,8 +518,8 @@ private:
 	string stored_bearer_token;
 	string stored_cert_file_path;
 
-	static std::mutex &GetRefLock() {
-		static std::mutex mtx;
+	static mutex &GetRefLock() {
+		static mutex mtx;
 		return mtx;
 	}
 

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -548,7 +548,7 @@ private:
 
 unique_ptr<HTTPClient> HTTPFSCurlUtil::InitializeClient(HTTPParams &http_params, const string &proto_host_port) {
 	if (connection_caching_enabled) {
-		auto client = FindCachedCandidate(proto_host_port);
+		auto client = connection_cache.Find(proto_host_port);
 		if (client) {
 			if (http_params.logger &&
 			    http_params.logger->ShouldLog(HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL)) {

--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -18,13 +18,13 @@
 
 namespace duckdb {
 
-static void ClearCachedConnectionsFunction(ClientContext &context, TableFunctionInput &, DataChunk &) {
+static void ClearHTTPFSConnectionCacheFunction(ClientContext &context, TableFunctionInput &, DataChunk &) {
 	auto &config = DBConfig::GetConfig(context);
 	auto &httpfs_util = static_cast<HTTPFSUtil &>(config.GetHTTPUtil());
 	httpfs_util.ClearCachedConnections();
 }
 
-static unique_ptr<FunctionData> ClearCachedConnectionsBind(ClientContext &, TableFunctionBindInput &,
+static unique_ptr<FunctionData> ClearHTTPFSConnectionCacheBind(ClientContext &, TableFunctionBindInput &,
                                                            vector<LogicalType> &return_types, vector<string> &names) {
 	return_types.emplace_back(LogicalType::BOOLEAN);
 	names.emplace_back("success");
@@ -183,9 +183,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 	auto provider = make_uniq<AWSEnvironmentCredentialsProvider>(config);
 	provider->SetAll();
 
-	auto clear_cached_connections =
-	    TableFunction("clear_cached_connections", {}, ClearCachedConnectionsFunction, ClearCachedConnectionsBind);
-	loader.RegisterFunction(clear_cached_connections);
+	auto clear_httpfs_connection_cache =
+	    TableFunction("clear_httpfs_connection_cache", {}, ClearHTTPFSConnectionCacheFunction, ClearHTTPFSConnectionCacheBind);
+	loader.RegisterFunction(clear_httpfs_connection_cache);
 
 	CreateS3SecretFunctions::Register(loader);
 	CreateBearerTokenFunctions::Register(loader);

--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -137,23 +137,29 @@ static void LoadInternal(ExtensionLoader &loader) {
 			config.SetHTTPUtil(make_shared_ptr<HTTPFSCurlUtil>());
 			return;
 		}
-		if (value == "connection-caching") {
-			config.SetHTTPUtil(make_shared_ptr<HTTPFSCachedUtil>());
-			return;
-		}
 		if (value == "httplib") {
 			config.SetHTTPUtil(make_shared_ptr<HTTPFSUtil>());
 			return;
 		}
 #endif
-		throw InvalidInputException("Unsupported option for httpfs_client_implementation, only `curl`, `httplib`, "
-		                            "`connection-caching` and `default` are currently supported");
+		throw InvalidInputException("Unsupported option for httpfs_client_implementation, only `curl`, `httplib` "
+		                            "and `default` are currently supported");
 	};
 	config.AddExtensionOption("httpfs_client_implementation", "Select which is the HTTPUtil implementation to be used",
 	                          LogicalType::VARCHAR, "default", callback_httpfs_client_implementation);
-	// NOP — connection caching not yet implemented on this branch
+
+	auto callback_httpfs_connection_caching = [](ClientContext &context, SetScope scope, Value &parameter) {
+		auto &config = DBConfig::GetConfig(context);
+		auto &http_util = config.GetHTTPUtil();
+#ifndef EMSCRIPTEN
+		auto *curl_util = dynamic_cast<HTTPFSCurlUtil *>(&http_util);
+		if (curl_util) {
+			curl_util->connection_caching_enabled = BooleanValue::Get(parameter);
+		}
+#endif
+	};
 	config.AddExtensionOption("httpfs_connection_caching", "Enable connection caching for HTTP requests",
-	                          LogicalType::BOOLEAN, Value::BOOLEAN(false));
+	                          LogicalType::BOOLEAN, Value::BOOLEAN(false), callback_httpfs_connection_caching);
 
 	config.AddExtensionOption("enable_global_s3_configuration",
 	                          "Automatically fetch AWS credentials from environment variables.", LogicalType::BOOLEAN,

--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -25,7 +25,8 @@ static void ClearHTTPFSConnectionCacheFunction(ClientContext &context, TableFunc
 }
 
 static unique_ptr<FunctionData> ClearHTTPFSConnectionCacheBind(ClientContext &, TableFunctionBindInput &,
-                                                           vector<LogicalType> &return_types, vector<string> &names) {
+                                                               vector<LogicalType> &return_types,
+                                                               vector<string> &names) {
 	return_types.emplace_back(LogicalType::BOOLEAN);
 	names.emplace_back("success");
 	return nullptr;
@@ -183,8 +184,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 	auto provider = make_uniq<AWSEnvironmentCredentialsProvider>(config);
 	provider->SetAll();
 
-	auto clear_httpfs_connection_cache =
-	    TableFunction("clear_httpfs_connection_cache", {}, ClearHTTPFSConnectionCacheFunction, ClearHTTPFSConnectionCacheBind);
+	auto clear_httpfs_connection_cache = TableFunction(
+	    "clear_httpfs_connection_cache", {}, ClearHTTPFSConnectionCacheFunction, ClearHTTPFSConnectionCacheBind);
 	loader.RegisterFunction(clear_httpfs_connection_cache);
 
 	CreateS3SecretFunctions::Register(loader);

--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -137,13 +137,17 @@ static void LoadInternal(ExtensionLoader &loader) {
 			config.SetHTTPUtil(make_shared_ptr<HTTPFSCurlUtil>());
 			return;
 		}
+		if (value == "connection-caching") {
+			config.SetHTTPUtil(make_shared_ptr<HTTPFSCachedUtil>());
+			return;
+		}
 		if (value == "httplib") {
 			config.SetHTTPUtil(make_shared_ptr<HTTPFSUtil>());
 			return;
 		}
 #endif
-		throw InvalidInputException("Unsupported option for httpfs_client_implementation, only `curl`, `httplib` and "
-		                            "`default` are currently supported");
+		throw InvalidInputException("Unsupported option for httpfs_client_implementation, only `curl`, `httplib`, "
+		                            "`connection-caching` and `default` are currently supported");
 	};
 	config.AddExtensionOption("httpfs_client_implementation", "Select which is the HTTPUtil implementation to be used",
 	                          LogicalType::VARCHAR, "default", callback_httpfs_client_implementation);

--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -6,6 +6,7 @@
 #include "s3fs.hpp"
 #include "hffs.hpp"
 #include "duckdb/common/local_file_system.hpp"
+#include "duckdb/logging/log_manager.hpp"
 #include "duckdb/main/client_context_file_opener.hpp"
 #ifdef OVERRIDE_ENCRYPTION_UTILS
 #include "crypto.hpp"
@@ -17,13 +18,14 @@
 
 namespace duckdb {
 
-static void ClearHTTPFSConnectionCacheFunction(ClientContext &, TableFunctionInput &, DataChunk &) {
-	// NOP — connection caching not yet implemented on this branch
+static void ClearCachedConnectionsFunction(ClientContext &context, TableFunctionInput &, DataChunk &) {
+	auto &config = DBConfig::GetConfig(context);
+	auto &httpfs_util = static_cast<HTTPFSUtil &>(config.GetHTTPUtil());
+	httpfs_util.ClearCachedConnections();
 }
 
-static unique_ptr<FunctionData> ClearHTTPFSConnectionCacheBind(ClientContext &, TableFunctionBindInput &,
-                                                               vector<LogicalType> &return_types,
-                                                               vector<string> &names) {
+static unique_ptr<FunctionData> ClearCachedConnectionsBind(ClientContext &, TableFunctionBindInput &,
+                                                           vector<LogicalType> &return_types, vector<string> &names) {
 	return_types.emplace_back(LogicalType::BOOLEAN);
 	names.emplace_back("success");
 	return nullptr;
@@ -36,6 +38,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 	fs.RegisterSubSystem(make_uniq<HTTPFileSystem>());
 	fs.RegisterSubSystem(make_uniq<HuggingFaceFileSystem>());
 	fs.RegisterSubSystem(make_uniq<S3FileSystem>(BufferManager::GetBufferManager(instance)));
+
+	instance.GetLogManager().RegisterLogType(make_uniq<HTTPFSInfoLogType>());
 
 	auto &config = DBConfig::GetConfig(instance);
 
@@ -179,9 +183,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 	auto provider = make_uniq<AWSEnvironmentCredentialsProvider>(config);
 	provider->SetAll();
 
-	auto clear_httpfs_connection_cache = TableFunction(
-	    "clear_httpfs_connection_cache", {}, ClearHTTPFSConnectionCacheFunction, ClearHTTPFSConnectionCacheBind);
-	loader.RegisterFunction(clear_httpfs_connection_cache);
+	auto clear_cached_connections =
+	    TableFunction("clear_cached_connections", {}, ClearCachedConnectionsFunction, ClearCachedConnectionsBind);
+	loader.RegisterFunction(clear_cached_connections);
 
 	CreateS3SecretFunctions::Register(loader);
 	CreateBearerTokenFunctions::Register(loader);

--- a/src/httpfs_httplib_client.cpp
+++ b/src/httpfs_httplib_client.cpp
@@ -8,6 +8,7 @@ namespace duckdb {
 class HTTPFSClient : public HTTPClient {
 public:
 	HTTPFSClient(HTTPFSParams &http_params, const string &proto_host_port) {
+		base_url = proto_host_port;
 		client = make_uniq<duckdb_httplib_openssl::Client>(proto_host_port);
 		Initialize(http_params);
 	}

--- a/src/httpfs_httplib_client.cpp
+++ b/src/httpfs_httplib_client.cpp
@@ -7,8 +7,7 @@ namespace duckdb {
 
 class HTTPFSClient : public HTTPClient {
 public:
-	HTTPFSClient(HTTPFSParams &http_params, const string &proto_host_port) {
-		base_url = proto_host_port;
+	HTTPFSClient(HTTPFSParams &http_params, const string &proto_host_port) : HTTPClient(proto_host_port) {
 		client = make_uniq<duckdb_httplib_openssl::Client>(proto_host_port);
 		Initialize(http_params);
 	}

--- a/src/httpfs_httplib_client.cpp
+++ b/src/httpfs_httplib_client.cpp
@@ -17,6 +17,8 @@ public:
 		client->set_keep_alive(http_params.keep_alive);
 		if (!http_params.ca_cert_file.empty()) {
 			client->set_ca_cert_path(http_params.ca_cert_file.c_str());
+		} else {
+			client->set_ca_cert_path("");
 		}
 		const bool verify_ssl =
 		    http_params.override_verify_ssl ? http_params.verify_ssl : http_params.enable_server_cert_verification;
@@ -27,6 +29,8 @@ public:
 		client->set_decompress(false);
 		if (!http_params.bearer_token.empty()) {
 			client->set_bearer_token_auth(http_params.bearer_token.c_str());
+		} else {
+			client->set_bearer_token_auth("");
 		}
 
 		if (!http_params.http_proxy.empty()) {
@@ -35,6 +39,9 @@ public:
 			if (!http_params.http_proxy_username.empty()) {
 				client->set_proxy_basic_auth(http_params.http_proxy_username, http_params.http_proxy_password);
 			}
+		} else {
+			client->set_proxy("", -1);
+			client->set_proxy_basic_auth("", "");
 		}
 		state = http_params.state;
 	}

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -77,6 +77,8 @@ public:
 
 	// We keep an http client stored for connection reuse with keep-alive headers
 	HTTPClientCache client_cache;
+	// The resolved proto_host_port for global cache keying
+	string cached_proto_host_port;
 
 	shared_ptr<HTTPInput> http_input;
 	HTTPFSParams &http_params;

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -77,8 +77,6 @@ public:
 
 	// We keep an http client stored for connection reuse with keep-alive headers
 	HTTPClientCache client_cache;
-	// The resolved proto_host_port for global cache keying
-	string cached_proto_host_port;
 
 	shared_ptr<HTTPInput> http_input;
 	HTTPFSParams &http_params;

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -10,8 +10,6 @@
 #include "http_metadata_cache.hpp"
 #include "httpfs_client.hpp"
 
-#include <mutex>
-
 namespace duckdb {
 
 class RangeRequestNotSupportedException {
@@ -106,7 +104,7 @@ public:
 	idx_t buffer_end;
 
 	// Used when file handle created with parallel access flag specified.
-	std::mutex mu;
+	mutex mu;
 
 	// Read buffer
 	AllocatedData read_buffer;

--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb/common/http_util.hpp"
+#include <mutex>
 
 namespace duckdb {
 class HTTPLogger;
@@ -35,11 +36,19 @@ struct HTTPFSParams : public HTTPParams {
 	// TODO: make this unnecessary
 };
 
+struct CachedHTTPClient {
+	unique_ptr<HTTPClient> cached_client;
+	string proto_host_port;
+};
+
 class HTTPFSUtil : public HTTPUtil {
 public:
 	unique_ptr<HTTPParams> InitializeParameters(optional_ptr<FileOpener> opener,
 	                                            optional_ptr<FileOpenerInfo> info) override;
 	unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
+
+	//! Close a client — may cache it for reuse
+	virtual void CloseClient(const string &proto_host_port, unique_ptr<HTTPClient> &&client);
 
 	static unordered_map<string, string> ParseGetParameters(const string &text);
 	static HTTPUtil &GetHTTPUtil(optional_ptr<FileOpener> opener);
@@ -56,6 +65,21 @@ public:
 	static unordered_map<string, string> ParseGetParameters(const string &text);
 
 	string GetName() const override;
+};
+
+class HTTPFSCachedUtil : public HTTPFSCurlUtil {
+public:
+	unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
+	void CloseClient(const string &proto_host_port, unique_ptr<HTTPClient> &&client) override;
+	unique_ptr<HTTPResponse> SendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client) override;
+
+	string GetName() const override;
+
+	bool EnableCaching(BaseRequest &request);
+	unique_ptr<HTTPClient> FindCachedCandidate(const string &proto_host_port);
+	void StoreCachedCandidate(const string &proto_host_port, unique_ptr<HTTPClient> &&client);
+	std::mutex cached_httpclients_mutex {};
+	std::vector<CachedHTTPClient> cached_httpclients;
 };
 
 #endif

--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -60,7 +60,7 @@ public:
 	void Clear();
 
 private:
-	mutex mutex {};
+	mutex cache_lock {};
 	std::vector<unique_ptr<HTTPClient>> entries;
 };
 

--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -1,9 +1,23 @@
 #pragma once
 
 #include "duckdb/common/http_util.hpp"
+#include "duckdb/logging/log_type.hpp"
 #include <mutex>
 
 namespace duckdb {
+
+class HTTPFSInfoLogType {
+public:
+	static constexpr const char *NAME = "HTTPFSInfo";
+	static constexpr LogLevel LEVEL = LogLevel::LOG_INFO;
+
+	static string ConstructLogMessage(const string &type, const string &host, const string &payload = "") {
+		if (payload.empty()) {
+			return "{\"type\":\"" + type + "\",\"host\":\"" + host + "\"}";
+		}
+		return "{\"type\":\"" + type + "\",\"host\":\"" + host + "\",\"payload\":\"" + payload + "\"}";
+	}
+};
 class HTTPLogger;
 class FileOpener;
 struct FileOpenerInfo;

--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "duckdb/common/http_util.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/logging/log_type.hpp"
-#include <mutex>
 
 namespace duckdb {
 
@@ -60,7 +60,7 @@ public:
 	void Clear();
 
 private:
-	std::mutex mutex {};
+	mutex mutex {};
 	std::vector<unique_ptr<HTTPClient>> entries;
 };
 

--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -72,19 +72,21 @@ public:
 class HTTPFSCurlUtil : public HTTPFSUtil {
 public:
 	unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
+	void CloseClient(unique_ptr<HTTPClient> &&client) override;
+	unique_ptr<HTTPResponse> SendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client) override;
 
 	static unordered_map<string, string> ParseGetParameters(const string &text);
 
 	string GetName() const override;
-};
 
-class HTTPFSCachedUtil : public HTTPFSCurlUtil {
-public:
-	unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
-	void CloseClient(unique_ptr<HTTPClient> &&client) override;
-	unique_ptr<HTTPResponse> SendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client) override;
+	//! Whether connection caching is enabled
+	bool connection_caching_enabled = false;
 
-	string GetName() const override;
+private:
+	//! Send request with connection caching (acquire from pool, run, store back)
+	unique_ptr<HTTPResponse> CachingSendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client);
+	//! Send request without caching (delegates to HTTPUtil::SendRequest)
+	unique_ptr<HTTPResponse> BaseSendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client);
 
 	bool EnableCaching(BaseRequest &request);
 	unique_ptr<HTTPClient> FindCachedCandidate(const string &proto_host_port);

--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -61,9 +61,6 @@ public:
 	                                            optional_ptr<FileOpenerInfo> info) override;
 	unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
 
-	//! Close a client — may cache it for reuse
-	virtual void CloseClient(const string &proto_host_port, unique_ptr<HTTPClient> &&client);
-
 	static unordered_map<string, string> ParseGetParameters(const string &text);
 	static HTTPUtil &GetHTTPUtil(optional_ptr<FileOpener> opener);
 
@@ -84,7 +81,7 @@ public:
 class HTTPFSCachedUtil : public HTTPFSCurlUtil {
 public:
 	unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
-	void CloseClient(const string &proto_host_port, unique_ptr<HTTPClient> &&client) override;
+	void CloseClient(unique_ptr<HTTPClient> &&client) override;
 	unique_ptr<HTTPResponse> SendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client) override;
 
 	string GetName() const override;

--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -6,10 +6,13 @@
 
 namespace duckdb {
 
-class HTTPFSInfoLogType {
+class HTTPFSInfoLogType : public LogType {
 public:
 	static constexpr const char *NAME = "HTTPFSInfo";
 	static constexpr LogLevel LEVEL = LogLevel::LOG_INFO;
+
+	HTTPFSInfoLogType() : LogType(NAME, LEVEL) {
+	}
 
 	static string ConstructLogMessage(const string &type, const string &host, const string &payload = "") {
 		if (payload.empty()) {
@@ -61,6 +64,9 @@ public:
 	                                            optional_ptr<FileOpenerInfo> info) override;
 	unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
 
+	//! Clear any cached connections
+	virtual void ClearCachedConnections();
+
 	static unordered_map<string, string> ParseGetParameters(const string &text);
 	static HTTPUtil &GetHTTPUtil(optional_ptr<FileOpener> opener);
 
@@ -73,6 +79,7 @@ class HTTPFSCurlUtil : public HTTPFSUtil {
 public:
 	unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
 	void CloseClient(unique_ptr<HTTPClient> &&client) override;
+	void ClearCachedConnections() override;
 	unique_ptr<HTTPResponse> SendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client) override;
 
 	static unordered_map<string, string> ParseGetParameters(const string &text);

--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -53,9 +53,15 @@ struct HTTPFSParams : public HTTPParams {
 	// TODO: make this unnecessary
 };
 
-struct CachedHTTPClient {
-	unique_ptr<HTTPClient> cached_client;
-	string proto_host_port;
+class HTTPClientConnectionCache {
+public:
+	unique_ptr<HTTPClient> Find(const string &base_url);
+	void Store(unique_ptr<HTTPClient> &&client);
+	void Clear();
+
+private:
+	std::mutex mutex {};
+	std::vector<unique_ptr<HTTPClient>> entries;
 };
 
 class HTTPFSUtil : public HTTPUtil {
@@ -96,10 +102,7 @@ private:
 	unique_ptr<HTTPResponse> BaseSendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client);
 
 	bool EnableCaching(BaseRequest &request);
-	unique_ptr<HTTPClient> FindCachedCandidate(const string &proto_host_port);
-	void StoreCachedCandidate(const string &proto_host_port, unique_ptr<HTTPClient> &&client);
-	std::mutex cached_httpclients_mutex {};
-	std::vector<CachedHTTPClient> cached_httpclients;
+	HTTPClientConnectionCache connection_cache;
 };
 
 #endif

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -383,8 +383,8 @@ void S3FileHandle::FinalizeUpload() {
 
 unique_ptr<HTTPClient> S3FileHandle::CreateClient() {
 	auto parsed_url = S3FileSystem::S3UrlParse(path, this->auth_params);
-
 	string proto_host_port = parsed_url.http_proto + parsed_url.host;
+	cached_proto_host_port = proto_host_port;
 	return http_params.http_util.InitializeClient(http_params, proto_host_port);
 }
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -384,7 +384,6 @@ void S3FileHandle::FinalizeUpload() {
 unique_ptr<HTTPClient> S3FileHandle::CreateClient() {
 	auto parsed_url = S3FileSystem::S3UrlParse(path, this->auth_params);
 	string proto_host_port = parsed_url.http_proto + parsed_url.host;
-	cached_proto_host_port = proto_host_port;
 	return http_params.http_util.InitializeClient(http_params, proto_host_port);
 }
 

--- a/test/sql/connection_caching.test
+++ b/test/sql/connection_caching.test
@@ -47,7 +47,7 @@ SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_hit%';
 
 # Clear the cache
 statement ok
-CALL clear_cached_connections();
+CALL clear_httpfs_connection_cache();
 
 # Request after clearing — should be a cache miss again
 statement ok

--- a/test/sql/connection_caching.test
+++ b/test/sql/connection_caching.test
@@ -1,0 +1,68 @@
+# name: test/sql/connection_caching.test
+# description: Test connection caching behavior
+# group: [sql]
+
+require httpfs
+
+require parquet
+
+# override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
+set ignore_error_messages
+
+statement ok
+SET enable_logging=true;
+
+statement ok
+CALL enable_logging('HTTPFSInfo');
+
+statement ok
+SET httpfs_connection_caching=true;
+
+# First request — should be a cache miss
+statement ok
+FROM 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_role_type.parquet';
+
+query I
+SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_miss%';
+----
+1
+
+# Second request to the same file — should be a cache hit
+statement ok
+FROM 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_role_type.parquet';
+
+query I
+SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_hit%';
+----
+1
+
+# Different file on the same host — should still be a cache hit (same base_url)
+statement ok
+SELECT * FROM 'https://github.com/duckdb/duckdb/raw/9cf66f950dde0173e1a863a7659b3ecf11bf3978/data/csv/customer.csv';
+
+query I
+SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_hit%';
+----
+2
+
+# Clear the cache
+statement ok
+CALL clear_cached_connections();
+
+# Request after clearing — should be a cache miss again
+statement ok
+FROM 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_role_type.parquet';
+
+query I
+SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_miss%';
+----
+2
+
+# Request again — should be a cache hit
+statement ok
+FROM 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_role_type.parquet';
+
+query I
+SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_hit%';
+----
+3

--- a/test/sql/s3/connection_caching_s3.test
+++ b/test/sql/s3/connection_caching_s3.test
@@ -56,7 +56,7 @@ true
 
 # Clear cache and verify miss on next request
 statement ok
-CALL clear_cached_connections();
+CALL clear_httpfs_connection_cache();
 
 statement ok
 CREATE TABLE hits_after_clear AS SELECT count(*) AS cnt FROM duckdb_logs WHERE message LIKE '%connection_cache_miss%';

--- a/test/sql/s3/connection_caching_s3.test
+++ b/test/sql/s3/connection_caching_s3.test
@@ -1,0 +1,70 @@
+# name: test/sql/s3/connection_caching_s3.test
+# description: Test connection caching with S3 on a public bucket
+# group: [s3]
+
+require parquet
+
+require httpfs
+
+# override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
+set ignore_error_messages
+
+statement ok
+SET s3_access_key_id='';
+SET s3_secret_access_key='';
+SET s3_endpoint='s3.amazonaws.com';
+SET s3_region='us-west-2';
+
+statement ok
+SET enable_logging=true;
+
+statement ok
+CALL enable_logging('HTTPFSInfo');
+
+statement ok
+SET httpfs_connection_caching=true;
+
+# Read a single parquet file — cache miss
+statement ok
+FROM parquet_scan('s3://overturemaps-us-west-2/bridgefiles/2025-03-19.0-beta.0/dataset=Esri Community Maps/theme=buildings/type=building/part-00000-947c2149-23db-4abc-a7ee-3a892aac90ff.c000.snappy.parquet') LIMIT 1;
+
+query I
+SELECT count(*) > 0 FROM duckdb_logs WHERE message LIKE '%connection_cache_miss%';
+----
+true
+
+# Read the same file again — the file handle was destroyed, client returned to pool, should get a hit
+statement ok
+FROM parquet_scan('s3://overturemaps-us-west-2/bridgefiles/2025-03-19.0-beta.0/dataset=Esri Community Maps/theme=buildings/type=building/part-00000-947c2149-23db-4abc-a7ee-3a892aac90ff.c000.snappy.parquet') LIMIT 1;
+
+query I
+SELECT count(*) > 0 FROM duckdb_logs WHERE message LIKE '%connection_cache_hit%';
+----
+true
+
+# Cache hits should increase with more requests to the same host
+statement ok
+CREATE TABLE hits_before AS SELECT count(*) AS cnt FROM duckdb_logs WHERE message LIKE '%connection_cache_hit%';
+
+statement ok
+FROM parquet_scan('s3://overturemaps-us-west-2/bridgefiles/2025-03-19.0-beta.0/dataset=Esri Community Maps/theme=buildings/type=building/part-00000-947c2149-23db-4abc-a7ee-3a892aac90ff.c000.snappy.parquet') LIMIT 1;
+
+query I
+SELECT (SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_hit%') > (SELECT cnt FROM hits_before);
+----
+true
+
+# Clear cache and verify miss on next request
+statement ok
+CALL clear_cached_connections();
+
+statement ok
+CREATE TABLE hits_after_clear AS SELECT count(*) AS cnt FROM duckdb_logs WHERE message LIKE '%connection_cache_miss%';
+
+statement ok
+FROM parquet_scan('s3://overturemaps-us-west-2/bridgefiles/2025-03-19.0-beta.0/dataset=Esri Community Maps/theme=buildings/type=building/part-00000-947c2149-23db-4abc-a7ee-3a892aac90ff.c000.snappy.parquet') LIMIT 1;
+
+query I
+SELECT (SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_miss%') > (SELECT cnt FROM hits_after_clear);
+----
+true


### PR DESCRIPTION
Creating an Client to perform HTTP requests is somewhat heavy, and those can be cached across different usages.

Recycle of clients when their usage is done (but they are still valid) allows subsequent usages (in the same or different queries) to be faster.

Example of cases are like:
* sequential queries to the same API endpoint (like performing S3 globs)
* read of files in the same bucket (like `FROM read_parquet('s3://<fixed_bucket>/path/to/*.parquet');`
* frequent usage of common endpoints (also mixed)

Advantages can be from very visible (possibly say 3x in performing repeated HEAD requests) to somewhat visible, but more importantly this should be a strict improvement with no issues (if done right).

Given in case of any implementation problem, this might end up being very problematic, this is introduced opt-in via `SET httpfs_connection_caching=true;`. `RESET httpfs_connection_caching;` or `SET httpfs_connection_caching = false;` will restore the default state.

----

Implementation side, there is a global cache that act as a parcking lot of sort, on Curl HTTP client creation, if one is available on the same `base_url`, it moves to being used, freeing a spot. When a Curl HTTP client is not needed anymore (say for example destructor of FileHandle), those are returned to the cache/parking lot.

Logic to fill the parking spots is somewhat random:
* if any free spot, use that
* else, evict a random other client (that is bound to be older)

Note that in the cache/parking lot there can be multiple clients on the same `base_url`, since if those are used in parallel there might be multiple one that are useful.

Also, we add logging via `CALL enable_logging('HTTPFSInfo');`, a small example would be:
```sql
SET httpfs_connection_caching=true;
--- enable connection caching

CALL enable_logging('HTTPFSInfo');
FROM parquet_scan('s3://overturemaps-us-west-2/bridgefiles/2025-03-19.0-beta.0/dataset=Esri Community Maps/theme=buildings/type=building/part-00000-947c2149-23db-4abc-a7ee-3a892aac90ff.c000.snappy.parquet') LIMIT 1;
SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_miss%';
--- this should return some cache_miss

FROM parquet_scan('s3://overturemaps-us-west-2/bridgefiles/2025-03-19.0-beta.0/dataset=Esri Community Maps/theme=buildings/type=building/part-00000-947c2149-23db-4abc-a7ee-3a892aac90ff.c000.snappy.parquet') LIMIT 1;
SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_miss%';
--- this should return the same number of cache_miss, since they all come from the first round
```

Note that this cache only impact performances of requests, so this should be invisible at the SQL level, meaning the same physical request are performed.