### PR TITLE
Add virtual alias for S3 URL style

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -496,7 +496,7 @@ ParsedS3Url S3FileSystem::S3UrlParse(string url, const S3AuthParams &params) {
 
 	// Update host and path according to the url style
 	// See https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
-	if (params.url_style == "vhost" || params.url_style == "") {
+	if (params.url_style == "vhost" || params.url_style == "virtual" || params.url_style == "") {
 		host = bucket + "." + host;
 	} else if (params.url_style == "path") {
 		path += "/" + bucket;

--- a/test/sql/copy/s3/download_config.test
+++ b/test/sql/copy/s3/download_config.test
@@ -25,7 +25,7 @@ set ignore_error_messages
 statement ok
 CREATE TABLE test as SELECT * FROM range(0,10) tbl(i);
 
-foreach url_style path vhost
+foreach url_style path vhost virtual
 # Have to set these because they get altered during the loop
 statement ok
 SET s3_secret_access_key='${AWS_SECRET_ACCESS_KEY}';

--- a/test/sql/copy/s3/fully_qualified_s3_url.test
+++ b/test/sql/copy/s3/fully_qualified_s3_url.test
@@ -159,6 +159,9 @@ statement ok
 SELECT i FROM "s3://test-bucket/s3_query_params/test.parquet?s3_url_style=vhost" LIMIT 3
 
 statement ok
+SELECT i FROM "s3://test-bucket/s3_query_params/test.parquet?s3_url_style=virtual" LIMIT 3
+
+statement ok
 SET s3_url_style='path';
 
 # test combinations


### PR DESCRIPTION
Adds `virtual` as a backward-compatible alias for the existing `vhost` S3 URL style in httpfs.

This fixes duckdb/duckdb#23335 by allowing AWS-compatible `virtual` naming while keeping existing `vhost` behavior and the default unchanged.