### PR TITLE
Add per-request cancellation hook to HTTPFSCurlClient

### DIFF
--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -40,6 +40,33 @@ static std::string SelectCURLCertPath() {
 	return std::string();
 }
 
+// libcurl progress callback. libcurl invokes this periodically during transfers
+// (including connect / TLS handshake / body I/O). Returning a non-zero value
+// causes libcurl to abort the transfer with CURLE_ABORTED_BY_CALLBACK.
+//
+// Invocation cadence is controlled by libcurl (typically every few hundred ms,
+// faster during active I/O), so this is safe for use as an interrupt poll. The
+// userdata is a pointer to a std::function<bool()> owned by the HTTPFSCurlClient
+// for the lifetime of one request.
+static int RequestProgressCallback(void *clientp, curl_off_t /*dltotal*/, curl_off_t /*dlnow*/, curl_off_t /*ultotal*/,
+                                   curl_off_t /*ulnow*/) {
+	if (!clientp) {
+		return 0;
+	}
+	auto *cancel_fn = static_cast<std::function<bool()> *>(clientp);
+	if (!*cancel_fn) {
+		return 0;
+	}
+	try {
+		return (*cancel_fn)() ? 1 : 0;
+	} catch (...) {
+		// A throwing cancel hook is a programming error; libcurl can't propagate
+		// exceptions across the C boundary. Treat as "cancel" so we exit the
+		// transfer cleanly rather than terminating the process.
+		return 1;
+	}
+}
+
 static size_t RequestWriteCallback(void *contents, size_t size, size_t nmemb, void *userp) {
 	size_t totalSize = size * nmemb;
 	std::string *str = static_cast<std::string *>(userp);
@@ -212,6 +239,17 @@ public:
 				curl_easy_setopt(*curl, CURLOPT_PROXYPASSWORD, http_params.http_proxy_password.c_str());
 			}
 		}
