### PR TITLE
Fix format string bug in S3FileSystem::RemoveFile causing SIGABRT

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -802,16 +802,15 @@ bool S3FileSystem::CanHandleFile(const string &fpath) {
 void S3FileSystem::RemoveFile(const string &path, optional_ptr<FileOpener> opener) {
 	auto handle = OpenFile(path, FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS, opener);
 	if (!handle) {
-		throw IOException({{"errno", "404"}}, "Could not remove file \"%s\": %s", path, string("No such file or directory"));```
-
-Maybe like this? Forcing cast to string, where deduction just works (and same also below).
+		throw IOException({{"errno", "404"}}, "Could not remove file \"%s\": %s", path,
+		                  string("No such file or directory"));
 	}
 
 	auto &s3fh = handle->Cast<S3FileHandle>();
 	auto res = DeleteRequest(*handle, s3fh.path, {});
 	if (res->status != HTTPStatusCode::OK_200 && res->status != HTTPStatusCode::NoContent_204) {
-		throw IOException({{"errno", to_string(static_cast<int>(res->status))}},
-		                  "Could not remove file \"" + path + "\": " + res->GetError());
+		throw IOException({{"errno", to_string(static_cast<int>(res->status))}}, "Could not remove file \"%s\": %s",
+		                  path, res->GetError());
 	}
 }
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -802,14 +802,14 @@ bool S3FileSystem::CanHandleFile(const string &fpath) {
 void S3FileSystem::RemoveFile(const string &path, optional_ptr<FileOpener> opener) {
 	auto handle = OpenFile(path, FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS, opener);
 	if (!handle) {
-		throw IOException({{"errno", "404"}}, "Could not remove file \"%s\": %s", path, "No such file or directory");
+		throw IOException({{"errno", "404"}}, "Could not remove file \"" + path + "\": No such file or directory");
 	}
 
 	auto &s3fh = handle->Cast<S3FileHandle>();
 	auto res = DeleteRequest(*handle, s3fh.path, {});
 	if (res->status != HTTPStatusCode::OK_200 && res->status != HTTPStatusCode::NoContent_204) {
-		throw IOException({{"errno", to_string(static_cast<int>(res->status))}}, "Could not remove file \"%s\": %s",
-		                  path, res->GetError());
+		throw IOException({{"errno", to_string(static_cast<int>(res->status))}},
+		                  "Could not remove file \"" + path + "\": " + res->GetError());
 	}
 }
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -802,7 +802,9 @@ bool S3FileSystem::CanHandleFile(const string &fpath) {
 void S3FileSystem::RemoveFile(const string &path, optional_ptr<FileOpener> opener) {
 	auto handle = OpenFile(path, FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS, opener);
 	if (!handle) {
-		throw IOException({{"errno", "404"}}, "Could not remove file \"" + path + "\": No such file or directory");
+		throw IOException({{"errno", "404"}}, "Could not remove file \"%s\": %s", path, string("No such file or directory"));```
+
+Maybe like this? Forcing cast to string, where deduction just works (and same also below).
 	}
 
 	auto &s3fh = handle->Cast<S3FileHandle>();


### PR DESCRIPTION
Fix format string bug in S3FileSystem::RemoveFile causing SIGABRT when we should just generate a regular IOException. 

The string literal "No such file or directory" (char[26]) passed as a format argument to IOException does not match any CreateFormatValue specialization, falling through to the default template which casts the pointer to int64_t. This creates an INTEGER format value that causes vsprintf to throw "Invalid type specifier 's' for formatting a value of type int", resulting in an InternalException and SIGABRT (DuckDB calls abort() on InternalException when DUCKDB_CRASH_ON_ASSERT is defined, which is the default for release builds).

Replace format string arguments with string concatenation in both error paths of RemoveFile to avoid format string processing entirely.