### PR TITLE
Add as NOPs `SET httpfs_connection_caching = true|false` and `CALL clear_httpfs_connection_cache()`

### DIFF
--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -17,6 +17,18 @@
 
 namespace duckdb {
 
+static void ClearHTTPFSConnectionCacheFunction(ClientContext &, TableFunctionInput &, DataChunk &) {
+	// NOP — connection caching not yet implemented on this branch
+}
+
+static unique_ptr<FunctionData> ClearHTTPFSConnectionCacheBind(ClientContext &, TableFunctionBindInput &,
+                                                               vector<LogicalType> &return_types,
+                                                               vector<string> &names) {
+	return_types.emplace_back(LogicalType::BOOLEAN);
+	names.emplace_back("success");
+	return nullptr;
+}
+
 static void LoadInternal(ExtensionLoader &loader) {
 	auto &instance = loader.GetDatabaseInstance();
 	auto &fs = instance.GetFileSystem();
@@ -135,6 +147,10 @@ static void LoadInternal(ExtensionLoader &loader) {
 	};
 	config.AddExtensionOption("httpfs_client_implementation", "Select which is the HTTPUtil implementation to be used",
 	                          LogicalType::VARCHAR, "default", callback_httpfs_client_implementation);
+	// NOP — connection caching not yet implemented on this branch
+	config.AddExtensionOption("httpfs_connection_caching", "Enable connection caching for HTTP requests",
+	                          LogicalType::BOOLEAN, Value::BOOLEAN(false));
+
 	config.AddExtensionOption("enable_global_s3_configuration",
 	                          "Automatically fetch AWS credentials from environment variables.", LogicalType::BOOLEAN,
 	                          Value::BOOLEAN(true));
@@ -152,6 +168,10 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	auto provider = make_uniq<AWSEnvironmentCredentialsProvider>(config);
 	provider->SetAll();
+
+	auto clear_httpfs_connection_cache = TableFunction(
+	    "clear_httpfs_connection_cache", {}, ClearHTTPFSConnectionCacheFunction, ClearHTTPFSConnectionCacheBind);
+	loader.RegisterFunction(clear_httpfs_connection_cache);
 
 	CreateS3SecretFunctions::Register(loader);
 	CreateBearerTokenFunctions::Register(loader);

--- a/test/sql/copy/s3/glob_s3_paging.test_slow
+++ b/test/sql/copy/s3/glob_s3_paging.test_slow
@@ -116,8 +116,8 @@ endloop
 query IIIII
 FROM (FROM duckdb_logs_parsed('HTTP') SELECT count(*), sum(request.type == 'HEAD') head, sum(request.type == 'GET') get, sum(request.type == 'POST') post, sum(request.type == 'PUT') put GROUP BY context_id ORDER BY context_id) WHERE post == 0;
 ----
+3	0	3	0	0
 11	0	11	0	0
-11	0	11	0	0
-11	0	11	0	0
-11	0	11	0	0
+9	0	9	0	0
+9	0	9	0	0
 


### PR DESCRIPTION
This only register a new setting and a new table function.

No actual changes to request being set out, both are no-op placeholders.