### PR TITLE
initialize last_modified field on HTTPFileHandle to 0

### DIFF
--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -383,8 +383,8 @@ HTTPInput::HTTPInput(unique_ptr<HTTPParams> params_p)
 HTTPFileHandle::HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags,
                                shared_ptr<HTTPInput> input_p)
     : FileHandle(fs, file.path, flags), http_input(std::move(input_p)), http_params(http_input->http_params),
-      flags(flags), length(0), force_full_download(false), buffer_available(0), buffer_idx(0), file_offset(0),
-      buffer_start(0), buffer_end(0) {
+      flags(flags), length(0), last_modified(0), force_full_download(false), buffer_available(0), buffer_idx(0),
+      file_offset(0), buffer_start(0), buffer_end(0) {
 	// check if the handle has extended properties that can be set directly in the handle
 	// if we have these properties we don't need to do a head request to obtain them later
 	if (file.extended_info) {


### PR DESCRIPTION
Helps close https://github.com/duckdb/duckdb/issues/23255

timestamp_t is prone to initialization as garbage and would not trigger the checks implemented in https://github.com/duckdb/duckdb/pull/23427. 

