### PR TITLE
Add credentials refresh in more locations

### DIFF
--- a/scripts/test_refresh_get_range.sh
+++ b/scripts/test_refresh_get_range.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Regression test for PR #165 -- ExecuteWithRefresh on S3FileSystem::GetRangeRequest.
+#
+# The existing refresh hook lives in S3FileHandle::Initialize and only fires
+# on HEAD failures. Callers that skip HEAD (DuckLake, Iceberg, anything using
+# prefilled OpenFileInfo.extended_info) silently opt out of auto-refresh.
+# We trigger the same HEAD-skip via enable_http_metadata_cache, then revoke
+# the service-account token mid-session so phase B's first range GET hits a
+# real minio 403. REFRESH_INFO swaps the secret to a second token on refresh.
+#
+# Usage:
+#   source ./scripts/run_s3_test_server.sh
+#   source scripts/set_s3_test_server_variables.sh
+#   make release
+#   ./scripts/test_refresh_get_range.sh
+#
+# Service accounts are minio's revocable per-key tokens, distinct from
+# disabling the parent user. Mirrors STS revocation semantically -- parent
+# stays enabled, only the cached token is invalidated.
+
+set -euo pipefail
+
+DUCKDB=${DUCKDB:-./build/release/duckdb}
+KEY_A=svcacct_phase_a
+SEC_A=svcacct_phase_a_secret
+KEY_B=svcacct_phase_b
+SEC_B=svcacct_phase_b_secret
+URL=s3://test-bucket/refresh-range-test.parquet
+
+MC_RUN="docker exec duckdb-minio-minio-1 /usr/bin/mc"
+mc() { $MC_RUN "$@"; }
+
+cleanup() {
+    mc admin user svcacct rm local "$KEY_A" >/dev/null 2>&1 || true
+    mc admin user svcacct rm local "$KEY_B" >/dev/null 2>&1 || true
+    mc rm local/test-bucket/refresh-range-test.parquet >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+mc alias set local http://localhost:9000 duckdb_minio_admin duckdb_minio_admin_password >/dev/null
+mc admin info local >/dev/null
+
+mc admin user svcacct rm local "$KEY_A" >/dev/null 2>&1 || true
+mc admin user svcacct rm local "$KEY_B" >/dev/null 2>&1 || true
+mc admin user svcacct add local minio_duckdb_user --access-key "$KEY_A" --secret-key "$SEC_A" >/dev/null
+mc admin user svcacct add local minio_duckdb_user --access-key "$KEY_B" --secret-key "$SEC_B" >/dev/null
+
+"$DUCKDB" -bail -list -noheader <<SQL
+.output stdout
+LOAD httpfs;
+SET enable_http_metadata_cache=true; -- to provoke skipping the HEAD request
+SET enable_external_file_cache=false;
+SET s3_endpoint='localhost:9000'; SET s3_url_style='path';
+SET s3_use_ssl=false;        SET s3_region='eu-west-1';
+
+CREATE SECRET seed (TYPE S3,
+    KEY_ID 'duckdb_minio_admin', SECRET 'duckdb_minio_admin_password');
+COPY (SELECT range FROM range(1000)) TO '$URL' (FORMAT PARQUET);
+DROP SECRET seed;
+
+CREATE SECRET refresh_test (TYPE S3,
+    KEY_ID '$KEY_A', SECRET '$SEC_A',
+    REFRESH_INFO MAP {'KEY_ID': '$KEY_B', 'SECRET': '$SEC_B'});
+
+-- Phase A: populates http_metadata_cache. Assert read returns 1000.
+CREATE TEMP TABLE _a AS SELECT count(*)::BIGINT AS rcount FROM read_parquet('$URL');
+SELECT CASE WHEN (SELECT rcount FROM _a) = 1000 THEN NULL
+       ELSE error('phase A read != 1000, got ' || (SELECT rcount FROM _a)::VARCHAR) END;
+
+.shell $MC_RUN admin user svcacct rm local $KEY_A
+
+-- Phase B: cache hit -> no HEAD; first range GET hits 403 from revoked
+-- token. PR #165 wrapper catches, refreshes via REFRESH_INFO, retries.
+-- Force the read into its own statement so the refresh side effects land
+-- before the duckdb_logs / duckdb_secrets checks below.
+CREATE TEMP TABLE _b AS SELECT count(*)::BIGINT AS rcount FROM read_parquet('$URL');
+
+.output stdout
+SELECT CASE
+    WHEN (SELECT rcount FROM _b) != 1000
+        THEN error('phase B read != 1000, got ' || (SELECT rcount FROM _b)::VARCHAR)
+    WHEN (SELECT regexp_extract(secret_string, 'key_id=(\w+)', 1)
+          FROM duckdb_secrets() WHERE name='refresh_test') != '$KEY_B'
+        THEN error('key_id did not advance')
+    ELSE 'PASS: range-GET refresh recovered; key_id $KEY_A -> $KEY_B'
+END;
+SQL

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -61,9 +61,16 @@ struct S3AuthParams {
 	bool requester_pays = false;
 	string oauth2_bearer_token; // OAuth2 bearer token for GCS
 
+	// Store FileOpener and path for credential refresh
+	optional_ptr<FileOpener> opener;
+	string path;
+
 	static S3AuthParams ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info);
 	static S3AuthParams ReadFrom(S3KeyValueReader &secret_reader, const std::string &file_path);
 	void SetRegion(string region_p);
+	//! Try to refresh credentials if they've expired
+	//! Returns true if refresh succeeded and credentials were updated
+	bool TryRefreshCredentials();
 
 private:
 	void InitializeEndpoint();
@@ -207,6 +214,9 @@ public:
 	static HTTPException GetS3Error(const S3AuthParams &s3_auth_params, const HTTPResponse &response,
 	                                const string &url);
 	HTTPException GetHTTPError(FileHandle &, const HTTPResponse &response, const string &url) override;
+
+	//! Helper method to attempt secret refresh for a given path
+	static bool TryRefreshSecret(const string &path, optional_ptr<FileOpener> opener);
 
 protected:
 	bool ListFilesExtended(const string &directory, const std::function<void(OpenFileInfo &info)> &callback,

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -183,7 +183,10 @@ S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerI
 	const char *secret_types[] = {"s3", "r2", "gcs", "aws"};
 	S3KeyValueReader secret_reader(*opener, info, secret_types, 4);
 
-	return ReadFrom(secret_reader, info.file_path);
+	auto result = ReadFrom(secret_reader, info.file_path);
+	result.opener = opener;
+	result.path = info.file_path;
+	return result;
 }
 
 bool EndpointIsAWS(const string &endpoint) {
@@ -250,6 +253,31 @@ S3AuthParams S3AuthParams::ReadFrom(S3KeyValueReader &secret_reader, const strin
 void S3AuthParams::SetRegion(string new_region) {
 	region = std::move(new_region);
 	InitializeEndpoint();
+}
+
+bool S3AuthParams::TryRefreshCredentials() {
+	if (!opener) {
+		return false;
+	}
+
+	// Try to refresh the secret using S3FileSystem helper
+	if (S3FileSystem::TryRefreshSecret(path, opener)) {
+		// Refresh succeeded, reload credentials
+		FileOpenerInfo info = {path};
+		auto refreshed_params = S3AuthParams::ReadFrom(opener, info);
+
+		// Update this object's credentials
+		this->access_key_id = refreshed_params.access_key_id;
+		this->secret_access_key = refreshed_params.secret_access_key;
+		this->session_token = refreshed_params.session_token;
+		this->region = refreshed_params.region;
+		this->endpoint = refreshed_params.endpoint;
+		this->oauth2_bearer_token = refreshed_params.oauth2_bearer_token;
+
+		return true;
+	}
+
+	return false;
 }
 
 unique_ptr<KeyValueSecret> CreateSecret(vector<string> &prefix_paths_p, string &type, string &provider, string &name,
@@ -534,141 +562,161 @@ string ParsedS3Url::GetHTTPUrl(S3AuthParams &auth_params, const string &http_que
 	return full_url;
 }
 
+template <typename RequestFunc>
+auto ExecuteWithRefresh(S3AuthParams &auth_params, RequestFunc request_func) -> decltype(request_func(auth_params)) {
+	try {
+		return request_func(auth_params);
+	} catch (std::exception &ex) {
+		ErrorData error(ex);
+		if (error.Type() == ExceptionType::IO || error.Type() == ExceptionType::HTTP) {
+			if (auth_params.TryRefreshCredentials()) {
+				return request_func(auth_params);
+			}
+		}
+		throw;
+	}
+}
+
 unique_ptr<HTTPResponse> S3FileSystem::PostRequest(HTTPInput &input, string url, HTTPHeaders header_map, string &result,
                                                    char *buffer_in, idx_t buffer_in_len, string http_params) {
 	auto &s3_input = input.Cast<S3HTTPInput>();
-	auto auth_params = s3_input.auth_params;
-	auto parsed_s3_url = S3UrlParse(url, auth_params);
-	string http_url = parsed_s3_url.GetHTTPUrl(auth_params, http_params);
+	return ExecuteWithRefresh(s3_input.auth_params, [&](S3AuthParams &auth_params) {
+		auto parsed_s3_url = S3UrlParse(url, auth_params);
+		string http_url = parsed_s3_url.GetHTTPUrl(auth_params, http_params);
 
-	HTTPHeaders headers;
-	if (IsGCSRequest(url) && !auth_params.oauth2_bearer_token.empty()) {
-		// Use bearer token for GCS
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_s3_url.host;
-		headers["Content-Type"] = "application/octet-stream";
-	} else {
-		// Use existing S3 authentication
-		auto payload_hash = GetPayloadHash(buffer_in, buffer_in_len);
-		headers = CreateS3Header(parsed_s3_url.path, http_params, parsed_s3_url.host, "s3", "POST", auth_params, "", "",
-		                         payload_hash, "application/octet-stream");
-	}
+		HTTPHeaders headers;
+		if (IsGCSRequest(url) && !auth_params.oauth2_bearer_token.empty()) {
+			// Use bearer token for GCS
+			headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
+			headers["Host"] = parsed_s3_url.host;
+			headers["Content-Type"] = "application/octet-stream";
+		} else {
+			// Use existing S3 authentication
+			auto payload_hash = GetPayloadHash(buffer_in, buffer_in_len);
+			headers = CreateS3Header(parsed_s3_url.path, http_params, parsed_s3_url.host, "s3", "POST", auth_params, "",
+			                         "", payload_hash, "application/octet-stream");
+		}
 
-	return HTTPFileSystem::PostRequest(input, http_url, headers, result, buffer_in, buffer_in_len);
+		return HTTPFileSystem::PostRequest(input, http_url, headers, result, buffer_in, buffer_in_len);
+	});
 }
 
 unique_ptr<HTTPResponse> S3FileSystem::PutRequest(HTTPInput &input, string url, HTTPHeaders header_map, char *buffer_in,
                                                   idx_t buffer_in_len, string http_params) {
 	auto &s3_input = input.Cast<S3HTTPInput>();
-	auto auth_params = s3_input.auth_params;
-	auto parsed_s3_url = S3UrlParse(url, auth_params);
-	string http_url = parsed_s3_url.GetHTTPUrl(auth_params, http_params);
-	auto content_type = "application/octet-stream";
+	return ExecuteWithRefresh(s3_input.auth_params, [&](S3AuthParams &auth_params) {
+		auto parsed_s3_url = S3UrlParse(url, auth_params);
+		string http_url = parsed_s3_url.GetHTTPUrl(auth_params, http_params);
+		auto content_type = "application/octet-stream";
 
-	HTTPHeaders headers;
-	if (IsGCSRequest(url) && !auth_params.oauth2_bearer_token.empty()) {
-		// Use bearer token for GCS
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_s3_url.host;
-		headers["Content-Type"] = content_type;
-	} else {
-		// Use existing S3 authentication
-		auto payload_hash = GetPayloadHash(buffer_in, buffer_in_len);
-		headers = CreateS3Header(parsed_s3_url.path, http_params, parsed_s3_url.host, "s3", "PUT", auth_params, "", "",
-		                         payload_hash, content_type);
-	}
+		HTTPHeaders headers;
+		if (IsGCSRequest(url) && !auth_params.oauth2_bearer_token.empty()) {
+			// Use bearer token for GCS
+			headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
+			headers["Host"] = parsed_s3_url.host;
+			headers["Content-Type"] = content_type;
+		} else {
+			// Use existing S3 authentication
+			auto payload_hash = GetPayloadHash(buffer_in, buffer_in_len);
+			headers = CreateS3Header(parsed_s3_url.path, http_params, parsed_s3_url.host, "s3", "PUT", auth_params, "",
+			                         "", payload_hash, content_type);
+		}
 
-	return HTTPFileSystem::PutRequest(input, http_url, headers, buffer_in, buffer_in_len);
+		return HTTPFileSystem::PutRequest(input, http_url, headers, buffer_in, buffer_in_len);
+	});
 }
 
 unique_ptr<HTTPResponse> S3FileSystem::HeadRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map) {
-	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
-	auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
-	string http_url = parsed_s3_url.GetHTTPUrl(auth_params);
+	auto &s3_handle = handle.Cast<S3FileHandle>();
+	return ExecuteWithRefresh(s3_handle.auth_params, [&](S3AuthParams &auth_params) {
+		auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
+		string http_url = parsed_s3_url.GetHTTPUrl(auth_params);
 
-	HTTPHeaders headers;
-	if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
-		// Use bearer token for GCS
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_s3_url.host;
-	} else {
-		// Use existing S3 authentication
-		headers = CreateS3Header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "HEAD", auth_params, "", "", "", "");
-	}
+		HTTPHeaders headers;
+		if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
+			// Use bearer token for GCS
+			headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
+			headers["Host"] = parsed_s3_url.host;
+		} else {
+			// Use existing S3 authentication
+			headers =
+			    CreateS3Header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "HEAD", auth_params, "", "", "", "");
+		}
 
-	return HTTPFileSystem::HeadRequest(handle, http_url, headers);
+		return HTTPFileSystem::HeadRequest(handle, http_url, headers);
+	});
 }
 
 unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
