### PR TITLE
Fix S3 settings scope retrieval (debug only)

### DIFF
--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -30,8 +30,8 @@ public:
 	SettingLookupResult TryGetSecretKeyOrSetting(const string &secret_key, const string &setting_name, TYPE &result) {
 		Value temp_result;
 		auto setting_scope = reader.TryGetSecretKeyOrSetting(secret_key, setting_name, temp_result);
-		if (!temp_result.IsNull() &&
-		    !(setting_scope.GetScope() == SettingScope::GLOBAL && !use_env_variables_for_secret_settings)) {
+		if (!temp_result.IsNull() && !(setting_scope && setting_scope.GetScope() == SettingScope::GLOBAL &&
+		                               !use_env_variables_for_secret_settings)) {
 			result = temp_result.GetValue<TYPE>();
 		}
 		return setting_scope;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -233,10 +233,10 @@ S3AuthParams S3AuthParams::ReadFrom(S3KeyValueReader &secret_reader, const strin
 
 	if (StringUtil::StartsWith(file_path, "gcs://") || StringUtil::StartsWith(file_path, "gs://")) {
 		// For GCS urls we force the endpoint and vhost path style, allowing only to be overridden by secrets
-		if (result.endpoint.empty() || endpoint_result.GetScope() != SettingScope::SECRET) {
+		if (result.endpoint.empty() || !endpoint_result || endpoint_result.GetScope() != SettingScope::SECRET) {
 			result.endpoint = "storage.googleapis.com";
 		}
-		if (result.url_style.empty() || url_style_result.GetScope() != SettingScope::SECRET) {
+		if (result.url_style.empty() || !url_style_result || url_style_result.GetScope() != SettingScope::SECRET) {
 			result.url_style = "path";
 		}
 		// Read bearer token for GCS


### PR DESCRIPTION
There was a problem discovered when in assertion-enabled builds the following `ATTACH` to S3 was failing:

```sql
ATTACH 's3://my-bucket/my.duckdb'
```
```
IO Error: Cannot open database "s3://my-bucket/my.duckdb" in read-only mode: database does not exist
```

When this `ATTACH` was working correctly in release builds.

The setting retrieval assertion was triggered [here](https://github.com/duckdb/duckdb/blob/c4770ecba48065b691843da2e6eb9f91e3fea77b/src/include/duckdb/main/setting_info.hpp#L58) and was swallowed by [this catch](https://github.com/duckdb/duckdb-httpfs/blob/c3f215ab360f04dc3d3d5305fa81849c0121f111/src/httpfs.cpp#L454) afterwards, so generic IO error message was returned.

This PR adds the setting checks in two places where `GetScope` is used.