### PR TITLE
Fall back to full GET when HEAD is not allowed

### DIFF
--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -493,6 +493,15 @@ void HTTPFileHandle::AdaptReadBufferSize(idx_t next_read_offset) {
 	read_buffer = read_buffer.GetAllocator()->Allocate(read_buffer.GetSize() * 2);
 }
 
+static bool RespondedWithRangeRequestNotSupported(const HTTPResponse &res) {
+	if (!res.HasRequestError()) {
+		return false;
+	}
+	ErrorData error(res.GetRequestError());
+	return error.Type() == RangeRequestNotSupportedException::TYPE &&
+	       error.RawMessage() == RangeRequestNotSupportedException::MESSAGE;
+}
+
 bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders header_map, idx_t file_offset,
                                      char *buffer_out, idx_t buffer_out_len) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
@@ -518,16 +527,15 @@ bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders
 
 		// Request failed and we have a request error
 		if (res->HasRequestError()) {
-			ErrorData error(res->GetRequestError());
 
 			// Special case: we can do a retry with a full file download
-			if (error.Type() == RangeRequestNotSupportedException::TYPE &&
-			    error.RawMessage() == RangeRequestNotSupportedException::MESSAGE) {
+			if (RespondedWithRangeRequestNotSupported(*res)) {
 				auto &hfh = handle.Cast<HTTPFileHandle>();
 				if (hfh.http_params.auto_fallback_to_full_download) {
 					return false;
 				}
 			}
+			ErrorData error(res->GetRequestError());
 			error.Throw();
 		}
 		throw HTTPException(*res, "Request returned HTTP %d for HTTP %s to '%s'", static_cast<int>(res->status),
@@ -862,8 +870,13 @@ void HTTPFileHandle::LoadFileInfo() {
 				auto range_res = hfs.GetRangeRequest(*this, path, {}, 0, nullptr, 2);
 				if (range_res->status != HTTPStatusCode::PartialContent_206 &&
 				    range_res->status != HTTPStatusCode::Accepted_202 && range_res->status != HTTPStatusCode::OK_200) {
-					// It failed again
-					throw hfs.GetHTTPError(*this, *range_res, path);
+					// It failed again, check whether we can fall back to full download
+					if (RespondedWithRangeRequestNotSupported(*range_res) &&
+					    http_params.auto_fallback_to_full_download) {
+						force_full_download = true;
+					} else {
+						throw hfs.GetHTTPError(*this, *range_res, path);
+					}
 				}
 				res = std::move(range_res);
 			} else {


### PR DESCRIPTION
Currently when `Range` requests are performed during the file download and the server does not support ranges - then the download logic falls back to use full file download with `GET`.

To perform the `Range` requests the client first sends a `HEAD` request to get the `Content-Length`. In case when `HEAD` is not supported by the server, it resorts to using `Range: bytes=0-1` requests instead of `HEAD`. The problem is that these `Range: bytes=0-1` requests (unlike normal download `Range` requests) are throwing on error, so when neither `Range` nor `HEAD` are supported - then the fallback to full `GET` does not happen.

This PR allows to fall back from `Range: bytes=0-1` responses to a full `GET` download.

Testing: adding an SQLLogic test is untrivial because `PYTHON_HTTP_SERVER_DIR` server currently used on CI only uses default `http.server` handler. A custom handler is required there to be able to disallow `HEAD` on selected requests. Please let me know if this needs to be implemented. So far the change was tested manually on OpenAI API with the following:

```sql
statement ok
CREATE TEMPORARY SECRET openai (
  TYPE http,
  SCOPE 'https://api.openai.com',
  EXTRA_HTTP_HEADERS MAP {'Authorization': 'Bearer sk-admin-xxx'}
)

query IIIIII
FROM read_json('https://api.openai.com/v1/organization/users/user-xxx')
----
user-xxx organization.user 1234567890 alexkasko@ducklabs.com Alex Kasko owner
```

Supersedes: #309

Fixes: duckdb/duckdb#21583