### PR TITLE
Remove duplicate crypto.cpp from base HTTPFS_SOURCES

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,6 @@ set(HTTPFS_SOURCES
     s3fs.cpp
     httpfs.cpp
     http_state.cpp
-    crypto.cpp
     hash_functions.cpp
     create_secret_functions.cpp
     httpfs_extension.cpp


### PR DESCRIPTION
## Summary
- `src/crypto.cpp` was listed twice in `src/CMakeLists.txt`: once in the unconditional `HTTPFS_SOURCES` list and again under the `if(NOT EMSCRIPTEN)` branch.
- `crypto.cpp` includes OpenSSL headers (`openssl/{err,evp,ssl,x509v3,rand}.h`) directly and has no Emscripten preprocessor guards, so it can only be compiled when OpenSSL is available — i.e. not under wasm.
- This drops the duplicate entry from the base list and keeps the one already correctly guarded by `if(NOT EMSCRIPTEN)`, matching the intent of the surrounding code (which links `duckdb_mbedtls` instead of OpenSSL for Emscripten builds).

## Test plan
- [ ] Native build still compiles and links (crypto.cpp picked up via the `NOT EMSCRIPTEN` branch).
- [ ] Wasm/Emscripten build no longer attempts to compile `crypto.cpp`.