### PR TITLE
Remove clear_httpfs_connection_cache functionality

### DIFF
--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -186,7 +186,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	auto clear_httpfs_connection_cache = TableFunction(
 	    "clear_httpfs_connection_cache", {}, ClearHTTPFSConnectionCacheFunction, ClearHTTPFSConnectionCacheBind);
-	loader.RegisterFunction(clear_httpfs_connection_cache);
+	// No registration (for now), due to issues with loading httpfs with partially intialized duckdb
+	// loader.RegisterFunction(clear_httpfs_connection_cache);
 
 	CreateS3SecretFunctions::Register(loader);
 	CreateBearerTokenFunctions::Register(loader);

--- a/test/sql/connection_caching.test
+++ b/test/sql/connection_caching.test
@@ -45,6 +45,9 @@ SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_hit%';
 ----
 2
 
+# Clear of caching disabled temporarily
+mode skip
+
 # Clear the cache
 statement ok
 CALL clear_httpfs_connection_cache();

--- a/test/sql/s3/connection_caching_s3.test
+++ b/test/sql/s3/connection_caching_s3.test
@@ -54,6 +54,9 @@ SELECT (SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_h
 ----
 true
 
+# Clear of cache currently disabled
+mode skip
+
 # Clear cache and verify miss on next request
 statement ok
 CALL clear_httpfs_connection_cache();


### PR DESCRIPTION
This is a very quirky issue, connected to failure to execute `duckdb https://some.org/dataset.db` in v1.5.2.

It turns out that registering a table function throws due to `main` schema missing. I think we might be doing the load too early, but need to fix that before this can be reintroduced.