### PR TITLE
fix: use stoull instead of stoi/stoll for Content-Length parsing

### DIFF
--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -337,13 +337,16 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
 			    }
 
 			    if (response.HasHeader("Content-Length")) {
+				    unsigned long long content_length;
+				    bool parsed = false;
 				    try {
-					    auto content_length = stoull(response.GetHeaderValue("Content-Length"));
-					    if ((idx_t)content_length != buffer_out_len) {
-						    RangeRequestNotSupportedException::Throw();
-					    }
+					    content_length = stoull(response.GetHeaderValue("Content-Length"));
+					    parsed = true;
 				    } catch (const std::exception &) {
 					    // Content-Length header contains a non-numeric value — skip validation.
+				    }
+				    if (parsed && (idx_t)content_length != buffer_out_len) {
+					    RangeRequestNotSupportedException::Throw();
 				    }
 			    }
 		    }

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -337,9 +337,13 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
 			    }
 
 			    if (response.HasHeader("Content-Length")) {
-				    auto content_length = stoll(response.GetHeaderValue("Content-Length"));
-				    if ((idx_t)content_length != buffer_out_len) {
-					    RangeRequestNotSupportedException::Throw();
+				    try {
+					    auto content_length = stoull(response.GetHeaderValue("Content-Length"));
+					    if ((idx_t)content_length != buffer_out_len) {
+						    RangeRequestNotSupportedException::Throw();
+					    }
+				    } catch (const std::exception &) {
+					    // Content-Length header contains a non-numeric value — skip validation.
 				    }
 			    }
 		    }

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -335,9 +335,15 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
 			    }
 
 			    if (response.HasHeader("Content-Length")) {
-				    auto content_length = stoll(response.GetHeaderValue("Content-Length"));
-				    if ((idx_t)content_length != buffer_out_len) {
-					    RangeRequestNotSupportedException::Throw();
+				    try {
+					    auto content_length = stoll(response.GetHeaderValue("Content-Length"));
+					    if ((idx_t)content_length != buffer_out_len) {
+						    RangeRequestNotSupportedException::Throw();
+					    }
+				    } catch (const std::invalid_argument &) {
+					    // Header value not parseable — skip range validation
+				    } catch (const std::out_of_range &) {
+					    // Header value overflows — skip range validation
 				    }
 			    }
 		    }

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -340,10 +340,10 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
 					    if ((idx_t)content_length != buffer_out_len) {
 						    RangeRequestNotSupportedException::Throw();
 					    }
-				    } catch (const std::invalid_argument &) {
-					    // Header value not parseable — skip range validation
-				    } catch (const std::out_of_range &) {
-					    // Header value overflows — skip range validation
+				    } catch (const std::exception &e) {
+					    auto raw = response.GetHeaderValue("Content-Length");
+					    fprintf(stderr, "httpfs: unparseable Content-Length header: '%s' (%s), skipping range validation\n",
+					            raw.c_str(), e.what());
 				    }
 			    }
 		    }

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -250,11 +250,14 @@ public:
 		const idx_t bytes_received = request_info->body.size();
 		if (!request_info->header_collection.empty() &&
 		    request_info->header_collection.back().HasHeader("content-length")) {
-			const idx_t content_length_received =
-			    std::stoi(request_info->header_collection.back().GetHeaderValue("content-length"));
-			if (bytes_received != content_length_received) {
-				// Something is off, might happen in case of unreliable network
-				// TODO: consider logging this
+			try {
+				const idx_t content_length_received =
+				    std::stoi(request_info->header_collection.back().GetHeaderValue("content-length"));
+				if (bytes_received != content_length_received) {
+					// Something is off, might happen in case of unreliable network
+				}
+			} catch (...) {
+				// Header value not parseable — ignore, bytes_received is authoritative
 			}
 		}
 

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -256,8 +256,10 @@ public:
 				if (bytes_received != content_length_received) {
 					// Something is off, might happen in case of unreliable network
 				}
-			} catch (...) {
-				// Header value not parseable — ignore, bytes_received is authoritative
+			} catch (const std::exception &e) {
+				auto raw = request_info->header_collection.back().GetHeaderValue("content-length");
+				fprintf(stderr, "httpfs: unparseable content-length header: '%s' (%s), using body size %zu\n",
+				        raw.c_str(), e.what(), (size_t)bytes_received);
 			}
 		}
 

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -248,11 +248,16 @@ public:
 		const idx_t bytes_received = request_info->body.size();
 		if (!request_info->header_collection.empty() &&
 		    request_info->header_collection.back().HasHeader("content-length")) {
-			const idx_t content_length_received =
-			    std::stoi(request_info->header_collection.back().GetHeaderValue("content-length"));
-			if (bytes_received != content_length_received) {
-				// Something is off, might happen in case of unreliable network
-				// TODO: consider logging this
+			try {
+				// Use stoull (not stoi) — Content-Length can exceed INT_MAX for files >2GB.
+				const idx_t content_length_received =
+				    std::stoull(request_info->header_collection.back().GetHeaderValue("content-length"));
+				if (bytes_received != content_length_received) {
+					// Something is off, might happen in case of unreliable network
+					// TODO: consider logging this
+				}
+			} catch (const std::exception &) {
+				// Content-Length header contains a non-numeric value — skip validation.
 			}
 		}
 


### PR DESCRIPTION
std::stoi returns int (max 2,147,483,647). When downloading files larger than 2GB, the Content-Length HTTP header value overflows int and throws std::out_of_range. DuckDB surfaces this as "Invalid Error: stoi", crashing the query.

This affects any read_parquet() call on files >2GB served over HTTP/S3.

Fix: replace std::stoi with std::stoull (unsigned 64-bit) in both call sites that parse Content-Length headers. Also wrap in try-catch for robustness against malformed headers.