-	auto auth_params = s3_handle.auth_params;
-	auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
+	return ExecuteWithRefresh(s3_handle.auth_params, [&](S3AuthParams &auth_params) {
+		auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
+		string query_string;
+		if (!s3_handle.version_id.empty()) {
+			query_string = "versionId=" + UrlEncode(s3_handle.version_id, true);
+		}
+		string http_url = parsed_s3_url.GetHTTPUrl(auth_params, query_string);
 
-	string query_string;
-	if (!s3_handle.version_id.empty()) {
-		query_string = "versionId=" + UrlEncode(s3_handle.version_id, true);
-	}
+		HTTPHeaders headers;
+		if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
+			// Use bearer token for GCS
+			headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
+			headers["Host"] = parsed_s3_url.host;
+		} else {
+			// Use existing S3 authentication
+			headers = CreateS3Header(parsed_s3_url.path, query_string, parsed_s3_url.host, "s3", "GET", auth_params, "",
+			                         "", "", "");
+		}
 
-	string http_url = parsed_s3_url.GetHTTPUrl(auth_params, query_string);
-
-	HTTPHeaders headers;
-	if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
-		// Use bearer token for GCS
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_s3_url.host;
-	} else {
-		// Use existing S3 authentication
-		headers = CreateS3Header(parsed_s3_url.path, query_string, parsed_s3_url.host, "s3", "GET", auth_params, "", "",
-		                         "", "");
-	}
-
-	return HTTPFileSystem::GetRequest(handle, http_url, headers);
+		return HTTPFileSystem::GetRequest(handle, http_url, headers);
+	});
 }
 
 unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
                                                        idx_t file_offset, char *buffer_out, idx_t buffer_out_len) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
