### PR TITLE
Implement Cleanup() hook for curl, and use it while caching connections

### DIFF
--- a/src/httpfs_connection_caching.cpp
+++ b/src/httpfs_connection_caching.cpp
@@ -72,10 +72,12 @@ void HTTPFSCurlUtil::ClearCachedConnections() {
 }
 
 void HTTPFSCurlUtil::CloseClient(unique_ptr<HTTPClient> &&client) {
-	if (connection_caching_enabled) {
-		// TODO: would be nice to log connection_cache_store here, but no logger is available at this call site
-		connection_cache.Store(std::move(client));
+	if (!client || !connection_caching_enabled) {
+		return;
 	}
+	client->Cleanup();
+	// TODO: would be nice to log connection_cache_store here, but no logger is available at this call site
+	connection_cache.Store(std::move(client));
 }
 
 unique_ptr<HTTPResponse> HTTPFSCurlUtil::BaseSendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client) {

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -467,6 +467,11 @@ public:
 		return TransformResponseCurl(res);
 	}
 
+	void Cleanup() override {
+		// Release any buffers retained from the last request before this client is parked in the connection cache.
+		request_info = make_uniq<RequestInfo>();
+	}
+
 private:
 	CURLRequestHeaders TransformHeadersCurl(const HTTPHeaders &header_map, const HTTPParams &params) {
 		auto &httpfs_params = params.Cast<HTTPFSParams>();


### PR DESCRIPTION
This avoids the penality of keeping around the body for each parked connection, potentially significant memory usage