+
+		// Wire the per-request cancellation hook. The callback is installed
+		// unconditionally (with userdata pointing at our stored std::function);
+		// when the function is empty the callback returns 0 (continue) cheaply.
+		// Storing the hook on the client keeps the userdata pointer stable
+		// across cached-client reuse, where Initialize() runs again with new
+		// params.
+		cancel_fn = http_params.should_cancel;
+		curl_easy_setopt(*curl, CURLOPT_NOPROGRESS, 0L);
+		curl_easy_setopt(*curl, CURLOPT_XFERINFOFUNCTION, RequestProgressCallback);
+		curl_easy_setopt(*curl, CURLOPT_XFERINFODATA, &cancel_fn);
 	}
 
 	~HTTPFSCurlClient() {
@@ -507,6 +545,17 @@ private:
 		auto response = make_uniq<HTTPResponse>(status_code);
 		if (res != CURLcode::CURLE_OK) {
 			response->request_error = curl_easy_strerror(res);
+			if (res == CURLcode::CURLE_ABORTED_BY_CALLBACK) {
+				// Surface cancellation as HTTP 499 (nginx's "Client Closed
+				// Request"). Cast through the integer value because the
+				// HTTPStatusCode enum in duckdb-core does not yet have a
+				// dedicated identifier; a follow-up duckdb-core PR can add
+				// `Cancelled_499 = 499`. Callers can detect cancellation via
+				// either `response->status == static_cast<HTTPStatusCode>(499)`
+				// or `response->request_error` containing "callback".
+				response->status = static_cast<HTTPStatusCode>(499);
+				response->request_error = "Request cancelled by callback";
+			}
 			return response;
 		}
 		response->body = request_info->body;
@@ -532,6 +581,11 @@ private:
 	CURLU *curl_base_url = nullptr;
 	string stored_bearer_token;
 	string stored_cert_file_path;
+	// Cancellation hook copied from HTTPFSParams::should_cancel on each
+	// Initialize(). Address-of is passed to libcurl as XFERINFODATA; the curl
+	// progress callback dereferences it to decide whether to abort. Stored on
+	// the client so the userdata pointer is stable across cached-client reuse.
+	std::function<bool()> cancel_fn;
 
 	static mutex &GetRefLock() {
 		static mutex mtx;

--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -53,6 +53,14 @@ struct HTTPFSParams : public HTTPParams {
 
 	// Additional fields needs to be appended at the end and need to be propagated to duckdb-wasm
 	// TODO: make this unnecessary
+
+	//! Optional cancellation hook. When set and returns true during an in-flight
+	//! transfer, libcurl aborts with CURLE_ABORTED_BY_CALLBACK and the resulting
+	//! HTTPResponse is marked with status 499 ("client closed request") and a
+	//! "Request cancelled" request_error. The closure must remain valid for the
+	//! duration of any request issued with this HTTPFSParams; copy it into the
+	//! params struct rather than storing a reference to short-lived state.
+	std::function<bool()> should_cancel;
 };
 
 class HTTPClientConnectionCache {


### PR DESCRIPTION
## Summary

Adds an optional `should_cancel` `std::function<bool()>` field to `HTTPFSParams`. When set, it is wired into libcurl as a `CURLOPT_XFERINFOFUNCTION` progress callback that returns non-zero to abort the in-flight transfer with `CURLE_ABORTED_BY_CALLBACK`.

## Motivation

Extensions doing slow HTTP work from inside a query (remote-function execution, long S3 fetches, etc.) currently have no way to honor a user Ctrl-C while a request is in flight. libcurl is run with `CURLOPT_NOSIGNAL=1` (correctly, for thread-safety in DuckDB's multi-threaded executor), so SIGINT does not unblock the underlying `poll()`/`recv()` syscall. There is no in-band cancel primitive between the extension and libcurl, so a stuck endpoint hangs the query until `CURLOPT_TIMEOUT` fires (or forever, if no timeout is set).

I hit this concretely while debugging a hung VGI extension query: the main thread was blocked in `curl_easy_perform → multi_wait → poll`, completely unresponsive to Ctrl-C. There's no clean fix possible at the extension layer alone — extensions can't add curl options to clients owned by httpfs. The interrupt primitive has to live in httpfs.

This patch is modeled on libcurl's own blessed pattern for cooperative cancellation (`XFERINFOFUNCTION` returning non-zero), which is the standard way to abort an in-flight transfer from another context without removing `CURLOPT_NOSIGNAL`.

## Behavior

- **Default (no hook):** zero behavior change. Empty `std::function` makes the callback return `0` cheaply on every progress tick.
- **Hook returning `true`:** libcurl aborts the transfer; the resulting `HTTPResponse` has `status` set to `499` (\"Client Closed Request\", matching nginx's convention) and `request_error = \"Request cancelled by callback\"`.
- **Throwing hook:** treated as cancel (libcurl callbacks cannot propagate C++ exceptions across the C boundary; throwing would crash the process).

## Caller pattern

```cpp
auto params = http_util.InitializeParameters(context, url);
auto &httpfs_params = params->Cast<HTTPFSParams>();
httpfs_params.should_cancel = [&context]() {
    return context.interrupted.load();
};

PostRequestInfo post(url, headers, *params, body.data(), body.size());
auto response = http_util.Request(post);
if (response->status == static_cast<HTTPStatusCode>(499)) {
    throw InterruptException(\"Request cancelled\");
}
```

## Implementation notes

- The hook is stored as a member on `HTTPFSCurlClient` so its address remains stable across cached-client reuse (`Initialize()` is called again with new params on each request, but `&cancel_fn` doesn't move).
- The progress callback is installed unconditionally on every `Initialize()`, even when the hook is empty — the empty-`std::function` check inside the callback is a single branch and cheaper than conditionally `setopt`-ing per request.
- Field is appended to the end of `HTTPFSParams` to preserve the existing layout expected by duckdb-wasm.
- WASM client (`httpfs_client_wasm.cpp`) is unchanged; cancellation there is a separate concern (emscripten_fetch / sync XHR have different abort primitives).

## Latency to cancel

Bounded by libcurl's progress-callback cadence — typically every few hundred ms during active I/O, less often during long DNS resolves or TLS handshakes. In practice, well under one second for the common cases. Setting a reasonable `CURLOPT_CONNECTTIMEOUT` complements this for the connect-phase edge case.

## Follow-up

A small duckdb-core PR could add `Cancelled_499 = 499` to the `HTTPStatusCode` enum so callers don't need to cast through the integer value:

```cpp
// duckdb/common/enums/http_status_code.hpp
Cancelled_499 = 499,  // Client Closed Request (nginx convention)
```

Once that lands, the cast in `TransformResponseCurl` can be replaced with the named constant.

## Test plan

- [ ] CI build passes on all platforms
- [ ] Existing httpfs tests pass (no behavior change for callers that don't set the hook)
- [ ] Manual: extension with cancel hook returning `true` after 100ms aborts an in-flight POST and surfaces status 499

🤖 Generated with [Claude Code](https://claude.com/claude-code)