-	auto auth_params = s3_handle.auth_params;
-	auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
+	return ExecuteWithRefresh(s3_handle.auth_params, [&](S3AuthParams &auth_params) {
+		auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
+		string query_string;
+		if (!s3_handle.version_id.empty()) {
+			query_string = "versionId=" + UrlEncode(s3_handle.version_id, true);
+		}
+		string http_url = parsed_s3_url.GetHTTPUrl(auth_params, query_string);
 
-	string query_string;
-	if (!s3_handle.version_id.empty()) {
-		query_string = "versionId=" + UrlEncode(s3_handle.version_id, true);
-	}
+		HTTPHeaders headers;
+		if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
+			// Use bearer token for GCS
+			headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
+			headers["Host"] = parsed_s3_url.host;
+		} else {
+			// Use existing S3 authentication
+			headers = CreateS3Header(parsed_s3_url.path, query_string, parsed_s3_url.host, "s3", "GET", auth_params, "",
+			                         "", "", "");
+		}
 
-	string http_url = parsed_s3_url.GetHTTPUrl(auth_params, query_string);
-
-	HTTPHeaders headers;
-	if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
-		// Use bearer token for GCS
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_s3_url.host;
-	} else {
-		// Use existing S3 authentication
-		headers = CreateS3Header(parsed_s3_url.path, query_string, parsed_s3_url.host, "s3", "GET", auth_params, "", "",
-		                         "", "");
-	}
-
-	return HTTPFileSystem::GetRangeRequest(handle, http_url, headers, file_offset, buffer_out, buffer_out_len);
+		return HTTPFileSystem::GetRangeRequest(handle, http_url, headers, file_offset, buffer_out, buffer_out_len);
+	});
 }
 
 unique_ptr<HTTPResponse> S3FileSystem::DeleteRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map) {
-	auto auth_params = handle.Cast<S3FileHandle>().auth_params;
-	auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
-	string http_url = parsed_s3_url.GetHTTPUrl(auth_params);
+	auto &s3_handle = handle.Cast<S3FileHandle>();
+	return ExecuteWithRefresh(s3_handle.auth_params, [&](S3AuthParams &auth_params) {
+		auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
+		string http_url = parsed_s3_url.GetHTTPUrl(auth_params);
 
-	HTTPHeaders headers;
-	if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
-		// Use bearer token for GCS
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_s3_url.host;
-	} else {
-		// Use existing S3 authentication
-		headers =
-		    CreateS3Header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "DELETE", auth_params, "", "", "", "");
-	}
+		HTTPHeaders headers;
+		if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
+			// Use bearer token for GCS
+			headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
+			headers["Host"] = parsed_s3_url.host;
+		} else {
+			// Use existing S3 authentication
+			headers =
+			    CreateS3Header(parsed_s3_url.path, "", parsed_s3_url.host, "s3", "DELETE", auth_params, "", "", "", "");
+		}
 
