### PR TITLE
Add a check for content length discrepancy

### DIFF
--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -15,6 +15,7 @@
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "http_state.hpp"
 
+#include <cinttypes>
 #include <chrono>
 #include <map>
 #include <string>
@@ -553,8 +554,9 @@ bool HTTPFileSystem::ReadInternal(FileHandle &handle, void *buffer, int64_t nr_b
 			throw InternalException("Cached file not initialized properly");
 		}
 		if (hfh.cached_file_handle->GetSize() < location + nr_bytes) {
-			throw IOException("Cached file length can't satisfy the requested Read. You can try to resolve this by "
-			                  "enabling `SET force_download=true`");
+			throw InternalException("Cached file length: %" PRIu64
+			                        " can't satisfy the requested Read, location: %" PRIu64 ", length: %" PRIu64 ".",
+			                        hfh.cached_file_handle->GetSize(), location, nr_bytes);
 		}
 		memcpy(buffer, hfh.cached_file_handle->GetData() + location, nr_bytes);
 		DUCKDB_LOG_FILE_SYSTEM_READ(handle, nr_bytes, location);
@@ -664,6 +666,16 @@ void HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, id
 
 	bool should_write_cache = false;
 	hfh.FullDownload(*this, should_write_cache);
+
+	if (hfh.cached_file_handle->GetSize() < location + nr_bytes) {
+		throw HTTPException(Exception::ConstructMessage(
+		    "The size of the fully downloaded file: %" PRIu64 " can't satisfy the requested Read, location: %" PRIu64
+		    ", length: %" PRIu64
+		    ". This can happen when the Content-Lenght reported by HEAD request exceeds the downloaded "
+		    "Content-Length (from the GET request). You can try to resolve this by "
+		    "enabling `SET force_download=true`",
+		    hfh.cached_file_handle->GetSize(), location, nr_bytes));
+	}
 
 	if (!ReadInternal(handle, buffer, nr_bytes, location)) {
 		throw HTTPException("Failed to read from HTTP file after automatically retrying a full file download.");


### PR DESCRIPTION
This PR adds a check for the content lenght discrepancy, when the content lenght obtained from `HEAD` requests exceeds the actual content lenght of a file fully downloaded by a `GET` request. This check can only happen when server does not support `GET` requests with a `Range`.

It effectively rolls back the change added in #342 in favour of a check in a more specific scenario.

It does not seem to be possible to handle this gracefully, as the content length from the `HEAD` request is considered as a `stat`-resulted file length in the cached file system up the stack.

It is also not posisble to easily add a strict check that `HEAD` and `GET` content lenghts match exactly, as the `GET` is called through the generic FS API call that does not pass down the known full lenght of the file.

Testing: the check can be triggered using the following test server:

```python
from http.server import SimpleHTTPRequestHandler, HTTPServer
import sys

class ReproduceHTTPRequestHandler(SimpleHTTPRequestHandler):
    def do_HEAD(self):
        print(f"HEAD request received for {self.path}")
        self.send_response(200)
        self.send_header("Content-Length", "2")
        self.end_headers()

    def do_GET(self):
        print(f"GET request received for {self.path} with headers:\n{self.headers}")

        body = b"A"

        self.send_response(200)
        self.send_header("Content-Length", str(len(body)))
        self.end_headers()
        self.wfile.write(body)

def run(port=8080):
    server_address = ('', port)
    httpd = HTTPServer(server_address, ReproduceHTTPRequestHandler)
    print(f"Starting HTTP server on port {port}...")
    try:
        httpd.serve_forever()
    except KeyboardInterrupt:
        print("\nStopping server.")
        sys.exit(0)

if __name__ == "__main__":
    port = 8080
    if len(sys.argv) > 1:
        port = int(sys.argv[1])
    run(port)
```

Ref: duckdblabs/duckdb-internal#9799