### PR TITLE
Curl: Propagate User-Agent from HTTPParams to Headers

### DIFF
--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -218,8 +218,14 @@ public:
 		curl_url_cleanup(curl_base_url);
 		DestroyCurlGlobal();
 	}
+	static void AddUserAgentIfAvailable(HTTPFSParams &http_params, HTTPHeaders &header_map) {
+		if (!http_params.user_agent.empty()) {
+			header_map.Insert("User-Agent", http_params.user_agent);
+		}
+	}
 
 	unique_ptr<HTTPResponse> Get(GetRequestInfo &info) override {
+		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
 		ResetRequestInfo();
 		if (state) {
 			state->get_count++;
@@ -278,6 +284,7 @@ public:
 	}
 
 	unique_ptr<HTTPResponse> Put(PutRequestInfo &info) override {
+		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
 		ResetRequestInfo();
 		if (state) {
 			state->put_count++;
@@ -327,6 +334,7 @@ public:
 	}
 
 	unique_ptr<HTTPResponse> Head(HeadRequestInfo &info) override {
+		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
 		ResetRequestInfo();
 		if (state) {
 			state->head_count++;
@@ -365,6 +373,7 @@ public:
 	}
 
 	unique_ptr<HTTPResponse> Delete(DeleteRequestInfo &info) override {
+		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
 		ResetRequestInfo();
 		if (state) {
 			state->delete_count++;
@@ -401,6 +410,7 @@ public:
 	}
 
 	unique_ptr<HTTPResponse> Post(PostRequestInfo &info) override {
+		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
 		ResetRequestInfo();
 		if (state) {
 			state->post_count++;


### PR DESCRIPTION
API is not super trivial, this might require changes in duckdb as well (for next minor), but for now whack the mole httpfs side, basically avoiding throwing information away.