### PR TITLE
More helpful error message on cache errors

### DIFF
--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -545,7 +545,8 @@ bool HTTPFileSystem::ReadInternal(FileHandle &handle, void *buffer, int64_t nr_b
 			throw InternalException("Cached file not initialized properly");
 		}
 		if (hfh.cached_file_handle->GetSize() < location + nr_bytes) {
-			throw InternalException("Cached file length can't satisfy the requested Read");
+			throw IOException("Cached file length can't satisfy the requested Read. You can try to resolve this by "
+			                  "enabling `SET force_download=true`");
 		}
 		memcpy(buffer, hfh.cached_file_handle->GetData() + location, nr_bytes);
 		DUCKDB_LOG_FILE_SYSTEM_READ(handle, nr_bytes, location);


### PR DESCRIPTION
When experimenting with calling JSON API it was discovered that [this check](https://github.com/duckdb/duckdb-httpfs/blob/c3f215ab360f04dc3d3d5305fa81849c0121f111/src/httpfs.cpp#L548) can be triggered using the following request (with default settings):

```sql
FROM read_json('https://api.openai.com/v1/me')
```

Currently it throws an `InternalException` and prints a stack trace.

Root cause for the problem is currently not clear (unlike #341 the fallback from `Range` requests to full `GET` is indeed performed in this case), just there is an easy workaround with setting:

```sql
SET force_download = TRUE
```

That seems to be a reasonable option, when a request is sent not to a static file, but to an API endpoint.

It is suggested to treat this cache problem as an `IOException` and provide a hint about `force_download` in the error message.