### PR TITLE
Enable httpfs_connection_caching by default

### DIFF
--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -164,7 +164,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 #endif
 	};
 	config.AddExtensionOption("httpfs_connection_caching", "Enable connection caching for HTTP requests",
-	                          LogicalType::BOOLEAN, Value::BOOLEAN(false), callback_httpfs_connection_caching);
+	                          LogicalType::BOOLEAN, Value::BOOLEAN(true), callback_httpfs_connection_caching);
 
 	config.AddExtensionOption("enable_global_s3_configuration",
 	                          "Automatically fetch AWS credentials from environment variables.", LogicalType::BOOLEAN,

--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -103,7 +103,7 @@ public:
 	string GetName() const override;
 
 	//! Whether connection caching is enabled
-	bool connection_caching_enabled = false;
+	bool connection_caching_enabled = true;
 
 private:
 	//! Send request with connection caching (acquire from pool, run, store back)

--- a/test/sql/connection_caching_default.test
+++ b/test/sql/connection_caching_default.test
@@ -1,0 +1,40 @@
+# name: test/sql/connection_caching_default.test
+# description: Connection caching is enabled by default (no SET required)
+# group: [sql]
+
+require httpfs
+
+require parquet
+
+# override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
+set ignore_error_messages
+
+# The registered default for the setting must report as enabled
+query I
+SELECT count(*) FROM duckdb_settings() WHERE name = 'httpfs_connection_caching' AND value = 'true';
+----
+1
+
+statement ok
+SET enable_logging=true;
+
+statement ok
+CALL enable_logging('HTTPFSInfo');
+
+# First request, without ever calling SET httpfs_connection_caching=true — should be a cache miss
+statement ok
+FROM 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_role_type.parquet';
+
+query I
+SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_miss%';
+----
+1
+
+# Second request to the same file — should be a cache hit purely because caching is on by default
+statement ok
+FROM 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_role_type.parquet';
+
+query I
+SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_hit%';
+----
+1

--- a/test/sql/connection_caching_disable.test
+++ b/test/sql/connection_caching_disable.test
@@ -1,0 +1,44 @@
+# name: test/sql/connection_caching_disable.test
+# description: Connection caching can be turned off via SET httpfs_connection_caching=false
+# group: [sql]
+
+require httpfs
+
+require parquet
+
+# override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
+set ignore_error_messages
+
+# Caching is on by default; explicitly disable it
+statement ok
+SET httpfs_connection_caching=false;
+
+# The setting must now report as disabled
+query I
+SELECT count(*) FROM duckdb_settings() WHERE name = 'httpfs_connection_caching' AND value = 'false';
+----
+1
+
+statement ok
+SET enable_logging=true;
+
+statement ok
+CALL enable_logging('HTTPFSInfo');
+
+# Two requests to the same file — with caching disabled the connection cache path is bypassed entirely
+statement ok
+FROM 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_role_type.parquet';
+
+statement ok
+FROM 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_role_type.parquet';
+
+# No connection should be served from (or stored in) the cache, so neither hit nor miss is logged
+query I
+SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_hit%';
+----
+0
+
+query I
+SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_miss%';
+----
+0


### PR DESCRIPTION
**What:** change the default of `httpfs_connection_caching` from `false` to `true`, so HTTP(S)
requests reuse the underlying connection instead of opening a new one per request.  It tests that it is on by default and that it can be disabled via the flag.

**Why:** Without caching, every request opens a fresh TCP connection and, over HTTPS, performs a CPU-intensive TLS handshake. Reusing the connection amortizes both, improving throughput for concurrent requests by 1.3×–1.6× on plain HTTP and 1.9×–3.0× over TLS.

**Impact:** Behavior change; existing clients move to connection caching when they upgrade to the release including this change.

**Motivation:** Benchmarked using the Quack [single-row INSERT transaction benchmark](https://github.com/duckdb/duckdb-quack/blob/v1.5-variegata/benchmarks/benchmark-transactions.py) over two AWS `m8g.2xlarge` nodes in the same availability zone (AZ).

**Speedup of enabling caching:**

| client threads | plain HTTP | HTTPS (TLS) |
| -------------- | ---------- | ----------- |
| 1              | 1.6×       | 2.9×        |
| 4              | 1.4×       | 3.0×        |
| 8              | 1.3×       | 2.7×        |
| 16             | 1.3×       | 1.9×        |

<img width="600" alt="image" src="https://github.com/user-attachments/assets/8ae98dfa-d7e9-4633-91d3-ced2b87f0f8d" />


