### PR TITLE
Fix httpfs deadlock if there is a s3 region redirect

### DIFF
--- a/src/http_state.cpp
+++ b/src/http_state.cpp
@@ -31,6 +31,18 @@ void CachedFileHandle::AllocateBuffer(idx_t size) {
 	file->capacity = size;
 }
 
+void CachedFileHandle::ResetBuffer() {
+	if (file->initialized) {
+		throw InternalException("Cannot reset a buffer for a cached file that was already initialized");
+	}
+	if (!lock) {
+		throw InternalException("Cannot reset a buffer for a cached file without lock");
+	}
+	file->data.reset();
+	file->capacity = 0;
+	file->size = 0;
+}
+
 void CachedFileHandle::GrowBuffer(idx_t new_capacity, idx_t bytes_to_copy) {
 	// copy shared ptr to old data
 	auto old_data = file->data;

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -753,16 +753,8 @@ void HTTPFileHandle::FullDownload(HTTPFileSystem &hfs, bool &should_write_cache)
 	if (!cached_file_handle->Initialized()) {
 		// Try to fully download the file first
 		unique_ptr<HTTPResponse> full_download_result;
-		try {
-			full_download_result = hfs.GetRequest(*this, path, {});
-		} catch (...) {
-			cached_file_handle->ResetBuffer();
-			length = 0;
-			throw;
-		}
+		full_download_result = hfs.GetRequest(*this, path, {});
 		if (full_download_result->status != HTTPStatusCode::OK_200) {
-			cached_file_handle->ResetBuffer();
-			length = 0;
 			throw HTTPException(*full_download_result, "Full download failed to to URL \"%s\": %d (%s)",
 			                    full_download_result->url, static_cast<int>(full_download_result->status),
 			                    full_download_result->GetError());
@@ -819,6 +811,13 @@ optional_idx TryParseContentLength(const HTTPHeaders &headers) {
 	} catch (...) {
 		return optional_idx();
 	}
+}
+
+void HTTPFileHandle::ResetDownloadState() {
+	if (cached_file_handle) {
+		cached_file_handle->ResetBuffer();
+	}
+	length = 0;
 }
 
 void HTTPFileHandle::LoadFileInfo() {

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -239,7 +239,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRequest(FileHandle &handle, string u
 				    error += " This could mean the file was changed. Try disabling the duckdb http metadata cache "
 				             "if enabled, and confirm the server supports range requests.";
 			    }
-			    throw HTTPException(error);
+			    throw HTTPException(response, error);
 		    }
 		    if (hfh.http_params.s3_version_id_pinning && hfh.version_id.empty() &&
 		        response.HasHeader("x-amz-version-id")) {
@@ -746,12 +746,23 @@ static optional_ptr<HTTPMetadataCache> TryGetMetadataCache(optional_ptr<FileOpen
 
 void HTTPFileHandle::FullDownload(HTTPFileSystem &hfs, bool &should_write_cache) {
 	// We are going to download the file at full, we don't need to do no head request.
-	const auto &cache_entry = http_params.state->GetCachedFile(path);
-	cached_file_handle = cache_entry->GetHandle();
+	if (!cached_file_handle) {
+		const auto &cache_entry = http_params.state->GetCachedFile(path);
+		cached_file_handle = cache_entry->GetHandle();
+	}
 	if (!cached_file_handle->Initialized()) {
 		// Try to fully download the file first
-		const auto full_download_result = hfs.GetRequest(*this, path, {});
+		unique_ptr<HTTPResponse> full_download_result;
+		try {
+			full_download_result = hfs.GetRequest(*this, path, {});
+		} catch (...) {
+			cached_file_handle->ResetBuffer();
+			length = 0;
+			throw;
+		}
 		if (full_download_result->status != HTTPStatusCode::OK_200) {
+			cached_file_handle->ResetBuffer();
+			length = 0;
 			throw HTTPException(*full_download_result, "Full download failed to to URL \"%s\": %d (%s)",
 			                    full_download_result->url, static_cast<int>(full_download_result->status),
 			                    full_download_result->GetError());

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -746,18 +746,23 @@ static optional_ptr<HTTPMetadataCache> TryGetMetadataCache(optional_ptr<FileOpen
 
 void HTTPFileHandle::FullDownload(HTTPFileSystem &hfs, bool &should_write_cache) {
 	// We are going to download the file at full, we don't need to do no head request.
-	if (!cached_file_handle) {
-		const auto &cache_entry = http_params.state->GetCachedFile(path);
-		cached_file_handle = cache_entry->GetHandle();
-	}
+	const auto &cache_entry = http_params.state->GetCachedFile(path);
+	cached_file_handle = cache_entry->GetHandle();
 	if (!cached_file_handle->Initialized()) {
-		// Try to fully download the file first
-		unique_ptr<HTTPResponse> full_download_result;
-		full_download_result = hfs.GetRequest(*this, path, {});
-		if (full_download_result->status != HTTPStatusCode::OK_200) {
-			throw HTTPException(*full_download_result, "Full download failed to to URL \"%s\": %d (%s)",
-			                    full_download_result->url, static_cast<int>(full_download_result->status),
-			                    full_download_result->GetError());
+		// Try to fully download the file first. On any failure we reset the buffer and release the
+		// handle (and with it the lock on the cached file) so the download can be retried from
+		// scratch with a fresh handle, without deadlocking on the still-held lock.
+		try {
+			auto full_download_result = hfs.GetRequest(*this, path, {});
+			if (full_download_result->status != HTTPStatusCode::OK_200) {
+				throw HTTPException(*full_download_result, "Full download failed to to URL \"%s\": %d (%s)",
+				                    full_download_result->url, static_cast<int>(full_download_result->status),
+				                    full_download_result->GetError());
+			}
+		} catch (...) {
+			ResetDownloadState();
+			cached_file_handle.reset();
+			throw;
 		}
 		// Mark the file as initialized, set its final length, and unlock it to allowing parallel reads
 		cached_file_handle->SetInitialized(length);

--- a/src/include/http_state.hpp
+++ b/src/include/http_state.hpp
@@ -41,6 +41,8 @@ public:
 
 	//! allocate a buffer for the file
 	void AllocateBuffer(idx_t size);
+	//! Reset an uninitialized buffer after a failed full download
+	void ResetBuffer();
 	//! Indicate the file is fully downloaded and safe for parallel reading without lock
 	void SetInitialized(idx_t total_size);
 	//! Grow buffer to new size, copying over `bytes_to_copy` to the new buffer

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -147,6 +147,8 @@ protected:
 	virtual unique_ptr<HTTPClient> CreateClient();
 	//! Perform a HEAD request to get the file info (if not yet loaded)
 	void LoadFileInfo();
+	//! Reset download state so a full download can be retried from scratch
+	void ResetDownloadState();
 
 	//! TODO: make base function virtual?
 	void TryAddLogger(FileOpener &opener);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -687,9 +687,7 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_
 		auto result = make_request();
 		string updated_bucket_region;
 		if (TryGetUpdatedBucketRegion(s3_handle.auth_params, *result, updated_bucket_region)) {
-			if (s3_handle.cached_file_handle) {
-				s3_handle.cached_file_handle->ResetBuffer();
-			}
+			s3_handle.ResetDownloadState();
 			s3_handle.SetRegion(std::move(updated_bucket_region));
 			return make_request();
 		}
@@ -699,6 +697,7 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_
 		if (!TryGetUpdatedBucketRegion(s3_handle.auth_params, ex, updated_bucket_region)) {
 			throw;
 		}
+		s3_handle.ResetDownloadState();
 		s3_handle.SetRegion(std::move(updated_bucket_region));
 		return make_request();
 	}
@@ -850,6 +849,7 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 			    path, auth_params.region, correct_region);
 			SetRegion(std::move(correct_region));
 		}
+		ResetDownloadState();
 		HTTPFileHandle::Initialize(opener);
 	}
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -657,9 +657,8 @@ bool TryGetUpdatedBucketRegion(const S3AuthParams &auth_params, std::exception &
 
 unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
-	constexpr idx_t MAX_REGION_REDIRECTS = 2;
-	for (idx_t attempt = 0;; attempt++) {
-		const bool can_retry = (attempt + 1 < MAX_REGION_REDIRECTS);
+
+	auto make_request = [&]() -> unique_ptr<HTTPResponse> {
 		auto auth_params = s3_handle.auth_params;
 		auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
 
@@ -681,39 +680,35 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_
 			                         "", "", "");
 		}
 
-		try {
-			auto result = HTTPFileSystem::GetRequest(handle, http_url, headers);
-			string updated_bucket_region;
-			if (can_retry && TryGetUpdatedBucketRegion(auth_params, *result, updated_bucket_region)) {
-				// A 3xx redirect status does not throw from the status callback, so the redirect response
-				// body may have been streamed into cached_file_handle. Reset it before retrying.
-				if (s3_handle.cached_file_handle) {
-					s3_handle.cached_file_handle->ResetBuffer();
-				}
-				s3_handle.SetRegion(std::move(updated_bucket_region));
-				continue;
+		return HTTPFileSystem::GetRequest(handle, http_url, headers);
+	};
+
+	try {
+		auto result = make_request();
+		string updated_bucket_region;
+		if (TryGetUpdatedBucketRegion(s3_handle.auth_params, *result, updated_bucket_region)) {
+			if (s3_handle.cached_file_handle) {
+				s3_handle.cached_file_handle->ResetBuffer();
 			}
-			// On the final attempt we return the result as-is; FullDownload's status check will surface
-			// a redirect status as HTTPException with the response attached, so S3FileHandle::Initialize
-			// can still extract the new region and retry once.
-			return result;
-		} catch (std::exception &ex) {
-			string updated_bucket_region;
-			if (can_retry && TryGetUpdatedBucketRegion(auth_params, ex, updated_bucket_region)) {
-				s3_handle.SetRegion(std::move(updated_bucket_region));
-				continue;
-			}
+			s3_handle.SetRegion(std::move(updated_bucket_region));
+			return make_request();
+		}
+		return result;
+	} catch (std::exception &ex) {
+		string updated_bucket_region;
+		if (!TryGetUpdatedBucketRegion(s3_handle.auth_params, ex, updated_bucket_region)) {
 			throw;
 		}
+		s3_handle.SetRegion(std::move(updated_bucket_region));
+		return make_request();
 	}
 }
 
 unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
                                                        idx_t file_offset, char *buffer_out, idx_t buffer_out_len) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
-	constexpr idx_t MAX_REGION_REDIRECTS = 2;
-	for (idx_t attempt = 0;; attempt++) {
-		const bool can_retry = (attempt + 1 < MAX_REGION_REDIRECTS);
+
+	auto make_request = [&]() -> unique_ptr<HTTPResponse> {
 		auto auth_params = s3_handle.auth_params;
 		auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
 
@@ -735,23 +730,24 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, strin
 			                         "", "", "");
 		}
 
-		try {
-			auto result =
-			    HTTPFileSystem::GetRangeRequest(handle, http_url, headers, file_offset, buffer_out, buffer_out_len);
-			string updated_bucket_region;
-			if (can_retry && TryGetUpdatedBucketRegion(auth_params, *result, updated_bucket_region)) {
-				s3_handle.SetRegion(std::move(updated_bucket_region));
-				continue;
-			}
-			return result;
-		} catch (std::exception &ex) {
-			string updated_bucket_region;
-			if (can_retry && TryGetUpdatedBucketRegion(auth_params, ex, updated_bucket_region)) {
-				s3_handle.SetRegion(std::move(updated_bucket_region));
-				continue;
-			}
+		return HTTPFileSystem::GetRangeRequest(handle, http_url, headers, file_offset, buffer_out, buffer_out_len);
+	};
+
+	try {
+		auto result = make_request();
+		string updated_bucket_region;
+		if (TryGetUpdatedBucketRegion(s3_handle.auth_params, *result, updated_bucket_region)) {
+			s3_handle.SetRegion(std::move(updated_bucket_region));
+			return make_request();
+		}
+		return result;
+	} catch (std::exception &ex) {
+		string updated_bucket_region;
+		if (!TryGetUpdatedBucketRegion(s3_handle.auth_params, ex, updated_bucket_region)) {
 			throw;
 		}
+		s3_handle.SetRegion(std::move(updated_bucket_region));
+		return make_request();
 	}
 }
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -657,7 +657,9 @@ bool TryGetUpdatedBucketRegion(const S3AuthParams &auth_params, std::exception &
 
 unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
-	for (idx_t attempt = 0; attempt < 2; attempt++) {
+	constexpr idx_t MAX_REGION_REDIRECTS = 2;
+	for (idx_t attempt = 0;; attempt++) {
+		const bool can_retry = (attempt + 1 < MAX_REGION_REDIRECTS);
 		auto auth_params = s3_handle.auth_params;
 		auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
 
@@ -682,34 +684,36 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_
 		try {
 			auto result = HTTPFileSystem::GetRequest(handle, http_url, headers);
 			string updated_bucket_region;
-			if (TryGetUpdatedBucketRegion(auth_params, *result, updated_bucket_region)) {
+			if (can_retry && TryGetUpdatedBucketRegion(auth_params, *result, updated_bucket_region)) {
 				// A 3xx redirect status does not throw from the status callback, so the redirect response
 				// body may have been streamed into cached_file_handle. Reset it before retrying.
 				if (s3_handle.cached_file_handle) {
 					s3_handle.cached_file_handle->ResetBuffer();
 				}
-				s3_handle.length = 0;
 				s3_handle.SetRegion(std::move(updated_bucket_region));
 				continue;
 			}
+			// On the final attempt we return the result as-is; FullDownload's status check will surface
+			// a redirect status as HTTPException with the response attached, so S3FileHandle::Initialize
+			// can still extract the new region and retry once.
 			return result;
 		} catch (std::exception &ex) {
 			string updated_bucket_region;
-			if (TryGetUpdatedBucketRegion(auth_params, ex, updated_bucket_region)) {
+			if (can_retry && TryGetUpdatedBucketRegion(auth_params, ex, updated_bucket_region)) {
 				s3_handle.SetRegion(std::move(updated_bucket_region));
 				continue;
 			}
 			throw;
 		}
 	}
-	throw InvalidInputException(
-	    "Exceeded retry count in S3FileSystem::GetRequest - this means we got multiple redirects to different regions");
 }
 
 unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
                                                        idx_t file_offset, char *buffer_out, idx_t buffer_out_len) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
-	for (idx_t attempt = 0; attempt < 2; attempt++) {
+	constexpr idx_t MAX_REGION_REDIRECTS = 2;
+	for (idx_t attempt = 0;; attempt++) {
+		const bool can_retry = (attempt + 1 < MAX_REGION_REDIRECTS);
 		auto auth_params = s3_handle.auth_params;
 		auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
 
@@ -735,23 +739,20 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, strin
 			auto result =
 			    HTTPFileSystem::GetRangeRequest(handle, http_url, headers, file_offset, buffer_out, buffer_out_len);
 			string updated_bucket_region;
-			if (TryGetUpdatedBucketRegion(auth_params, *result, updated_bucket_region)) {
+			if (can_retry && TryGetUpdatedBucketRegion(auth_params, *result, updated_bucket_region)) {
 				s3_handle.SetRegion(std::move(updated_bucket_region));
 				continue;
 			}
 			return result;
 		} catch (std::exception &ex) {
 			string updated_bucket_region;
-			if (TryGetUpdatedBucketRegion(auth_params, ex, updated_bucket_region)) {
+			if (can_retry && TryGetUpdatedBucketRegion(auth_params, ex, updated_bucket_region)) {
 				s3_handle.SetRegion(std::move(updated_bucket_region));
 				continue;
 			}
 			throw;
 		}
 	}
-	throw InvalidInputException(
-	    "Exceeded retry count in S3FileSystem::GetRangeRequest - this means we got multiple redirects to different "
-	    "regions");
 }
 
 unique_ptr<HTTPResponse> S3FileSystem::DeleteRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map) {

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -599,57 +599,153 @@ unique_ptr<HTTPResponse> S3FileSystem::HeadRequest(FileHandle &handle, string s3
 	return HTTPFileSystem::HeadRequest(handle, http_url, headers);
 }
 
+namespace {
+
+bool IsWrongRegionStatus(HTTPStatusCode status) {
+	return status == HTTPStatusCode::MovedPermanently_301 || status == HTTPStatusCode::BadRequest_400;
+}
+
+bool IsWrongRegionStatus(const string &status_code) {
+	return status_code == "301" || status_code == "400";
+}
+
+bool TrySetUpdatedBucketRegion(const S3AuthParams &auth_params, const string &response_region,
+                               string &updated_bucket_region) {
+	if (response_region == auth_params.region) {
+		return false;
+	}
+	updated_bucket_region = response_region;
+	return true;
+}
+
+bool TryGetUpdatedBucketRegion(const S3AuthParams &auth_params, HTTPStatusCode status, const HTTPHeaders &headers,
+                               string &updated_bucket_region) {
+	if (!IsWrongRegionStatus(status) || !headers.HasHeader("x-amz-bucket-region")) {
+		return false;
+	}
+	return TrySetUpdatedBucketRegion(auth_params, headers.GetHeaderValue("x-amz-bucket-region"), updated_bucket_region);
+}
+
+bool TryGetUpdatedBucketRegion(const S3AuthParams &auth_params, const unordered_map<string, string> &extra_info,
+                               string &updated_bucket_region) {
+	auto status_code = extra_info.find("status_code");
+	if (status_code == extra_info.end() || !IsWrongRegionStatus(status_code->second)) {
+		return false;
+	}
+	auto response_region = extra_info.find("header_x-amz-bucket-region");
+	if (response_region == extra_info.end()) {
+		return false;
+	}
+	return TrySetUpdatedBucketRegion(auth_params, response_region->second, updated_bucket_region);
+}
+
+bool TryGetUpdatedBucketRegion(const S3AuthParams &auth_params, const HTTPResponse &response,
+                               string &updated_bucket_region) {
+	return TryGetUpdatedBucketRegion(auth_params, response.status, response.headers, updated_bucket_region);
+}
+
+bool TryGetUpdatedBucketRegion(const S3AuthParams &auth_params, const ErrorData &error, string &updated_bucket_region) {
+	return TryGetUpdatedBucketRegion(auth_params, error.ExtraInfo(), updated_bucket_region);
+}
+
+bool TryGetUpdatedBucketRegion(const S3AuthParams &auth_params, std::exception &ex, string &updated_bucket_region) {
+	ErrorData error(ex);
+	return TryGetUpdatedBucketRegion(auth_params, error, updated_bucket_region);
+}
+
+} // namespace
+
 unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
-	auto auth_params = s3_handle.auth_params;
-	auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
+	for (idx_t attempt = 0; attempt < 2; attempt++) {
+		auto auth_params = s3_handle.auth_params;
+		auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
 
-	string query_string;
-	if (!s3_handle.version_id.empty()) {
-		query_string = "versionId=" + UrlEncode(s3_handle.version_id, true);
+		string query_string;
+		if (!s3_handle.version_id.empty()) {
+			query_string = "versionId=" + UrlEncode(s3_handle.version_id, true);
+		}
+
+		string http_url = parsed_s3_url.GetHTTPUrl(auth_params, query_string);
+
+		HTTPHeaders headers;
+		if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
+			// Use bearer token for GCS
+			headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
+			headers["Host"] = parsed_s3_url.host;
+		} else {
+			// Use existing S3 authentication
+			headers = CreateS3Header(parsed_s3_url.path, query_string, parsed_s3_url.host, "s3", "GET", auth_params, "",
+			                         "", "", "");
+		}
+
+		try {
+			auto result = HTTPFileSystem::GetRequest(handle, http_url, headers);
+			string updated_bucket_region;
+			if (TryGetUpdatedBucketRegion(auth_params, *result, updated_bucket_region)) {
+				s3_handle.SetRegion(std::move(updated_bucket_region));
+				continue;
+			}
+			return result;
+		} catch (std::exception &ex) {
+			string updated_bucket_region;
+			if (TryGetUpdatedBucketRegion(auth_params, ex, updated_bucket_region)) {
+				s3_handle.SetRegion(std::move(updated_bucket_region));
+				continue;
+			}
+			throw;
+		}
 	}
-
-	string http_url = parsed_s3_url.GetHTTPUrl(auth_params, query_string);
-
-	HTTPHeaders headers;
-	if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
-		// Use bearer token for GCS
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_s3_url.host;
-	} else {
-		// Use existing S3 authentication
-		headers = CreateS3Header(parsed_s3_url.path, query_string, parsed_s3_url.host, "s3", "GET", auth_params, "", "",
-		                         "", "");
-	}
-
-	return HTTPFileSystem::GetRequest(handle, http_url, headers);
+	throw InvalidInputException(
+	    "Exceeded retry count in S3FileSystem::GetRequest - this means we got multiple redirects to different regions");
 }
 
 unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
                                                        idx_t file_offset, char *buffer_out, idx_t buffer_out_len) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
-	auto auth_params = s3_handle.auth_params;
-	auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
+	for (idx_t attempt = 0; attempt < 2; attempt++) {
+		auto auth_params = s3_handle.auth_params;
+		auto parsed_s3_url = S3UrlParse(s3_url, auth_params);
 
-	string query_string;
-	if (!s3_handle.version_id.empty()) {
-		query_string = "versionId=" + UrlEncode(s3_handle.version_id, true);
+		string query_string;
+		if (!s3_handle.version_id.empty()) {
+			query_string = "versionId=" + UrlEncode(s3_handle.version_id, true);
+		}
+
+		string http_url = parsed_s3_url.GetHTTPUrl(auth_params, query_string);
+
+		HTTPHeaders headers;
+		if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
+			// Use bearer token for GCS
+			headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
+			headers["Host"] = parsed_s3_url.host;
+		} else {
+			// Use existing S3 authentication
+			headers = CreateS3Header(parsed_s3_url.path, query_string, parsed_s3_url.host, "s3", "GET", auth_params, "",
+			                         "", "", "");
+		}
+
+		try {
+			auto result =
+			    HTTPFileSystem::GetRangeRequest(handle, http_url, headers, file_offset, buffer_out, buffer_out_len);
+			string updated_bucket_region;
+			if (TryGetUpdatedBucketRegion(auth_params, *result, updated_bucket_region)) {
+				s3_handle.SetRegion(std::move(updated_bucket_region));
+				continue;
+			}
+			return result;
+		} catch (std::exception &ex) {
+			string updated_bucket_region;
+			if (TryGetUpdatedBucketRegion(auth_params, ex, updated_bucket_region)) {
+				s3_handle.SetRegion(std::move(updated_bucket_region));
+				continue;
+			}
+			throw;
+		}
 	}
-
-	string http_url = parsed_s3_url.GetHTTPUrl(auth_params, query_string);
-
-	HTTPHeaders headers;
-	if (IsGCSRequest(s3_url) && !auth_params.oauth2_bearer_token.empty()) {
-		// Use bearer token for GCS
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_s3_url.host;
-	} else {
-		// Use existing S3 authentication
-		headers = CreateS3Header(parsed_s3_url.path, query_string, parsed_s3_url.host, "s3", "GET", auth_params, "", "",
-		                         "", "");
-	}
-
-	return HTTPFileSystem::GetRangeRequest(handle, http_url, headers, file_offset, buffer_out, buffer_out_len);
+	throw InvalidInputException(
+	    "Exceeded retry count in S3FileSystem::GetRangeRequest - this means we got multiple redirects to different "
+	    "regions");
 }
 
 unique_ptr<HTTPResponse> S3FileSystem::DeleteRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map) {
@@ -724,16 +820,10 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 		}
 		string correct_region;
 		if (!refreshed_secret) {
-			auto &extra_info = error.ExtraInfo();
-			auto entry = extra_info.find("status_code");
-			if (entry != extra_info.end()) {
-				if (entry->second == "301" || entry->second == "400") {
-					auto new_region = extra_info.find("header_x-amz-bucket-region");
-					if (new_region != extra_info.end()) {
-						correct_region = new_region->second;
-					}
-				}
-				if (entry->second == "403") {
+			const auto &extra_info = error.ExtraInfo();
+			if (!TryGetUpdatedBucketRegion(auth_params, error, correct_region)) {
+				auto entry = extra_info.find("status_code");
+				if (entry != extra_info.end() && entry->second == "403") {
 					// 403: FORBIDDEN
 					string extra_text;
 					if (IsGCSRequest(path)) {
@@ -743,8 +833,6 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 					}
 					throw Exception(extra_info, error.Type(), error.RawMessage() + extra_text);
 				}
-			}
-			if (correct_region.empty()) {
 				throw;
 			}
 		}
@@ -1419,27 +1507,26 @@ string AWSListObjectV2::Request(const string &path, HTTPParams &http_params, S3A
 		string updated_bucket_region;
 		if (result->status == HTTPStatusCode::MovedPermanently_301) {
 			string moved_error;
-			if (it == 0 && result->HasHeader("x-amz-bucket-region")) {
+			if (it == 0 && TryGetUpdatedBucketRegion(s3_auth_params, *result, updated_bucket_region)) {
+				// bucket region was updated below
+			} else if (!result->HasHeader("x-amz-bucket-region")) {
+				moved_error = "HTTP response did not contain header_x-amz-bucket-region";
+			} else {
 				auto response_region = result->GetHeaderValue("x-amz-bucket-region");
 				if (response_region == s3_auth_params.region) {
 					moved_error = "suggested region \"" + response_region +
 					              "\" is the same as the region we used to make the request";
 				} else {
-					updated_bucket_region = response_region;
+					moved_error = "received another redirect to region \"" + response_region + "\" after retrying";
 				}
-			} else {
-				moved_error = "HTTP response did not contain header_x-amz-bucket-region";
 			}
 			if (!moved_error.empty()) {
 				throw HTTPException(*result, "HTTP 301 response when running glob \"%s\" but %s", path, moved_error);
 			}
 		}
 		if (error.HasError()) {
-			if (it == 0 && result->HasHeader("x-amz-bucket-region")) {
-				auto response_region = result->GetHeaderValue("x-amz-bucket-region");
-				if (response_region != s3_auth_params.region) {
-					updated_bucket_region = response_region;
-				}
+			if (it == 0 && updated_bucket_region.empty()) {
+				TryGetUpdatedBucketRegion(s3_auth_params, *result, updated_bucket_region);
 			}
 			if (updated_bucket_region.empty()) {
 				// no updated region found

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -683,6 +683,12 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_
 			auto result = HTTPFileSystem::GetRequest(handle, http_url, headers);
 			string updated_bucket_region;
 			if (TryGetUpdatedBucketRegion(auth_params, *result, updated_bucket_region)) {
+				// A 3xx redirect status does not throw from the status callback, so the redirect response
+				// body may have been streamed into cached_file_handle. Reset it before retrying.
+				if (s3_handle.cached_file_handle) {
+					s3_handle.cached_file_handle->ResetBuffer();
+				}
+				s3_handle.length = 0;
 				s3_handle.SetRegion(std::move(updated_bucket_region));
 				continue;
 			}

--- a/test/sql/s3/incorrect_s3_region_force_download.test_slow
+++ b/test/sql/s3/incorrect_s3_region_force_download.test_slow
@@ -6,6 +6,12 @@ require httpfs
 
 require parquet
 
+# override MinIO setup
+statement ok
+SET s3_access_key_id='';
+SET s3_secret_access_key='';
+SET s3_endpoint='s3.amazonaws.com';
+
 statement ok
 SET s3_region='us-east-1';
 SET force_download=true;
@@ -17,9 +23,6 @@ SELECT COUNT(*) > 0 FROM (
 );
 ----
 true
-
-statement ok
-SET force_download=false;
 
 query I
 SELECT COUNT(*) > 0 FROM (

--- a/test/sql/s3/incorrect_s3_region_force_download.test_slow
+++ b/test/sql/s3/incorrect_s3_region_force_download.test_slow
@@ -16,18 +16,32 @@ statement ok
 SET s3_region='us-east-1';
 SET force_download=true;
 
+# Full download path with wrong region (exercises the deadlock fix)
+statement ok
+CREATE TABLE full_download_result AS
+SELECT * FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet') LIMIT 100;
+
+statement ok
+SET s3_region='us-east-1';
+SET force_download=false;
+
+# Range read path with wrong region (exercises inner retry on GetRangeRequest)
+statement ok
+CREATE TABLE range_read_result AS
+SELECT * FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet') LIMIT 100;
+
+# Both paths must return exactly the same rows (catches buffer corruption from redirect-body leak)
 query I
-SELECT COUNT(*) > 0 FROM (
-	FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet')
-	LIMIT 1
-);
+SELECT COUNT(*) FROM full_download_result;
 ----
-true
+100
 
 query I
-SELECT COUNT(*) > 0 FROM (
-	FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet')
-	LIMIT 1
-);
+SELECT COUNT(*) FROM (FROM full_download_result EXCEPT FROM range_read_result);
 ----
-true
+0
+
+query I
+SELECT COUNT(*) FROM (FROM range_read_result EXCEPT FROM full_download_result);
+----
+0

--- a/test/sql/s3/incorrect_s3_region_force_download.test_slow
+++ b/test/sql/s3/incorrect_s3_region_force_download.test_slow
@@ -1,0 +1,30 @@
+# name: test/sql/s3/incorrect_s3_region_force_download.test_slow
+# description: Test force_download and range reads when the incorrect S3 region is specified
+# group: [s3]
+
+require httpfs
+
+require parquet
+
+statement ok
+SET s3_region='us-east-1';
+SET force_download=true;
+
+query I
+SELECT COUNT(*) > 0 FROM (
+	FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet')
+	LIMIT 1
+);
+----
+true
+
+statement ok
+SET force_download=false;
+
+query I
+SELECT COUNT(*) > 0 FROM (
+	FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet')
+	LIMIT 1
+);
+----
+true

--- a/test/sql/s3/incorrect_s3_region_force_download.test_slow
+++ b/test/sql/s3/incorrect_s3_region_force_download.test_slow
@@ -12,36 +12,42 @@ SET s3_access_key_id='';
 SET s3_secret_access_key='';
 SET s3_endpoint='s3.amazonaws.com';
 
+# 301 redirect (pre-March-2019 regional endpoint)
+
 statement ok
 SET s3_region='us-east-1';
 SET force_download=true;
 
-# Full download path with wrong region (exercises the deadlock fix)
-statement ok
-CREATE TABLE full_download_result AS
+# Full download path with wrong region
+query I nosort region_redirect
 SELECT * FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet') LIMIT 100;
+----
 
 statement ok
 SET s3_region='us-east-1';
 SET force_download=false;
 
-# Range read path with wrong region (exercises inner retry on GetRangeRequest)
-statement ok
-CREATE TABLE range_read_result AS
+# Range read path with wrong region
+query I nosort region_redirect
 SELECT * FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet') LIMIT 100;
-
-# Both paths must return exactly the same rows (catches buffer corruption from redirect-body leak)
-query I
-SELECT COUNT(*) FROM full_download_result;
 ----
-100
 
-query I
-SELECT COUNT(*) FROM (FROM full_download_result EXCEPT FROM range_read_result);
-----
-0
+# 400 redirect (post-March-2019 regional endpoint)
+# ap-east-1 returns HTTP 400 instead of 301 for wrong-region requests,
+# exercising the exception retry path in S3FileSystem::GetRequest.
 
-query I
-SELECT COUNT(*) FROM (FROM range_read_result EXCEPT FROM full_download_result);
+statement ok
+SET s3_region='ap-east-1';
+SET force_download=true;
+
+query I nosort region_redirect
+SELECT * FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet') LIMIT 100;
 ----
-0
+
+statement ok
+SET s3_region='ap-east-1';
+SET force_download=false;
+
+query I nosort region_redirect
+SELECT * FROM read_parquet('s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet') LIMIT 100;
+----


### PR DESCRIPTION
The deadlock happens when calling `S3FileHandle::Initialize` and `force_download` set to true.

1. We call `S3FileHandle::Intialize` with a `FileOpener` which in turn calls the `HTTPFileHandle::Initialize`. The `FileOpener` is only used to retrive the `ClientContext` and the `HTTPState`. The HTTPState contains references to all cached files for this `ClientContext`. 
2. During `HTTPFileHandle::Initialize` we get a reference to this `CachedFile`. That `CachedFile` is then resolved to a `CachedFileHandle` which locks the `CachedFile`. As long as the `CachedFileHandle` is alive and the `CachedFileHandle` has not been initialized the `CachedFile` is locked and no new `CachedFileHandle` can be created. The `CachedFileHandle` is now stored in the `HTTPFileHandle` which in turn is extended by the `S3FileHandle`.
3. If `HTTPFileHandle::Initialize` fails (because we have been redirected and 301!=200) `S3FileHandle::Intialize` retries the initialization using `HTTPFileHandle::Initialize` with a different S3 region. For this retry the `CachedFileHandle` says alive, because it `HTTPFileHandle` which owns it is still alive. 
4. For the second call of `HTTPFileHandle::Initialize` we have the problem that the `CachedFileHandle` is still holding the lock for `CachedFile`, but `HTTPFileHandle::Initialize` stull tries to create a new `CachedFileHandle`. This is not possible because the already existing `CachedFileHandle` still holds the lock on `CachedFile`.


This PR fixes this by releasing the lock the `CachedFileHandle` holds if we fail to read from S3. Additionally it implements the region retry mechanism for more S3 call paths.