### PR TITLE
Add move constructor to CURLRequestHeaders

### DIFF
--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -495,7 +495,7 @@ private:
 				curl_headers.Add(entry.first + ": " + entry.second);
 			}
 		}
-		return curl_headers;
+		return std::move(curl_headers);
 	}
 
 	void ResetRequestInfo() {

--- a/src/include/httpfs_curl_client.hpp
+++ b/src/include/httpfs_curl_client.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <curl/curl.h>
+#include <utility>
 
 #include "duckdb/common/http_util.hpp"
 
@@ -36,6 +37,16 @@ public:
 	}
 	CURLRequestHeaders() {
 	}
+	CURLRequestHeaders(CURLRequestHeaders &&other) noexcept {
+		headers = other.headers;
+		other.headers = nullptr;
+	}
+	CURLRequestHeaders &operator=(CURLRequestHeaders &&other) noexcept {
+		std::swap(headers, other.headers);
+		return *this;
+	}
+	CURLRequestHeaders(const CURLRequestHeaders &) = delete;
+	CURLRequestHeaders &operator=(const CURLRequestHeaders &) = delete;
 
 	~CURLRequestHeaders() {
 		if (headers) {


### PR DESCRIPTION
`CURLRequestHeaders` class contains a pointer to `curl_slist` that is freed in destructor. The instance of this class is created in `TransformHeadersCurl()` and returned by value from there. Normally the copy does not happen on return due to Named Return Value Optimization. But NVRO is not guaranteed in C++17, for example it never happens in MSVC debug builds. That is causing the destructor call on return and the use-after-free for the `curl_slist` contents after that, that may or may not cause a segfault (or a hang when iterating over this list) later.

This PR adds the move constructor (and assignment operator) to `CURLRequestHeaders` and also changes the return of `TransformHeadersCurl()` to make the move constructor to be called all the time.

Ref: duckdblabs/duckdb-internal#9402