### PR TITLE
Add relassert and re-run tests to stabilize CI

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -41,3 +41,46 @@ jobs:
       ci_tools_version: v1.5-variegata
       extra_toolchains: 'python3'
       format_checks: 'format'
+
+  relassert:
+    name: Build relassert
+    runs-on: ${{ github.repository_owner == 'duckdb' && 'namespace-profile-linux-x64' || 'ubuntu-latest' }}
+    env:
+      GEN: ninja
+      CC: clang-20
+      CXX: clang++-20
+      # Enable -DDEBUG slow verifiers (expression verifier, operator
+      # round-trips, etc.) without changing the optimization level.
+      FORCE_DEBUG: 1
+      FORCE_ASSERT: 1
+      ASAN_OPTIONS: "detect_leaks=1:halt_on_error=1:abort_on_error=0"
+      UBSAN_OPTIONS: "halt_on_error=1:print_stacktrace=1"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+      - name: Install tools
+        run: python3 duckdb/scripts/ci/retry.py -- make -C duckdb toolsci
+      - name: Fix ASan runtime
+        # libclang_rt.asan_static.a is missing in ubuntu 24.04 — workaround
+        # mirrored from upstream Main.yml.
+        run: |
+          asan_static_dir="/usr/lib/llvm-20/lib/clang/20/lib/x86_64-pc-linux-gnu"
+          asan_static_target="/usr/lib/llvm-20/lib/clang/20/lib/linux/libclang_rt.asan_static-x86_64.a"
+          if [[ ! -e "${asan_static_dir}/libclang_rt.asan_static.a" && -e "${asan_static_target}" ]]; then
+            sudo mkdir -p "${asan_static_dir}"
+            sudo ln -sf "${asan_static_target}" "${asan_static_dir}/libclang_rt.asan_static.a"
+          fi
+      - name: Setup Ccache
+        uses: hendrikmuhs/ccache-action@main
+        with:
+          max-size: 5GB
+          evict-old-files: job
+      - name: Build (relassert → ASan + UBSan + LSan)
+        uses: duckdb/duckdb-ci/build-duckdb@main
+        with:
+          build-type: relassert
+          build: python3 duckdb/scripts/ci/retry.py -- make relassert
+          test: make unittest_relassert
+          vcpkg-commit: 84bab45d415d22042bd0b9081aea57f362da3f35

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,15 @@ PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 EXT_NAME=httpfs
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
+# Stabilize all tests in CI
+ifdef CI
+TEST_FLAGS:=--stabilize-tests
+endif
+T ?= $(TEST_FLAGS) "test/*"
+
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
 include extension-ci-tools/makefiles/vcpkg.Makefile
+ 
+unittest_relassert:
+	build/relassert/test/run $(T)


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/9787

I want to repeatedly run extensions tests to detect (more) ASAN failures in CI. Some tests can fail "randomly" (if the right code paths are executed) and that affects duckdb CI on main and in PRs (and some customers that build duckdb from main).

The extension author is not always aware of failure when bumping the extension in duckdb, and re-running tests should reduce the chance of merging code that fails once every ~ten runs.

I'm trying the new CLI flag `--stabilize-tests` in this extension first to see what we discover. It could be that we move the changes elsewhere (like `extension-ci-tools`) in the future.