### PR TITLE
fix: Fix ASAN issue

### DIFF
--- a/src/hffs.cpp
+++ b/src/hffs.cpp
@@ -62,8 +62,9 @@ string HuggingFaceFileSystem::ListHFRequest(ParsedHFUrl &url, HTTPFSParams &http
 	if (!StringUtil::StartsWith(fragment_next_page_url, "/")) {
 		fragment_next_page_url = "/" + fragment_next_page_url;
 	}
+	const string full_url = url.endpoint + fragment_next_page_url;
 	GetRequestInfo get_request(
-	    url.endpoint + fragment_next_page_url, header_map, http_params,
+	    full_url, header_map, http_params,
 	    [&](const HTTPResponse &response) {
 		    if (static_cast<int>(response.status) >= 400) {
 			    throw HTTPException(response, "HTTP GET error on '%s' (HTTP %d)", next_page_url, response.status);


### PR DESCRIPTION
Fix UB caused by passing a temporary `std::string` (url.endpoint + fragment_next_page_url) directly into GetRequestInfo.

I'd strongly encourage to store a plain `std::string` instead of `const std::string&` in `BaseRequestInfo` to avoid such issues in future. If you'd like to go this way I can contribute, but that'd be a bigger change and out of scope of this PR.