### PR TITLE
Multiple parking lots

### DIFF
--- a/src/httpfs_connection_caching.cpp
+++ b/src/httpfs_connection_caching.cpp
@@ -1,8 +1,11 @@
 #include "httpfs_client.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/random_engine.hpp"
+#include "duckdb/common/thread.hpp"
 #include "duckdb/logging/log_type.hpp"
 #include "duckdb/logging/logger.hpp"
+
+#include <functional>
 
 namespace duckdb {
 
@@ -10,13 +13,27 @@ namespace duckdb {
 // HTTPClientConnectionCache
 //===--------------------------------------------------------------------===//
 
+// Per-thread starting pool index. Initialised from a hash of the thread id so
+// threads spread across pools, then updated to the last successfully-touched
+// pool so subsequent calls revisit the warm pool first.
+static thread_local size_t cache_pool_idx =
+    std::hash<thread_id> {}(ThreadUtil::GetThreadId()) & (HTTPClientConnectionCache::POOL_COUNT - 1);
+
 unique_ptr<HTTPClient> HTTPClientConnectionCache::Find(const string &base_url) {
 	if (base_url.empty()) {
 		return nullptr;
 	}
-	if (auto lock = unique_lock<mutex>(cache_lock, std::try_to_lock)) {
-		for (auto &entry : entries) {
+	const size_t start = cache_pool_idx;
+	for (size_t i = 0; i < POOL_COUNT; i++) {
+		const size_t idx = (start + i) & (POOL_COUNT - 1);
+		auto &pool = pools[idx];
+		unique_lock<mutex> lock(pool.lock, std::try_to_lock);
+		if (!lock) {
+			continue;
+		}
+		for (auto &entry : pool.entries) {
 			if (entry && entry->GetBaseUrl() == base_url) {
+				cache_pool_idx = idx;
 				return std::move(entry);
 			}
 		}
@@ -28,29 +45,47 @@ void HTTPClientConnectionCache::Store(unique_ptr<HTTPClient> &&client) {
 	if (!client || client->GetBaseUrl().empty()) {
 		return;
 	}
-	if (auto lock = unique_lock<mutex>(cache_lock, std::try_to_lock)) {
-		if (entries.empty()) {
-			entries.resize(64);
+	const size_t start = cache_pool_idx;
+	// Pass 1: prefer an empty slot in any reachable pool
+	for (size_t i = 0; i < POOL_COUNT; i++) {
+		const size_t idx = (start + i) & (POOL_COUNT - 1);
+		auto &pool = pools[idx];
+		unique_lock<mutex> lock(pool.lock, std::try_to_lock);
+		if (!lock) {
+			continue;
 		}
-		// First prefer an empty slot
-		for (auto &entry : entries) {
+		for (auto &entry : pool.entries) {
 			if (!entry) {
 				entry = std::move(client);
+				cache_pool_idx = idx;
 				return;
 			}
 		}
-		// Else evict one at random
-		{
-			RandomEngine engine;
-			size_t index = engine.NextRandomInteger() % entries.size();
-			entries[index] = std::move(client);
-		}
 	}
+	// Pass 2: every reachable pool is full — evict at random in the first lockable pool
+	RandomEngine engine;
+	for (size_t i = 0; i < POOL_COUNT; i++) {
+		const size_t idx = (start + i) & (POOL_COUNT - 1);
+		auto &pool = pools[idx];
+		unique_lock<mutex> lock(pool.lock, std::try_to_lock);
+		if (!lock) {
+			continue;
+		}
+		const size_t slot = engine.NextRandomInteger() % pool.entries.size();
+		pool.entries[slot] = std::move(client);
+		cache_pool_idx = idx;
+		return;
+	}
+	// Every pool busy — drop the client; will reconnect next time.
 }
 
 void HTTPClientConnectionCache::Clear() {
-	lock_guard<mutex> lck(cache_lock);
-	entries.clear();
+	for (auto &pool : pools) {
+		lock_guard<mutex> lock(pool.lock);
+		for (auto &entry : pool.entries) {
+			entry.reset();
+		}
+	}
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/httpfs_connection_caching.cpp
+++ b/src/httpfs_connection_caching.cpp
@@ -72,10 +72,12 @@ void HTTPFSCurlUtil::ClearCachedConnections() {
 }
 
 void HTTPFSCurlUtil::CloseClient(unique_ptr<HTTPClient> &&client) {
-	if (connection_caching_enabled) {
-		// TODO: would be nice to log connection_cache_store here, but no logger is available at this call site
-		connection_cache.Store(std::move(client));
+	if (!client || !connection_caching_enabled) {
+		return;
 	}
+	client->Cleanup();
+	// TODO: would be nice to log connection_cache_store here, but no logger is available at this call site
+	connection_cache.Store(std::move(client));
 }
 
 unique_ptr<HTTPResponse> HTTPFSCurlUtil::BaseSendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client) {

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -467,6 +467,11 @@ public:
 		return TransformResponseCurl(res);
 	}
 
+	void Cleanup() override {
+		// Release any buffers retained from the last request before this client is parked in the connection cache.
+		request_info = make_uniq<RequestInfo>();
+	}
+
 private:
 	CURLRequestHeaders TransformHeadersCurl(const HTTPHeaders &header_map, const HTTPParams &params) {
 		auto &httpfs_params = params.Cast<HTTPFSParams>();

--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -4,6 +4,8 @@
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/logging/log_type.hpp"
 
+#include <array>
+
 namespace duckdb {
 
 class HTTPFSInfoLogType : public LogType {
@@ -55,13 +57,21 @@ struct HTTPFSParams : public HTTPParams {
 
 class HTTPClientConnectionCache {
 public:
+	static constexpr size_t POOL_COUNT = 16;
+	static constexpr size_t POOL_SIZE = 16;
+	static_assert((POOL_COUNT & (POOL_COUNT - 1)) == 0, "POOL_COUNT must be a power of two");
+
 	unique_ptr<HTTPClient> Find(const string &base_url);
 	void Store(unique_ptr<HTTPClient> &&client);
 	void Clear();
 
 private:
-	mutex cache_lock {};
-	std::vector<unique_ptr<HTTPClient>> entries;
+	struct Pool {
+		mutex lock {};
+		std::vector<unique_ptr<HTTPClient>> entries {std::vector<unique_ptr<HTTPClient>>(POOL_SIZE)};
+	};
+
+	std::array<Pool, POOL_COUNT> pools {};
 };
 
 class HTTPFSUtil : public HTTPUtil {


### PR DESCRIPTION
On top, and dependent on, https://github.com/duckdb/duckdb-httpfs/pull/322

Basic idea: multiple parking lots, each thread has a preferred one. Still try_lock on various operations, so worse case we just drop if all are in use.