### PR TITLE
Always add user-agent to httplib request

### DIFF
--- a/src/httpfs_httplib_client.cpp
+++ b/src/httpfs_httplib_client.cpp
@@ -46,7 +46,14 @@ public:
 		state = http_params.state;
 	}
 
+	static void AddUserAgentIfAvailable(HTTPFSParams &http_params, HTTPHeaders &header_map) {
+		if (!http_params.user_agent.empty()) {
+			header_map.Insert("User-Agent", http_params.user_agent);
+		}
+	}
+
 	unique_ptr<HTTPResponse> Get(GetRequestInfo &info) override {
+		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
 		if (state) {
 			state->get_count++;
 		}
@@ -69,6 +76,7 @@ public:
 		}
 	}
 	unique_ptr<HTTPResponse> Put(PutRequestInfo &info) override {
+		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
 		if (state) {
 			state->put_count++;
 			state->total_bytes_sent += info.buffer_in_len;
@@ -79,6 +87,7 @@ public:
 	}
 
 	unique_ptr<HTTPResponse> Head(HeadRequestInfo &info) override {
+		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
 		if (state) {
 			state->head_count++;
 		}
@@ -87,6 +96,7 @@ public:
 	}
 
 	unique_ptr<HTTPResponse> Delete(DeleteRequestInfo &info) override {
+		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
 		if (state) {
 			state->delete_count++;
 		}
@@ -95,6 +105,7 @@ public:
 	}
 
 	unique_ptr<HTTPResponse> Post(PostRequestInfo &info) override {
+		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
 		if (state) {
 			state->post_count++;
 			state->total_bytes_sent += info.buffer_in_len;

--- a/test/sql/attach/attach_s3_tpch.test_slow
+++ b/test/sql/attach/attach_s3_tpch.test_slow
@@ -29,6 +29,9 @@ CREATE SECRET (
     USE_SSL '${DUCKDB_S3_USE_SSL}'
 )
 
+statement ok
+CALL enable_logging('HTTP');
+
 # ATTACH a DuckDB database over HTTPFS
 statement ok
 ATTACH 's3://test-bucket/presigned/lineitem_sf1.db' AS db (READONLY 1);
@@ -65,6 +68,14 @@ ATTACH 's3://test-bucket/presigned/lineitem_sf1.db' AS db (READONLY 1);
 
 statement ok
 USE db
+
+# every logged request must carry a User-Agent that identifies duckdb
+query I
+SELECT count(*) FROM duckdb_logs_parsed('HTTP')
+WHERE request.headers['User-Agent'] IS NULL
+   OR NOT starts_with(request.headers['User-Agent'], 'duckdb')
+----
+0
 
 query IIIIIIIIIIIIIIII
 select count(distinct columns(*)) from lineitem;

--- a/test/sql/copy/parquet/parquet_http_prefetch.test
+++ b/test/sql/copy/parquet/parquet_http_prefetch.test
@@ -24,6 +24,9 @@ require-env DUCKDB_S3_USE_SSL
 set ignore_error_messages
 
 statement ok
+CALL enable_logging('HTTP');
+
+statement ok
 CREATE TABLE test_fetch_delay (a INT, b INT);
 
 statement ok
@@ -37,5 +40,13 @@ CREATE TABLE test as SELECT * from 's3://test-bucket/skip_delay.parquet' where a
 
 query I
 SELECT COUNT(*) FROM test;
+----
+0
+
+# every logged request must carry a User-Agent that identifies duckdb
+query I
+SELECT count(*) FROM duckdb_logs_parsed('HTTP')
+WHERE request.headers['User-Agent'] IS NULL
+   OR NOT starts_with(request.headers['User-Agent'], 'duckdb')
 ----
 0

--- a/test/sql/copy/s3/glob_s3_paging.test_slow
+++ b/test/sql/copy/s3/glob_s3_paging.test_slow
@@ -113,6 +113,14 @@ SELECT count(*) FROM glob('s3://test-bucket/parquet_glob*/paging/*');
 
 endloop
 
+# every logged request must carry a User-Agent that identifies duckdb
+query I
+SELECT count(*) FROM duckdb_logs_parsed('HTTP')
+WHERE request.headers['User-Agent'] IS NULL
+   OR NOT starts_with(request.headers['User-Agent'], 'duckdb')
+----
+0
+
 query IIIII
 FROM (FROM duckdb_logs_parsed('HTTP') SELECT count(*), sum(request.type == 'HEAD') head, sum(request.type == 'GET') get, sum(request.type == 'POST') post, sum(request.type == 'PUT') put GROUP BY context_id ORDER BY context_id) WHERE post == 0;
 ----

--- a/test/sql/copy/s3/hive_partitioned_write_s3.test
+++ b/test/sql/copy/s3/hive_partitioned_write_s3.test
@@ -35,6 +35,9 @@ CREATE SECRET (
 statement ok
 set s3_endpoint='ensure.secret.is.used.instead.of.duckdb.setting.com'
 
+statement ok
+CALL enable_logging('HTTP');
+
 # Simple table that is easy to partition
 statement ok
 CREATE TABLE test as SELECT i%2 as part_col, (i+1)%5 as value_col, i as value2_col from range(0,10) tbl(i);
@@ -172,6 +175,14 @@ SELECT part_col, value_col, value2_col FROM 's3://test-bucket/partitioned7/part_
 0	0	4
 0	2	6
 0	4	8
+
+# every logged request must carry a User-Agent that identifies duckdb
+query I
+SELECT count(*) FROM duckdb_logs_parsed('HTTP')
+WHERE request.headers['User-Agent'] IS NULL
+   OR NOT starts_with(request.headers['User-Agent'], 'duckdb')
+----
+0
 
 query III
 SELECT part_col, value_col, value2_col FROM 's3://test-bucket/partitioned7/part_col=1/*.csv' ORDER BY value2_col;

--- a/test/sql/copy/s3/s3_remove_files.test
+++ b/test/sql/copy/s3/s3_remove_files.test
@@ -21,6 +21,9 @@ require-env DUCKDB_S3_USE_SSL
 # override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
 set ignore_error_messages
 
+statement ok
+CALL enable_logging('HTTP');
+
 foreach url_style path vhost
 
 statement ok
@@ -74,3 +77,11 @@ SELECT part_col, value FROM 's3://test-bucket/remove_files_test/**/*.parquet'
 99	new_data
 
 endloop
+
+# every logged request must carry a User-Agent that identifies duckdb
+query I
+SELECT count(*) FROM duckdb_logs_parsed('HTTP')
+WHERE request.headers['User-Agent'] IS NULL
+   OR NOT starts_with(request.headers['User-Agent'], 'duckdb')
+----
+0

--- a/test/sql/copy/s3/upload_large_file.test_slow
+++ b/test/sql/copy/s3/upload_large_file.test_slow
@@ -62,6 +62,9 @@ WHERE
 
 # Parquet file ~300MB
 statement ok
+CALL enable_logging('HTTP');
+
+statement ok
 COPY lineitem TO 's3://test-bucket/multipart/export_large.parquet' (FORMAT 'parquet');
 
 query I
@@ -77,3 +80,11 @@ WHERE
     AND l_quantity < 24;
 ----
 123141078.2283
+
+# every logged request must carry a User-Agent that identifies duckdb
+query I
+SELECT count(*) FROM duckdb_logs_parsed('HTTP')
+WHERE request.headers['User-Agent'] IS NULL
+   OR NOT starts_with(request.headers['User-Agent'], 'duckdb')
+----
+0

--- a/test/sql/copy/s3/upload_small_file.test
+++ b/test/sql/copy/s3/upload_small_file.test
@@ -24,6 +24,9 @@ require-env DUCKDB_S3_USE_SSL
 set ignore_error_messages
 
 statement ok
+CALL enable_logging('HTTP');
+
+statement ok
 CREATE TABLE web_page as (SELECT * FROM "duckdb/data/csv/real/web_page.csv");
 
 query IIIIIIIIIIIIII
@@ -61,6 +64,14 @@ SELECT * FROM "s3://test-bucket/multipart/web_page.parquet" LIMIT 10;
 # CSV file
 statement ok
 COPY web_page TO 's3://test-bucket/multipart/web_page.csv';
+
+# every logged request must carry a User-Agent that identifies duckdb
+query I
+SELECT count(*) FROM duckdb_logs_parsed('HTTP')
+WHERE request.headers['User-Agent'] IS NULL
+   OR NOT starts_with(request.headers['User-Agent'], 'duckdb')
+----
+0
 
 query IIIIIIIIIIIIII
 SELECT * FROM "s3://test-bucket/multipart/web_page.csv" LIMIT 10;

--- a/test/sql/full_file_download_fallback.test
+++ b/test/sql/full_file_download_fallback.test
@@ -36,6 +36,14 @@ select count(*) from duckdb_logs where log_level='WARNING' and message like '%Fa
 ----
 2
 
+# every logged request must carry a User-Agent that identifies duckdb
+query I
+SELECT count(*) FROM duckdb_logs_parsed('HTTP')
+WHERE request.headers['User-Agent'] IS NULL
+   OR NOT starts_with(request.headers['User-Agent'], 'duckdb')
+----
+0
+
 statement ok
 set auto_fallback_to_full_download=false
 

--- a/test/sql/httpfs/user_agent_httplib.test
+++ b/test/sql/httpfs/user_agent_httplib.test
@@ -1,0 +1,101 @@
+# name: test/sql/httpfs/user_agent_httplib.test
+# description: httplib client must send a duckdb User-Agent on every request type
+# group: [httpfs]
+
+#              (S3 LIST/glob, PUT, multipart POST, HEAD, GET, and generic HTTP)
+
+require-env S3_TEST_SERVER_AVAILABLE 1
+
+require-env AWS_DEFAULT_REGION
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+require-env DUCKDB_S3_ENDPOINT
+
+require-env DUCKDB_S3_USE_SSL
+
+require-env PYTHON_HTTP_SERVER_URL
+
+require-env PYTHON_HTTP_SERVER_DIR
+
+require httpfs
+
+require parquet
+
+statement ok
+SET httpfs_client_implementation='httplib';
+
+statement ok
+set s3_use_ssl='${DUCKDB_S3_USE_SSL}'
+
+statement ok
+set s3_endpoint='${DUCKDB_S3_ENDPOINT}'
+
+statement ok
+set s3_region='${AWS_DEFAULT_REGION}'
+
+statement ok
+CREATE SECRET s1 (TYPE S3, KEY_ID '${AWS_ACCESS_KEY_ID}', SECRET '${AWS_SECRET_ACCESS_KEY}')
+
+# shrink the multipart part size to the 5 MiB minimum so a small write still
+# exercises the multipart path (part_size = max_filesize / max_parts)
+statement ok
+SET s3_uploader_max_filesize='50GB'
+
+statement ok
+SET s3_uploader_max_parts_per_file=10000
+
+# publish a file to the local dir the python http.server serves (local write, not HTTP)
+statement ok
+COPY (SELECT 42 AS a) TO '${PYTHON_HTTP_SERVER_DIR}/ua_http.csv'
+
+statement ok
+CALL enable_logging('HTTP');
+
+# --- write: single PUT + multipart POST ---
+statement ok
+COPY (SELECT 42 AS a) TO 's3://test-bucket/ua_small.parquet'
+
+statement ok
+COPY (SELECT repeat('x', 1000) AS a FROM range(6000)) TO 's3://test-bucket/ua_big.csv'
+
+# --- read: HEAD + ranged GET, then a forced full GET ---
+statement ok
+SELECT count(*) FROM 's3://test-bucket/ua_small.parquet'
+
+statement ok
+SET force_download=true
+
+statement ok
+SELECT count(*) FROM 's3://test-bucket/ua_small.parquet'
+
+statement ok
+SET force_download=false
+
+# --- list: glob issues an S3 LIST (GET) ---
+statement ok
+SELECT count(*) FROM glob('s3://test-bucket/*')
+
+# --- generic (non-S3) HTTP: HEAD + GET via HTTPFileSystem ---
+statement ok
+SELECT count(*) FROM '${PYTHON_HTTP_SERVER_URL}/ua_http.csv'
+
+# we actually exercised every verb
+query I
+SELECT count(*) FILTER (WHERE request.type = 'PUT')  > 0
+   AND count(*) FILTER (WHERE request.type = 'POST') > 0
+   AND count(*) FILTER (WHERE request.type = 'HEAD') > 0
+   AND count(*) FILTER (WHERE request.type = 'GET')  > 0
+FROM duckdb_logs_parsed('HTTP')
+----
+true
+
+# every logged request must carry a User-Agent that identifies duckdb
+query I
+SELECT count(*) FROM duckdb_logs_parsed('HTTP')
+WHERE request.headers['User-Agent'] IS NULL
+   OR NOT starts_with(request.headers['User-Agent'], 'duckdb')
+----
+0

--- a/test/sql/s3/glob_user_agent.test
+++ b/test/sql/s3/glob_user_agent.test
@@ -1,0 +1,49 @@
+# name: test/sql/s3/glob_user_agent.test
+# description: an S3 glob (LIST) request must carry a duckdb User-Agent
+# group: [s3]
+
+require-env S3_TEST_SERVER_AVAILABLE 1
+
+require-env AWS_DEFAULT_REGION
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+require-env DUCKDB_S3_ENDPOINT
+
+require-env DUCKDB_S3_USE_SSL
+
+require httpfs
+
+statement ok
+set s3_use_ssl='${DUCKDB_S3_USE_SSL}'
+
+statement ok
+set s3_endpoint='${DUCKDB_S3_ENDPOINT}'
+
+statement ok
+set s3_region='${AWS_DEFAULT_REGION}'
+
+statement ok
+CREATE SECRET s1 (TYPE S3, KEY_ID '${AWS_ACCESS_KEY_ID}', SECRET '${AWS_SECRET_ACCESS_KEY}')
+
+statement ok
+CALL enable_logging('HTTP');
+
+# a glob issues an S3 LIST (GET) regardless of whether anything matches
+statement ok
+SELECT count(*) FROM glob('s3://test-bucket/*')
+
+query I
+SELECT count(*) > 0 FROM duckdb_logs_parsed('HTTP')
+----
+true
+
+# every logged request must carry a User-Agent that identifies duckdb
+query I
+SELECT count(*) FROM duckdb_logs_parsed('HTTP')
+WHERE request.headers['User-Agent'] IS NULL
+   OR NOT starts_with(request.headers['User-Agent'], 'duckdb')
+----
+0


### PR DESCRIPTION
Closes https://github.com/duckdblabs/duckdb-internal/issues/9861

When using the (non-default) httplib implementation, the User-Agent header was missing when performing a S3 LIST operation, e.g.

```sql
SELECT count(*) FROM glob('s3://test-bucket/ua_glob_*.parquet');
```

httplib now matches the curl implementation by applying the user-agent header, when missing, on each request.

Adds httplib specific User-Agent tests and User-Agent asserts to several existing S3/HTTP tests.