-	return HTTPFileSystem::DeleteRequest(handle, http_url, headers);
+		return HTTPFileSystem::DeleteRequest(handle, http_url, headers);
+	});
 }
 
 unique_ptr<HTTPFileHandle> S3FileSystem::CreateHandle(const OpenFileInfo &file, FileOpenFlags flags,
@@ -708,33 +756,19 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 		HTTPFileHandle::Initialize(opener);
 	} catch (std::exception &ex) {
 		ErrorData error(ex);
-		bool refreshed_secret = false;
-		if (error.Type() == ExceptionType::IO || error.Type() == ExceptionType::HTTP) {
-			// legacy endpoint (no region) returns 400
-			auto context = opener->TryGetClientContext();
-			if (context) {
-				auto transaction = CatalogTransaction::GetSystemCatalogTransaction(*context);
-				for (const string type : {"s3", "r2", "gcs", "aws"}) {
-					auto res = context->db->GetSecretManager().LookupSecret(transaction, path, type);
-					if (res.HasMatch()) {
-						refreshed_secret |= CreateS3SecretFunctions::TryRefreshS3Secret(*context, *res.secret_entry);
-					}
+		const bool can_refresh = error.Type() == ExceptionType::IO || error.Type() == ExceptionType::HTTP;
+		string correct_region;
+		auto &extra_info = error.ExtraInfo();
+		auto entry = extra_info.find("status_code");
+		if (entry != extra_info.end()) {
+			if (entry->second == "301" || entry->second == "400") {
+				auto new_region = extra_info.find("header_x-amz-bucket-region");
+				if (new_region != extra_info.end()) {
+					correct_region = new_region->second;
 				}
 			}
-		}
-		string correct_region;
-		if (!refreshed_secret) {
-			auto &extra_info = error.ExtraInfo();
-			auto entry = extra_info.find("status_code");
-			if (entry != extra_info.end()) {
-				if (entry->second == "301" || entry->second == "400") {
-					auto new_region = extra_info.find("header_x-amz-bucket-region");
-					if (new_region != extra_info.end()) {
-						correct_region = new_region->second;
-					}
-				}
-				if (entry->second == "403") {
-					// 403: FORBIDDEN
+			if (entry->second == "403") {
+				if (!auth_params.TryRefreshCredentials()) {
 					string extra_text;
 					if (IsGCSRequest(path)) {
 						extra_text = S3FileSystem::GetGCSAuthError(auth_params);
@@ -743,14 +777,13 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 					}
 					throw Exception(extra_info, error.Type(), error.RawMessage() + extra_text);
 				}
-			}
-			if (correct_region.empty()) {
-				throw;
+				HTTPFileHandle::Initialize(opener);
+				return;
 			}
 		}
-		// We have succesfully refreshed a secret: retry initializing with new credentials
-		FileOpenerInfo info = {path};
-		auth_params = S3AuthParams::ReadFrom(opener, info);
+		if (correct_region.empty() && (!can_refresh || !auth_params.TryRefreshCredentials())) {
+			throw;
+		}
 		if (!correct_region.empty()) {
 			DUCKDB_LOG_WARNING(
 			    logger,
@@ -774,6 +807,27 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 		    Storage::DEFAULT_BLOCK_SIZE;
 		D_ASSERT(multi_part_upload->part_size * max_part_count >= config_params.max_file_size);
 	}
+}
+
+bool S3FileSystem::TryRefreshSecret(const string &path, optional_ptr<FileOpener> opener) {
+	if (!opener) {
+		return false;
+	}
+
+	auto context = opener->TryGetClientContext();
+	if (!context) {
+		return false;
+	}
+
+	bool refreshed_secret = false;
+	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(*context);
+	for (const string type : {"s3", "r2", "gcs", "aws"}) {
+		auto res = context->db->GetSecretManager().LookupSecret(transaction, path, type);
+		if (res.HasMatch()) {
+			refreshed_secret |= CreateS3SecretFunctions::TryRefreshS3Secret(*context, *res.secret_entry);
+		}
+	}
+	return refreshed_secret;
 }
 
 bool S3FileSystem::CanHandleFile(const string &fpath) {
@@ -1065,8 +1119,10 @@ bool S3GlobResult::ExpandNextPath() const {
 		    Match(key_splits.begin(), key_splits.end(), pattern_splits.begin(), pattern_splits.end(), false);
 		if (is_match) {
 			prefix_path = S3FileSystem::UrlDecode(prefix_path);
-			auto prefix_res = AWSListObjectV2::Request(prefix_path, *http_params, s3_auth_params,
-			                                           common_prefix_continuation_token, true);
+			auto prefix_res = ExecuteWithRefresh(s3_auth_params, [&](S3AuthParams &auth_params) {
+				return AWSListObjectV2::Request(prefix_path, *http_params, auth_params,
+				                                common_prefix_continuation_token, true);
+			});
 
 			AWSListObjectV2::ParseFileList(prefix_res, s3_keys);
 			auto more_prefixes = AWSListObjectV2::ParseCommonPrefix(prefix_res);
@@ -1105,8 +1161,10 @@ bool S3GlobResult::ExpandNextPath() const {
 		bool perform_listing = (glob_type != GlobType::HIERARCHICAL);
 
 		// First perform listing once (default will get back up to 1000 elements)
-		string response_str = AWSListObjectV2::Request(shared_path, *http_params, s3_auth_params,
-		                                               main_continuation_token, !perform_listing);
+		string response_str = ExecuteWithRefresh(s3_auth_params, [&](S3AuthParams &auth_params) {
+			return AWSListObjectV2::Request(shared_path, *http_params, auth_params, main_continuation_token,
+			                                !perform_listing);
+		});
 
 		string next_continuation_token = AWSListObjectV2::ParseContinuationToken(response_str);
 
@@ -1136,8 +1194,10 @@ bool S3GlobResult::ExpandNextPath() const {
 				// 1. clear keys
 				s3_keys_tmp.clear();
 				// 2. do request again, now passing true
-				response_str =
-				    AWSListObjectV2::Request(shared_path, *http_params, s3_auth_params, main_continuation_token, true);
+				response_str = ExecuteWithRefresh(s3_auth_params, [&](S3AuthParams &auth_params) {
+					return AWSListObjectV2::Request(shared_path, *http_params, auth_params, main_continuation_token,
+					                                true);
+				});
 
 				// 3. now set next_continuation_token
 				next_continuation_token = AWSListObjectV2::ParseContinuationToken(response_str);

--- a/test/sql/secret/secret_refresh.test
+++ b/test/sql/secret/secret_refresh.test
@@ -63,7 +63,7 @@ statement ok
 FROM "s3://test-bucket/test-file.parquet"
 
 query I
-SELECT message[0:46] FROM duckdb_logs WHERE message like '%Successfully refreshed secret%'
+SELECT any_value(message[0:46]) FROM duckdb_logs WHERE message like '%Successfully refreshed secret%'
 ----
 Successfully refreshed secret: s1, new key_id:
 
@@ -87,7 +87,7 @@ FROM "s3://test-bucket/test-file.parquet"
 <REGEX>:.*HTTP Error:.*403.*
 
 query I
-SELECT message[0:46] FROM duckdb_logs WHERE message like '%Successfully refreshed secret%'
+SELECT any_value(message[0:46]) FROM duckdb_logs WHERE message like '%Successfully refreshed secret%'
 ----
 Successfully refreshed secret: s1, new key_id:
 
@@ -128,6 +128,7 @@ FROM "s3://test-bucket/test-file.parquet"
 <REGEX>:.*HTTP Error:.*403.*
 
 # -> log empty
-query II
-SELECT log_level, message FROM duckdb_logs WHERE message like '%Successfully refreshed secret%'
+query I
+SELECT count(*)::BIGINT FROM duckdb_logs WHERE message like '%Successfully refreshed secret%'
 ----
+0

--- a/test/sql/secret/secret_refresh_attach.test
+++ b/test/sql/secret/secret_refresh_attach.test
@@ -47,6 +47,6 @@ ATTACH 's3://test-bucket/presigned/attach.db' AS db (READONLY 1);
 
 # Secret refresh has been triggered
 query II
-SELECT log_level, message FROM duckdb_logs WHERE message like '%Successfully refreshed secret%'
+SELECT any_value(log_level), any_value(message) FROM duckdb_logs WHERE message like '%Successfully refreshed secret%'
 ----
 INFO	Successfully refreshed secret: uhuh_this_mah_sh, new key_id: all the girls


### PR DESCRIPTION
Supersedes #165.

Rebased `auto_refresh_fix` onto current `main`.

TODO follow-ups:
- [ ] batched `RemoveFiles` refresh support
- [ ] 4xx handling for non-GET paths
- [ ] regression test
- [ ] Thread safety / single-flight refresh
