### PR TITLE
Removed local tests in test_csv_remote.test

### DIFF
--- a/test/sql/copy/csv/test_csv_remote.test
+++ b/test/sql/copy/csv/test_csv_remote.test
@@ -19,16 +19,6 @@ FROM sniff_csv('https://github.com/duckdb/duckdb/raw/main/data/csv/customer.csv?
 
 require-env LOCAL_EXTENSION_REPO
 
-# regular csv file
-query ITTTIITITTIIII nosort webpagecsv
-SELECT * FROM read_csv_auto('duckdb/data/csv/real/web_page.csv') ORDER BY 1;
-----
-
-# file with gzip
-query IIIIIIIIIIIIIII nosort lineitemcsv
-SELECT * FROM read_csv_auto('duckdb/data/csv/lineitem1k.tbl.gz') ORDER BY ALL;
-----
-
 query ITTTIITITTIIII nosort webpagecsv
 SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/duckdb/duckdb/main/data/csv/real/web_page.csv') ORDER BY 1;
 ----


### PR DESCRIPTION
Previous path change did not fix the issue, as duckdb submodule is not available on the same path when running CI in the duckdb repository.

Removed the tests now, similar to: https://github.com/duckdb/duckdb-httpfs/pull/215