### PR TITLE
fix: avoid ODR-use of static constexpr LEVEL in HTTPFSInfoLogType

### DIFF
--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -11,7 +11,7 @@ public:
 	static constexpr const char *NAME = "HTTPFSInfo";
 	static constexpr LogLevel LEVEL = LogLevel::LOG_INFO;
 
-	HTTPFSInfoLogType() : LogType(NAME, LEVEL) {
+	HTTPFSInfoLogType() : LogType(NAME, LogLevel::LOG_INFO) {
 	}
 
 	static string ConstructLogMessage(const string &type, const string &host, const string &payload = "") {


### PR DESCRIPTION
The constructor passed LEVEL by const-reference to LogType(), which is an ODR-use requiring an out-of-line definition. In Debug builds (-O0) the constructor is not inlined, so the linker fails with "undefined reference to HTTPFSInfoLogType::LEVEL" when linking plan_serializer.

Use the enum literal directly to avoid the ODR-use.

Related CI: https://github.com/duckdb/pg_duckdb/actions/runs/24387367520/job/71224352195?pr=1025