### PR TITLE
Fix S3 LIST throwing a stale transient error after a successful retry

### DIFF
--- a/src/httpfs_httplib_client.cpp
+++ b/src/httpfs_httplib_client.cpp
@@ -59,7 +59,11 @@ public:
 		}
 		auto headers = TransformHeaders(info.headers, info.params);
 		if (!info.response_handler && !info.content_handler) {
-			return TransformResult(client->Get(info.path, headers));
+			auto result = TransformResult(client->Get(info.path, headers));
+			if (state) {
+				state->total_bytes_received += result->body.size();
+			}
+			return result;
 		} else {
 			return TransformResult(client->Get(
 			    info.path.c_str(), headers,

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1948,30 +1948,19 @@ string AWSListObjectV2::Request(const string &path, HTTPParams &http_params, S3A
 		} else {
 			actual_path += "/" + listobjectv2_url;
 		}
-		std::stringstream response_body;
-		ErrorData error;
-		GetRequestInfo get_request(
-		    actual_path, header_map, http_params,
-		    [&](const HTTPResponse &response) {
-			    // This handler runs once per retry attempt: reset state from a previous
-			    // failed attempt so a transient error (e.g. an S3 503) is not thrown
-			    // below after a retry has already succeeded
-			    response_body.str("");
-			    error = ErrorData();
-			    if (static_cast<int>(response.status) >= 400) {
-				    string trimmed_path = path;
-				    StringUtil::RTrim(trimmed_path, "/");
-				    error = ErrorData(S3FileSystem::GetS3Error(s3_auth_params, response, trimmed_path));
-			    }
-			    return true;
-		    },
-		    [&](const_data_ptr_t data, idx_t data_length) {
-			    response_body << string(const_char_ptr_cast(data), data_length);
-			    return true;
-		    });
+		// Buffer the response in HTTPResponse instead of streaming it through callbacks. The retry classifier needs the
+		// complete S3 error body to distinguish RequestTimeout (HTTP 400), and callbacks otherwise retain per-attempt
+		// state across HTTPUtil's internal retry loop.
+		GetRequestInfo get_request(actual_path, header_map, http_params, nullptr, nullptr);
 		auto result = http_params.http_util.Request(get_request);
 		if (result->HasRequestError()) {
 			throw IOException("%s error for HTTP GET to '%s'", result->GetRequestError(), listobjectv2_url);
+		}
+		ErrorData error;
+		if (static_cast<int>(result->status) >= 400) {
+			string trimmed_path = path;
+			StringUtil::RTrim(trimmed_path, "/");
+			error = ErrorData(S3FileSystem::GetS3Error(s3_auth_params, *result, trimmed_path));
 		}
 		// check
 		string updated_bucket_region;
@@ -2022,7 +2011,7 @@ string AWSListObjectV2::Request(const string &path, HTTPParams &http_params, S3A
 			retried_region = true;
 			continue;
 		}
-		return response_body.str();
+		return std::move(result->body);
 	}
 	throw InvalidInputException(
 	    "Exceeded retry count in AWSListObjectV2::Request while retrying region redirects or credential refresh");

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1894,11 +1894,16 @@ string AWSListObjectV2::Request(const string &path, HTTPParams &http_params, S3A
 		} else {
 			actual_path += "/" + listobjectv2_url;
 		}
-		std::stringstream response;
+		std::stringstream response_body;
 		ErrorData error;
 		GetRequestInfo get_request(
 		    actual_path, header_map, http_params,
 		    [&](const HTTPResponse &response) {
+			    // This handler runs once per retry attempt: reset state from a previous
+			    // failed attempt so a transient error (e.g. an S3 503) is not thrown
+			    // below after a retry has already succeeded
+			    response_body.str("");
+			    error = ErrorData();
 			    if (static_cast<int>(response.status) >= 400) {
 				    string trimmed_path = path;
 				    StringUtil::RTrim(trimmed_path, "/");
@@ -1907,7 +1912,7 @@ string AWSListObjectV2::Request(const string &path, HTTPParams &http_params, S3A
 			    return true;
 		    },
 		    [&](const_data_ptr_t data, idx_t data_length) {
-			    response << string(const_char_ptr_cast(data), data_length);
+			    response_body << string(const_char_ptr_cast(data), data_length);
 			    return true;
 		    });
 		auto result = http_params.http_util.Request(get_request);
@@ -1963,7 +1968,7 @@ string AWSListObjectV2::Request(const string &path, HTTPParams &http_params, S3A
 			retried_region = true;
 			continue;
 		}
-		return response.str();
+		return response_body.str();
 	}
 	throw InvalidInputException(
 	    "Exceeded retry count in AWSListObjectV2::Request while retrying region redirects or credential refresh");

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -4,8 +4,9 @@ include_directories(${CMAKE_SOURCE_DIR}/third_party)
 include_directories(${DUCKDB_MODULE_BASE_DIR}/third_party/httplib)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../src/include)
 
-add_executable(unittest_httpfs EXCLUDE_FROM_ALL main.cpp mock_s3_server.cpp
-                                                httpfs_refresh_test.cpp)
+add_executable(
+  unittest_httpfs EXCLUDE_FROM_ALL
+  main.cpp mock_s3_server.cpp httpfs_refresh_test.cpp s3_list_retry_test.cpp)
 set_target_properties(unittest_httpfs PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                                  ${CMAKE_BINARY_DIR}/test)
 

--- a/test/unittest/mock_s3_server.cpp
+++ b/test/unittest/mock_s3_server.cpp
@@ -5,6 +5,7 @@
 
 #include "httplib.hpp"
 
+#include <atomic>
 #include <cstring>
 #include <mutex>
 #include <thread>
@@ -138,6 +139,13 @@ struct MockS3Server::Impl {
 		response.set_header("ETag", config.etag);
 	}
 
+	void SendSlowDown(const httplib::Request &request, httplib::Response &response) const {
+		response.status = 503;
+		response.set_content("<Error><Code>SlowDown</Code><Message>Please reduce your request rate.</Message></Error>",
+		                     "application/xml");
+		Record(request, response.status);
+	}
+
 	void SendForbidden(const httplib::Request &request, httplib::Response &response) const {
 		response.status = 403;
 		response.set_content("<Error><Code>AccessDenied</Code><Message>stale credentials</Message></Error>",
@@ -254,6 +262,10 @@ struct MockS3Server::Impl {
 				SendForbidden(request, response);
 				return;
 			}
+			if (config.transient_503_lists > 0 && transient_503_lists_sent.fetch_add(1) < config.transient_503_lists) {
+				SendSlowDown(request, response);
+				return;
+			}
 			SendListObjectsSuccess(request, response);
 		};
 		server.Get(bucket_path, list_objects);
@@ -296,6 +308,7 @@ struct MockS3Server::Impl {
 	}
 
 	MockS3ServerConfig config;
+	mutable std::atomic<idx_t> transient_503_lists_sent {0};
 	httplib::Server server;
 	std::thread server_thread;
 	int port = 0;

--- a/test/unittest/mock_s3_server.cpp
+++ b/test/unittest/mock_s3_server.cpp
@@ -301,6 +301,10 @@ struct MockS3Server::Impl {
 				SendSlowDown(request, response);
 				return;
 			}
+			if (config.transient_400_lists > 0 && transient_400_lists_sent.fetch_add(1) < config.transient_400_lists) {
+				SendS3Error400(request, response, config.failure_is_request_timeout);
+				return;
+			}
 			SendListObjectsSuccess(request, response);
 		};
 		server.Get(bucket_path, list_objects);
@@ -364,6 +368,7 @@ struct MockS3Server::Impl {
 
 	MockS3ServerConfig config;
 	mutable std::atomic<idx_t> transient_503_lists_sent {0};
+	mutable std::atomic<idx_t> transient_400_lists_sent {0};
 	httplib::Server server;
 	std::thread server_thread;
 	int port = 0;

--- a/test/unittest/mock_s3_server.hpp
+++ b/test/unittest/mock_s3_server.hpp
@@ -25,6 +25,8 @@ struct MockS3ServerConfig {
 	MockS3RefreshTarget refresh_target = MockS3RefreshTarget::HEAD;
 	//! Answer this many leading ListObjectsV2 requests with HTTP 503 SlowDown
 	idx_t transient_503_lists = 0;
+	//! Answer this many leading ListObjectsV2 requests with HTTP 400
+	idx_t transient_400_lists = 0;
 	//! Number of object PUTs to fail with a 400 before succeeding
 	idx_t transient_put_failures = 0;
 	//! Number of object GETs to fail with a 400 before succeeding

--- a/test/unittest/mock_s3_server.hpp
+++ b/test/unittest/mock_s3_server.hpp
@@ -23,6 +23,8 @@ struct MockS3ServerConfig {
 	string stale_key_id = "STALE_KEY";
 	string etag = "\"httpfs-refresh-test-etag\"";
 	MockS3RefreshTarget refresh_target = MockS3RefreshTarget::HEAD;
+	//! Answer this many leading ListObjectsV2 requests with HTTP 503 SlowDown
+	idx_t transient_503_lists = 0;
 };
 
 struct MockS3RequestObservation {

--- a/test/unittest/s3_list_retry_test.cpp
+++ b/test/unittest/s3_list_retry_test.cpp
@@ -30,18 +30,27 @@ static void RequireQueryOk(Connection &con, const string &query) {
 	REQUIRE_FALSE(result->HasError());
 }
 
-static void ConfigureListRetryTest(DuckDB &db, Connection &con, MockS3Server &server) {
+static void ConfigureListRetryTest(DuckDB &db, Connection &con, MockS3Server &server,
+                                   const string &client_implementation, idx_t retries) {
 	LoadHTTPFSExtension(db);
 
-	RequireQueryOk(con, "SET http_retries=5");
-	RequireQueryOk(con, "SET http_retry_wait_ms=50");
+	RequireQueryOk(con, StringUtil::Format("SET httpfs_client_implementation='%s'", client_implementation));
+	RequireQueryOk(con, "SET http_retries=" + to_string(retries));
+	RequireQueryOk(con, "SET http_retry_wait_ms=1");
 	RequireQueryOk(con, "SET http_retry_backoff=2");
-	RequireQueryOk(con, StringUtil::Format("SET s3_endpoint='%s'", server.Endpoint()));
-	RequireQueryOk(con, "SET s3_region='us-east-1'");
-	RequireQueryOk(con, "SET s3_use_ssl=false");
-	RequireQueryOk(con, "SET s3_url_style='path'");
-	RequireQueryOk(con, "SET s3_access_key_id='FRESH_KEY'");
-	RequireQueryOk(con, "SET s3_secret_access_key='FRESH_SECRET'");
+	RequireQueryOk(con, StringUtil::Format(R"(
+CREATE SECRET list_retry_s3 (
+	TYPE S3,
+	PROVIDER CONFIG,
+	SCOPE 's3://refresh-bucket/',
+	KEY_ID 'FRESH_KEY',
+	SECRET 'FRESH_SECRET',
+	REGION 'us-east-1',
+	ENDPOINT '%s',
+	USE_SSL false,
+	URL_STYLE 'path'
+))",
+	                                       server.Endpoint()));
 }
 
 static idx_t CountListObservations(const vector<MockS3RequestObservation> &observations, int status) {
@@ -55,53 +64,119 @@ static idx_t CountListObservations(const vector<MockS3RequestObservation> &obser
 	return result;
 }
 
-} // namespace
-
-TEST_CASE("S3 glob recovers from a transient 503 on ListObjectsV2", "[httpfs][s3][retry]") {
+static void RunRecoveringListRetryTest(const string &client_implementation, int status) {
 	MockS3ServerConfig config;
-	config.transient_503_lists = 1;
+	if (status == 503) {
+		config.transient_503_lists = 1;
+	} else {
+		D_ASSERT(status == 400);
+		config.transient_400_lists = 1;
+	}
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
 	Connection con(db);
-	ConfigureListRetryTest(db, con, server);
+	ConfigureListRetryTest(db, con, server, client_implementation, 2);
 
-	// The first LIST returns 503 SlowDown; the in-request retry must recover
-	// instead of throwing the first attempt's error after the fact
 	auto result = con.Query("SELECT file FROM glob('s3://refresh-bucket/*.bin') ORDER BY file");
 	REQUIRE(result);
+	auto observations = server.Observations();
 	INFO((result->HasError() ? result->GetError() : string()));
+	INFO(MockS3DescribeObservations(observations));
 	REQUIRE_FALSE(result->HasError());
 	REQUIRE(result->RowCount() == 1);
-	// The recovered listing parses cleanly: the SlowDown error body from the
-	// failed attempt must not be prepended to the response
 	REQUIRE(result->GetValue(0, 0).ToString() == "s3://refresh-bucket/object.bin");
 
-	auto observations = server.Observations();
-	INFO(MockS3DescribeObservations(observations));
-	REQUIRE(CountListObservations(observations, 503) == 1);
+	REQUIRE(CountListObservations(observations, status) == 1);
 	REQUIRE(CountListObservations(observations, 200) >= 1);
 }
 
-TEST_CASE("S3 glob still fails when 503s outlast the configured retries", "[httpfs][s3][retry]") {
+static void RunExhaustedListRetryTest(const string &client_implementation, int status) {
 	MockS3ServerConfig config;
-	config.transient_503_lists = 1000;
+	if (status == 503) {
+		config.transient_503_lists = 1000;
+	} else {
+		D_ASSERT(status == 400);
+		config.transient_400_lists = 1000;
+	}
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
 	Connection con(db);
-	ConfigureListRetryTest(db, con, server);
+	ConfigureListRetryTest(db, con, server, client_implementation, 2);
 
 	auto result = con.Query("SELECT file FROM glob('s3://refresh-bucket/*.bin')");
 	REQUIRE(result);
 	REQUIRE(result->HasError());
-	REQUIRE(StringUtil::Contains(result->GetError(), "503"));
+	REQUIRE(StringUtil::Contains(result->GetError(), to_string(status)));
 
 	auto observations = server.Observations();
 	INFO(MockS3DescribeObservations(observations));
-	// initial attempt + http_retries, all 503
-	REQUIRE(CountListObservations(observations, 503) == 6);
+	// One initial attempt plus two retries.
+	REQUIRE(CountListObservations(observations, status) == 3);
 	REQUIRE(CountListObservations(observations, 200) == 0);
+}
+
+static void RunGeneric400ListTest(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.transient_400_lists = 1000;
+	config.failure_is_request_timeout = false;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureListRetryTest(db, con, server, client_implementation, 2);
+
+	auto result = con.Query("SELECT file FROM glob('s3://refresh-bucket/*.bin')");
+	REQUIRE(result);
+	REQUIRE(result->HasError());
+	REQUIRE(StringUtil::Contains(result->GetError(), "InvalidRequest"));
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(CountListObservations(observations, 400) == 1);
+	REQUIRE(CountListObservations(observations, 200) == 0);
+}
+
+} // namespace
+
+TEST_CASE("S3 glob recovers from transient ListObjectsV2 errors", "[httpfs][s3][retry]") {
+	SECTION("httplib retries 503") {
+		RunRecoveringListRetryTest("httplib", 503);
+	}
+	SECTION("curl retries 503") {
+		RunRecoveringListRetryTest("curl", 503);
+	}
+	SECTION("httplib retries 400 RequestTimeout") {
+		RunRecoveringListRetryTest("httplib", 400);
+	}
+	SECTION("curl retries 400 RequestTimeout") {
+		RunRecoveringListRetryTest("curl", 400);
+	}
+}
+
+TEST_CASE("S3 glob exhausts retries for persistent transient ListObjectsV2 errors", "[httpfs][s3][retry]") {
+	SECTION("httplib exhausts 503 retries") {
+		RunExhaustedListRetryTest("httplib", 503);
+	}
+	SECTION("curl exhausts 503 retries") {
+		RunExhaustedListRetryTest("curl", 503);
+	}
+	SECTION("httplib exhausts 400 RequestTimeout retries") {
+		RunExhaustedListRetryTest("httplib", 400);
+	}
+	SECTION("curl exhausts 400 RequestTimeout retries") {
+		RunExhaustedListRetryTest("curl", 400);
+	}
+}
+
+TEST_CASE("S3 glob does not retry a generic ListObjectsV2 400", "[httpfs][s3][retry]") {
+	SECTION("httplib") {
+		RunGeneric400ListTest("httplib");
+	}
+	SECTION("curl") {
+		RunGeneric400ListTest("curl");
+	}
 }
 
 } // namespace duckdb

--- a/test/unittest/s3_list_retry_test.cpp
+++ b/test/unittest/s3_list_retry_test.cpp
@@ -1,0 +1,107 @@
+#include "catch.hpp"
+
+#include "mock_s3_server.hpp"
+
+#include "httpfs_extension.hpp"
+
+#include "duckdb.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+namespace {
+
+static void LoadHTTPFSExtension(DuckDB &db) {
+	if (db.ExtensionIsLoaded("httpfs")) {
+		return;
+	}
+	ExtensionInfo extension_info;
+	ExtensionActiveLoad load_info(*db.instance, extension_info, "httpfs");
+	ExtensionLoader loader(load_info);
+	HttpfsExtension extension;
+	extension.Load(loader);
+}
+
+static void RequireQueryOk(Connection &con, const string &query) {
+	auto result = con.Query(query);
+	REQUIRE(result);
+	INFO((result->HasError() ? result->GetError() : string()));
+	REQUIRE_FALSE(result->HasError());
+}
+
+static void ConfigureListRetryTest(DuckDB &db, Connection &con, MockS3Server &server) {
+	LoadHTTPFSExtension(db);
+
+	RequireQueryOk(con, "SET http_retries=5");
+	RequireQueryOk(con, "SET http_retry_wait_ms=50");
+	RequireQueryOk(con, "SET http_retry_backoff=2");
+	RequireQueryOk(con, StringUtil::Format("SET s3_endpoint='%s'", server.Endpoint()));
+	RequireQueryOk(con, "SET s3_region='us-east-1'");
+	RequireQueryOk(con, "SET s3_use_ssl=false");
+	RequireQueryOk(con, "SET s3_url_style='path'");
+	RequireQueryOk(con, "SET s3_access_key_id='FRESH_KEY'");
+	RequireQueryOk(con, "SET s3_secret_access_key='FRESH_SECRET'");
+}
+
+static idx_t CountListObservations(const vector<MockS3RequestObservation> &observations, int status) {
+	idx_t result = 0;
+	for (auto &observation : observations) {
+		if (observation.method == "GET" && observation.target.find("list-type=2") != string::npos &&
+		    observation.status == status) {
+			result++;
+		}
+	}
+	return result;
+}
+
+} // namespace
+
+TEST_CASE("S3 glob recovers from a transient 503 on ListObjectsV2", "[httpfs][s3][retry]") {
+	MockS3ServerConfig config;
+	config.transient_503_lists = 1;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureListRetryTest(db, con, server);
+
+	// The first LIST returns 503 SlowDown; the in-request retry must recover
+	// instead of throwing the first attempt's error after the fact
+	auto result = con.Query("SELECT file FROM glob('s3://refresh-bucket/*.bin') ORDER BY file");
+	REQUIRE(result);
+	INFO((result->HasError() ? result->GetError() : string()));
+	REQUIRE_FALSE(result->HasError());
+	REQUIRE(result->RowCount() == 1);
+	// The recovered listing parses cleanly: the SlowDown error body from the
+	// failed attempt must not be prepended to the response
+	REQUIRE(result->GetValue(0, 0).ToString() == "s3://refresh-bucket/object.bin");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(CountListObservations(observations, 503) == 1);
+	REQUIRE(CountListObservations(observations, 200) >= 1);
+}
+
+TEST_CASE("S3 glob still fails when 503s outlast the configured retries", "[httpfs][s3][retry]") {
+	MockS3ServerConfig config;
+	config.transient_503_lists = 1000;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureListRetryTest(db, con, server);
+
+	auto result = con.Query("SELECT file FROM glob('s3://refresh-bucket/*.bin')");
+	REQUIRE(result);
+	REQUIRE(result->HasError());
+	REQUIRE(StringUtil::Contains(result->GetError(), "503"));
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	// initial attempt + http_retries, all 503
+	REQUIRE(CountListObservations(observations, 503) == 6);
+	REQUIRE(CountListObservations(observations, 200) == 0);
+}
+
+} // namespace duckdb


### PR DESCRIPTION
Fixes #361.

## Problem

`AWSListObjectV2::Request` installs a response handler that records any >=400 status into an `ErrorData` captured by reference, and throws it after `http_util.Request()` returns. The handler runs once per attempt of the retry loop in `HTTPUtil::Request`, but nothing resets that state between attempts. A transient error on the first attempt (an S3 503 SlowDown, for example) is therefore thrown even when the configured `http_retries` succeed on a later attempt. The response body has the same problem: each attempt appends to the same stringstream, so a recovered response would be parsed with the failed attempt's error XML prepended.

Net effect: every S3 glob (`parquet_scan` over a prefix) fails on a single transient 503 regardless of `http_retries`, while object-level GET/HEAD retries behave as configured. We hit this in production nightly batch runs, where an ordinary one-off SlowDown on one LIST call fails the whole query in ~100ms even with `http_retries=10`.

## Fix

Reset the captured error and body at the top of the response handler so each attempt starts clean. The >=400 capture itself is unchanged: a request that exhausts its retries still surfaces the detailed S3 error, and non-retryable statuses still fail fast. The body stringstream was shadowed by the handler's `response` parameter, so it is renamed to `response_body`.

## Tests

Uses the `unittest_httpfs` harness from #358:

- `MockS3ServerConfig` gets a `transient_503_lists` option: answer the first N ListObjectsV2 requests with 503 SlowDown, then recover.
- `test/unittest/s3_list_retry_test.cpp` adds two cases:
  - a `glob()` that must recover from a single transient 503 — the observations assert the retry actually happened (one 503 LIST followed by a 200) and that the recovered listing parses cleanly. This case fails without the fix, with the exact error from #361.
  - a persistent-503 control that must keep failing, after exactly `1 + http_retries` LIST attempts.

Full `unittest_httpfs` suite passes (existing refresh cases included), and `make format-check` is clean.

Targeting `v1.5-variegata` since that is where the unittest harness lives and where this code path is actively developed; happy to forward-port to `main` (same fix applies, the code there is at the pre-#358 shape) if useful.
