### PR TITLE
Retry transient S3 RequestTimeout (400) on multipart part upload

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
     with:
       extension_name: httpfs
-      duckdb_version: v1.5.4
+      duckdb_version: 983f81bd2dbf3e3eebbaf4b7e2fb04ab1bb058aa
       ci_tools_version: v1.5-variegata
 
   duckdb-stable-deploy:
@@ -27,7 +27,7 @@ jobs:
     secrets: inherit
     with:
       extension_name: httpfs
-      duckdb_version: v1.5.4
+      duckdb_version: 983f81bd2dbf3e3eebbaf4b7e2fb04ab1bb058aa
       ci_tools_version: v1.5-variegata
       deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') }}
       deploy_versioned: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}
@@ -37,7 +37,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@v1.5-variegata
     with:
       extension_name: httpfs
-      duckdb_version: v1.5.4
+      duckdb_version: 983f81bd2dbf3e3eebbaf4b7e2fb04ab1bb058aa
       ci_tools_version: v1.5-variegata
       extra_toolchains: 'python3'
       format_checks: 'format'

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -1123,6 +1123,18 @@ void HTTPFSUtil::ClearCachedConnections() {
 	// no-op by default
 }
 
+bool HTTPFSUtil::ShouldRetry(const BaseRequest &request, const HTTPResponse &response) {
+	if (HTTPUtil::ShouldRetry(request, response)) {
+		return true;
+	}
+	// Replaying a request requires idempotency: retrying a multipart-init POST would orphan a second upload,
+	// and multipart-complete/bulk-delete are ambiguous.
+	if (!HTTPUtil::IsIdempotent(request.type)) {
+		return false;
+	}
+	return IsS3RequestTimeout(response);
+}
+
 string HTTPFSUtil::GetName() const {
 	return "HTTPFS";
 }

--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -81,6 +81,7 @@ public:
 	unique_ptr<HTTPParams> InitializeParameters(optional_ptr<FileOpener> opener,
 	                                            optional_ptr<FileOpenerInfo> info) override;
 	unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
+	bool ShouldRetry(const BaseRequest &request, const HTTPResponse &response) override;
 
 	//! Clear any cached connections
 	virtual void ClearCachedConnections();

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -280,4 +280,7 @@ struct AWSListObjectV2 {
 HTTPHeaders CreateS3Header(string url, string query, string host, string service, string method,
                            const S3AuthParams &auth_params, string date_now = "", string datetime_now = "",
                            string payload_hash = "", string content_type = "", string content_md5 = "");
+
+//! Whether the response is S3's RequestTimeout error (a stalled socket reported as HTTP 400)
+bool IsS3RequestTimeout(const HTTPResponse &response);
 } // namespace duckdb

--- a/src/s3_multi_part_upload.cpp
+++ b/src/s3_multi_part_upload.cpp
@@ -131,8 +131,7 @@ void S3MultiPartUpload::UploadBufferImplementation(shared_ptr<S3WriteBuffer> wri
 	string etag;
 
 	try {
-		// Transient S3 errors (e.g. RequestTimeout) are retried inside PutRequest by the shared S3 request
-		// loop; a non-OK status here is therefore already final.
+		// Transient S3 errors are retried inside PutRequest; a non-OK status here is already final.
 		res = s3fs.PutRequest(*http_input, path, {}, (char *)write_buffer->Ptr(), write_buffer->idx, query_param);
 
 		if (res->status != HTTPStatusCode::OK_200) {

--- a/src/s3_multi_part_upload.cpp
+++ b/src/s3_multi_part_upload.cpp
@@ -1,5 +1,7 @@
 #include "s3_multi_part_upload.hpp"
 
+#include "duckdb/common/chrono.hpp"
+
 #include <thread>
 #ifdef EMSCRIPTEN
 #define SAME_THREAD_UPLOAD
@@ -125,17 +127,41 @@ void S3MultiPartUpload::UploadSingleBuffer(shared_ptr<S3WriteBuffer> write_buffe
 	UploadBufferImplementation(write_buffer, "", true);
 }
 
+// S3 signals a stalled part upload as HTTP 400 with <Code>RequestTimeout</Code> instead of 408, so
+// core's status-based retry (which only retries 408/429/5xx) does not catch it. Re-PUTting a part is
+// idempotent, so treat this specific 400 as transient and retry it locally.
+static bool IsTransientS3UploadError(const HTTPResponse &res) {
+	if (res.status != HTTPStatusCode::BadRequest_400) {
+		return false;
+	}
+	return res.body.find("RequestTimeout") != string::npos;
+}
+
 void S3MultiPartUpload::UploadBufferImplementation(shared_ptr<S3WriteBuffer> write_buffer, string query_param,
                                                    bool single_upload) {
 	unique_ptr<HTTPResponse> res;
 	string etag;
+	auto &http_params = http_input->http_params;
 
 	try {
-		res = s3fs.PutRequest(*http_input, path, {}, (char *)write_buffer->Ptr(), write_buffer->idx, query_param);
-
-		if (res->status != HTTPStatusCode::OK_200) {
-			throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", path, res->GetError(),
-			                    static_cast<int>(res->status));
+		// Retry the S3 RequestTimeout 400 using the same knobs as the core retry loop (no wait on the
+		// first retry, then retry_wait_ms scaled by retry_backoff), since core will not retry a 400.
+		uint64_t attempt = 0;
+		double wait_ms = static_cast<double>(http_params.retry_wait_ms);
+		for (;;) {
+			res = s3fs.PutRequest(*http_input, path, {}, (char *)write_buffer->Ptr(), write_buffer->idx, query_param);
+			if (res->status == HTTPStatusCode::OK_200) {
+				break;
+			}
+			if (attempt >= http_params.retries || !IsTransientS3UploadError(*res)) {
+				throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", path, res->GetError(),
+				                    static_cast<int>(res->status));
+			}
+			if (attempt > 0) {
+				std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<uint64_t>(wait_ms)));
+				wait_ms *= http_params.retry_backoff;
+			}
+			attempt++;
 		}
 
 		if (!res->headers.HasHeader("ETag")) {

--- a/src/s3_multi_part_upload.cpp
+++ b/src/s3_multi_part_upload.cpp
@@ -127,9 +127,8 @@ void S3MultiPartUpload::UploadSingleBuffer(shared_ptr<S3WriteBuffer> write_buffe
 	UploadBufferImplementation(write_buffer, "", true);
 }
 
-// S3 signals a stalled part upload as HTTP 400 with <Code>RequestTimeout</Code> instead of 408, so
-// core's status-based retry (which only retries 408/429/5xx) does not catch it. Re-PUTting a part is
-// idempotent, so treat this specific 400 as transient and retry it locally.
+// S3 reports a stalled part upload as 400 RequestTimeout (not 408), so core's status-based retry
+// misses it. Re-PUTting a part is idempotent, so retry this specific 400 locally.
 static bool IsTransientS3UploadError(const HTTPResponse &res) {
 	if (res.status != HTTPStatusCode::BadRequest_400) {
 		return false;
@@ -144,8 +143,7 @@ void S3MultiPartUpload::UploadBufferImplementation(shared_ptr<S3WriteBuffer> wri
 	auto &http_params = http_input->http_params;
 
 	try {
-		// Retry the S3 RequestTimeout 400 using the same knobs as the core retry loop (no wait on the
-		// first retry, then retry_wait_ms scaled by retry_backoff), since core will not retry a 400.
+		// Reuse the core retry knobs; no wait on the first retry, then back off (mirrors core).
 		uint64_t attempt = 0;
 		double wait_ms = static_cast<double>(http_params.retry_wait_ms);
 		for (;;) {

--- a/src/s3_multi_part_upload.cpp
+++ b/src/s3_multi_part_upload.cpp
@@ -1,7 +1,5 @@
 #include "s3_multi_part_upload.hpp"
 
-#include "duckdb/common/chrono.hpp"
-
 #include <thread>
 #ifdef EMSCRIPTEN
 #define SAME_THREAD_UPLOAD
@@ -127,39 +125,19 @@ void S3MultiPartUpload::UploadSingleBuffer(shared_ptr<S3WriteBuffer> write_buffe
 	UploadBufferImplementation(write_buffer, "", true);
 }
 
-// S3 reports a stalled part upload as 400 RequestTimeout (not 408), so core's status-based retry
-// misses it. Re-PUTting a part is idempotent, so retry this specific 400 locally.
-static bool IsTransientS3UploadError(const HTTPResponse &res) {
-	if (res.status != HTTPStatusCode::BadRequest_400) {
-		return false;
-	}
-	return res.body.find("RequestTimeout") != string::npos;
-}
-
 void S3MultiPartUpload::UploadBufferImplementation(shared_ptr<S3WriteBuffer> write_buffer, string query_param,
                                                    bool single_upload) {
 	unique_ptr<HTTPResponse> res;
 	string etag;
-	auto &http_params = http_input->http_params;
 
 	try {
-		// Reuse the core retry knobs; no wait on the first retry, then back off (mirrors core).
-		uint64_t attempt = 0;
-		double wait_ms = static_cast<double>(http_params.retry_wait_ms);
-		for (;;) {
-			res = s3fs.PutRequest(*http_input, path, {}, (char *)write_buffer->Ptr(), write_buffer->idx, query_param);
-			if (res->status == HTTPStatusCode::OK_200) {
-				break;
-			}
-			if (attempt >= http_params.retries || !IsTransientS3UploadError(*res)) {
-				throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", path, res->GetError(),
-				                    static_cast<int>(res->status));
-			}
-			if (attempt > 0) {
-				std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<uint64_t>(wait_ms)));
-				wait_ms *= http_params.retry_backoff;
-			}
-			attempt++;
+		// Transient S3 errors (e.g. RequestTimeout) are retried inside PutRequest by the shared S3 request
+		// loop; a non-OK status here is therefore already final.
+		res = s3fs.PutRequest(*http_input, path, {}, (char *)write_buffer->Ptr(), write_buffer->idx, query_param);
+
+		if (res->status != HTTPStatusCode::OK_200) {
+			throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)%s", path, res->GetError(),
+			                    static_cast<int>(res->status), S3FileSystem::ParseS3Error(res->body));
 		}
 
 		if (!res->headers.HasHeader("ETag")) {

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -408,7 +408,7 @@ static optional_idx GetRegionRedirect(const ErrorData &error, const S3AuthParams
 }
 
 // Defined later in this file.
-optional_idx FindTagContents(const string &response, const string &tag, idx_t cur_pos, string &result);
+optional_idx TryFindTagContents(const string &response, const string &tag, idx_t cur_pos, string &result);
 
 // Some transient S3 conditions surface as a status core won't retry (e.g. a stalled socket -> HTTP 400
 // with <Code>RequestTimeout</Code>); the discriminator is only in the S3 error <Code>, hence classified here.
@@ -421,7 +421,7 @@ static bool ParseTransientS3Error(int status_code, const string &body, string &c
 		return false;
 	}
 	string code;
-	if (!FindTagContents(body, "Code", 0, code).IsValid() || !IsRetryableS3ErrorCode(code)) {
+	if (!TryFindTagContents(body, "Code", 0, code).IsValid() || !IsRetryableS3ErrorCode(code)) {
 		return false;
 	}
 	code_out = std::move(code);
@@ -454,7 +454,9 @@ static void SleepForTransientRetry(const HTTPFSParams &http_params, idx_t transi
 		wait_ms = static_cast<double>(http_params.retry_wait_ms);
 		return;
 	}
+#ifndef DUCKDB_NO_THREADS
 	ThreadUtil::SleepMs(static_cast<idx_t>(wait_ms));
+#endif
 	wait_ms *= http_params.retry_backoff;
 }
 
@@ -562,7 +564,10 @@ static unique_ptr<HTTPResponse> SendS3HandleRequestWithClientCache(S3FileHandle 
                                                                    BaseRequest &request) {
 	auto client_entry = s3_handle.client_cache.GetClientWithGeneration();
 	auto response = params.http_util.Request(request, client_entry.client);
-	if (!s3_handle.client_cache.StoreClient(client_entry)) {
+	string transient_code;
+	// A transient timeout means this connection stalled; don't hand it back to the cache for the retry.
+	if ((response && IsTransientS3Error(*response, transient_code)) ||
+	    !s3_handle.client_cache.StoreClient(client_entry)) {
 		params.http_util.CloseClient(std::move(client_entry.client));
 	}
 	return response;
@@ -1810,7 +1815,9 @@ bool S3FileSystem::ListFilesExtended(const string &directory, const std::functio
 	return true;
 }
 
-optional_idx FindTagContents(const string &response, const string &tag, idx_t cur_pos, string &result) {
+// Tolerant variant for error bodies: a truncated/malformed body must not escalate to a DB-invalidating
+// InternalException, so an unmatched open tag is "not found".
+optional_idx TryFindTagContents(const string &response, const string &tag, idx_t cur_pos, string &result) {
 	string open_tag = "<" + tag + ">";
 	string close_tag = "</" + tag + ">";
 	auto open_tag_pos = response.find(open_tag, cur_pos);
@@ -1820,11 +1827,25 @@ optional_idx FindTagContents(const string &response, const string &tag, idx_t cu
 	}
 	auto close_tag_pos = response.find(close_tag, open_tag_pos + open_tag.size());
 	if (close_tag_pos == string::npos) {
-		throw InternalException("Failed to parse S3 result: found open tag for %s but did not find matching close tag",
-		                        tag);
+		return optional_idx();
 	}
 	result = response.substr(open_tag_pos + open_tag.size(), close_tag_pos - open_tag_pos - open_tag.size());
 	return close_tag_pos + close_tag.size();
+}
+
+optional_idx FindTagContents(const string &response, const string &tag, idx_t cur_pos, string &result) {
+	string open_tag = "<" + tag + ">";
+	auto open_tag_pos = response.find(open_tag, cur_pos);
+	if (open_tag_pos == string::npos) {
+		// tag not found
+		return optional_idx();
+	}
+	auto next_pos = TryFindTagContents(response, tag, cur_pos, result);
+	if (!next_pos.IsValid()) {
+		throw InternalException("Failed to parse S3 result: found open tag for %s but did not find matching close tag",
+		                        tag);
+	}
+	return next_pos;
 }
 
 string S3FileSystem::GetS3BadRequestError(const S3AuthParams &s3_auth_params, string correct_region) {
@@ -1882,26 +1903,26 @@ string S3FileSystem::ParseS3Error(const string &error) {
 	// find <Error> tag
 	string error_xml;
 	idx_t err_pos = 0;
-	auto next_pos = FindTagContents(error, "Error", err_pos, error_xml);
+	auto next_pos = TryFindTagContents(error, "Error", err_pos, error_xml);
 	if (!next_pos.IsValid()) {
 		return string();
 	}
 	// find <Code> and <Message>
 	string error_code, error_message, extra_error_data;
 	idx_t cur_pos = 0;
-	next_pos = FindTagContents(error_xml, "Code", cur_pos, error_code);
+	next_pos = TryFindTagContents(error_xml, "Code", cur_pos, error_code);
 	if (!next_pos.IsValid()) {
 		return string();
 	}
 	cur_pos = 0;
-	next_pos = FindTagContents(error_xml, "Message", cur_pos, error_message);
+	next_pos = TryFindTagContents(error_xml, "Message", cur_pos, error_message);
 	if (!next_pos.IsValid()) {
 		return string();
 	}
 	// depending on Code, find other info
 	if (error_code == "InvalidAccessKeyId") {
 		cur_pos = 0;
-		next_pos = FindTagContents(error_xml, "AWSAccessKeyId", cur_pos, extra_error_data);
+		next_pos = TryFindTagContents(error_xml, "AWSAccessKeyId", cur_pos, extra_error_data);
 		if (next_pos.IsValid()) {
 			extra_error_data = "\nInvalid Access Key: \"" + extra_error_data + "\"";
 		}

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -410,74 +410,24 @@ static optional_idx GetRegionRedirect(const ErrorData &error, const S3AuthParams
 // Defined later in this file.
 optional_idx TryFindTagContents(const string &response, const string &tag, idx_t cur_pos, string &result);
 
-// Some transient S3 conditions surface as a status core won't retry (e.g. a stalled socket -> HTTP 400
-// with <Code>RequestTimeout</Code>); the discriminator is only in the S3 error <Code>, hence classified here.
-static bool IsRetryableS3ErrorCode(const string &code) {
-	return code == "RequestTimeout";
-}
-
-static bool ParseTransientS3Error(int status_code, const string &body, string &code_out) {
-	if (status_code < 400 || body.empty()) {
+// Core's status-based retry can't catch this: the discriminator is only in the S3 error body.
+bool IsS3RequestTimeout(const HTTPResponse &response) {
+	if (response.status != HTTPStatusCode::BadRequest_400 || response.body.empty()) {
 		return false;
 	}
 	string code;
-	if (!TryFindTagContents(body, "Code", 0, code).IsValid() || !IsRetryableS3ErrorCode(code)) {
-		return false;
-	}
-	code_out = std::move(code);
-	return true;
-}
-
-static bool IsTransientS3Error(const HTTPResponse &response, string &code_out) {
-	return ParseTransientS3Error(static_cast<int>(response.status), response.body, code_out);
-}
-
-static bool IsTransientS3Error(const ErrorData &error, string &code_out) {
-	auto &extra_info = error.ExtraInfo();
-	auto status_entry = extra_info.find("status_code");
-	auto body_entry = extra_info.find("response_body");
-	if (status_entry == extra_info.end() || body_entry == extra_info.end()) {
-		return false;
-	}
-	int status_code;
-	try {
-		status_code = std::stoi(status_entry->second);
-	} catch (...) {
-		return false;
-	}
-	return ParseTransientS3Error(status_code, body_entry->second, code_out);
-}
-
-// No wait on the first retry, then retry_wait_ms scaled by retry_backoff (mirrors core's backoff).
-static void SleepForTransientRetry(const HTTPFSParams &http_params, idx_t transient_retries, double &wait_ms) {
-	if (transient_retries == 0) {
-		wait_ms = static_cast<double>(http_params.retry_wait_ms);
-		return;
-	}
-#ifndef DUCKDB_NO_THREADS
-	ThreadUtil::SleepMs(static_cast<idx_t>(wait_ms));
-#endif
-	wait_ms *= http_params.retry_backoff;
-}
-
-// Transient retries replay the whole request, so restrict them to idempotent methods. POST is excluded:
-// replaying multipart-init would orphan a second upload, and multipart-complete/bulk-delete are ambiguous.
-static bool IsTransientRetryEligibleMethod(const string &method) {
-	return method == "GET" || method == "HEAD" || method == "PUT" || method == "DELETE";
+	return TryFindTagContents(response.body, "Code", 0, code).IsValid() && code == "RequestTimeout";
 }
 
 template <class CREATE_DATA, class REQUEST, class REFRESH, class SET_REGION>
-static unique_ptr<HTTPResponse>
-RunS3RequestWithAuthRefreshInternal(const string &s3_url, bool transient_retry_eligible, CREATE_DATA create_data,
-                                    REQUEST request, REFRESH refresh_auth_params, SET_REGION set_region) {
-	// Auth refresh and region redirect are one-shot; transient S3 errors are retried with backoff up to http_retries.
+static unique_ptr<HTTPResponse> RunS3RequestWithAuthRefreshInternal(const string &s3_url, CREATE_DATA create_data,
+                                                                    REQUEST request, REFRESH refresh_auth_params,
+                                                                    SET_REGION set_region) {
+	// Auth refresh and region redirect are one-shot.
 	bool retried_auth_refresh = false;
 	bool retried_region = false;
-	idx_t transient_retries = 0;
-	double transient_wait_ms = 0;
 	for (;;) {
 		auto request_data = create_data();
-		auto &http_params = request_data.http_params->template Cast<HTTPFSParams>();
 		try {
 			auto result = request(request_data);
 			if (result && !retried_auth_refresh && IsAuthRefreshStatus(*result) &&
@@ -490,13 +440,6 @@ RunS3RequestWithAuthRefreshInternal(const string &s3_url, bool transient_retry_e
 			    GetRegionRedirect(*result, request_data.auth_params, correct_region).IsValid()) {
 				set_region(std::move(correct_region));
 				retried_region = true;
-				continue;
-			}
-			string s3_error_code;
-			if (transient_retry_eligible && result && transient_retries < http_params.retries &&
-			    IsTransientS3Error(*result, s3_error_code)) {
-				SleepForTransientRetry(http_params, transient_retries, transient_wait_ms);
-				transient_retries++;
 				continue;
 			}
 			return result;
@@ -513,13 +456,6 @@ RunS3RequestWithAuthRefreshInternal(const string &s3_url, bool transient_retry_e
 				retried_region = true;
 				continue;
 			}
-			string s3_error_code;
-			if (transient_retry_eligible && transient_retries < http_params.retries &&
-			    IsTransientS3Error(error, s3_error_code)) {
-				SleepForTransientRetry(http_params, transient_retries, transient_wait_ms);
-				transient_retries++;
-				continue;
-			}
 			throw;
 		}
 	}
@@ -531,7 +467,7 @@ S3FileSystem::RunS3InputRequestWithAuthRefresh(S3HTTPInput &s3_input, const stri
                                                const string &query_string, const string &payload_hash,
                                                const string &content_type, REQUEST request) {
 	return RunS3RequestWithAuthRefreshInternal(
-	    s3_url, IsTransientRetryEligibleMethod(method),
+	    s3_url,
 	    [&]() {
 		    lock_guard<mutex> lck(s3_input.mu);
 		    return CreateS3RequestData(s3_input.auth_params, s3_input.http_params, s3_url, method, query_string,
@@ -552,8 +488,7 @@ unique_ptr<HTTPResponse> S3FileSystem::RunS3HandleRequestWithAuthRefresh(S3FileH
                                                                          const string &method, bool use_version_id,
                                                                          REQUEST request) {
 	return RunS3RequestWithAuthRefreshInternal(
-	    s3_url, IsTransientRetryEligibleMethod(method),
-	    [&]() { return CreateS3HandleRequestData(s3_handle, s3_url, method, use_version_id); }, request,
+	    s3_url, [&]() { return CreateS3HandleRequestData(s3_handle, s3_url, method, use_version_id); }, request,
 	    [&](const S3AuthParams &request_auth_params, const S3RefreshableHTTPParams &request_http_params) {
 		    return s3_handle.TryRefreshAuthParams(request_auth_params, request_http_params);
 	    },
@@ -564,10 +499,7 @@ static unique_ptr<HTTPResponse> SendS3HandleRequestWithClientCache(S3FileHandle 
                                                                    BaseRequest &request) {
 	auto client_entry = s3_handle.client_cache.GetClientWithGeneration();
 	auto response = params.http_util.Request(request, client_entry.client);
-	string transient_code;
-	// A transient timeout means this connection stalled; don't hand it back to the cache for the retry.
-	if ((response && IsTransientS3Error(*response, transient_code)) ||
-	    !s3_handle.client_cache.StoreClient(client_entry)) {
+	if (!s3_handle.client_cache.StoreClient(client_entry)) {
 		params.http_util.CloseClient(std::move(client_entry.client));
 	}
 	return response;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -458,10 +458,16 @@ static void SleepForTransientRetry(const HTTPFSParams &http_params, idx_t transi
 	wait_ms *= http_params.retry_backoff;
 }
 
+// Transient retries replay the whole request, so restrict them to idempotent methods. POST is excluded:
+// replaying multipart-init would orphan a second upload, and multipart-complete/bulk-delete are ambiguous.
+static bool IsTransientRetryEligibleMethod(const string &method) {
+	return method == "GET" || method == "HEAD" || method == "PUT" || method == "DELETE";
+}
+
 template <class CREATE_DATA, class REQUEST, class REFRESH, class SET_REGION>
-static unique_ptr<HTTPResponse> RunS3RequestWithAuthRefreshInternal(const string &s3_url, CREATE_DATA create_data,
-                                                                    REQUEST request, REFRESH refresh_auth_params,
-                                                                    SET_REGION set_region) {
+static unique_ptr<HTTPResponse>
+RunS3RequestWithAuthRefreshInternal(const string &s3_url, bool transient_retry_eligible, CREATE_DATA create_data,
+                                    REQUEST request, REFRESH refresh_auth_params, SET_REGION set_region) {
 	// Auth refresh and region redirect are one-shot; transient S3 errors are retried with backoff up to http_retries.
 	bool retried_auth_refresh = false;
 	bool retried_region = false;
@@ -485,7 +491,8 @@ static unique_ptr<HTTPResponse> RunS3RequestWithAuthRefreshInternal(const string
 				continue;
 			}
 			string s3_error_code;
-			if (result && transient_retries < http_params.retries && IsTransientS3Error(*result, s3_error_code)) {
+			if (transient_retry_eligible && result && transient_retries < http_params.retries &&
+			    IsTransientS3Error(*result, s3_error_code)) {
 				SleepForTransientRetry(http_params, transient_retries, transient_wait_ms);
 				transient_retries++;
 				continue;
@@ -505,7 +512,8 @@ static unique_ptr<HTTPResponse> RunS3RequestWithAuthRefreshInternal(const string
 				continue;
 			}
 			string s3_error_code;
-			if (transient_retries < http_params.retries && IsTransientS3Error(error, s3_error_code)) {
+			if (transient_retry_eligible && transient_retries < http_params.retries &&
+			    IsTransientS3Error(error, s3_error_code)) {
 				SleepForTransientRetry(http_params, transient_retries, transient_wait_ms);
 				transient_retries++;
 				continue;
@@ -521,7 +529,7 @@ S3FileSystem::RunS3InputRequestWithAuthRefresh(S3HTTPInput &s3_input, const stri
                                                const string &query_string, const string &payload_hash,
                                                const string &content_type, REQUEST request) {
 	return RunS3RequestWithAuthRefreshInternal(
-	    s3_url,
+	    s3_url, IsTransientRetryEligibleMethod(method),
 	    [&]() {
 		    lock_guard<mutex> lck(s3_input.mu);
 		    return CreateS3RequestData(s3_input.auth_params, s3_input.http_params, s3_url, method, query_string,
@@ -542,7 +550,8 @@ unique_ptr<HTTPResponse> S3FileSystem::RunS3HandleRequestWithAuthRefresh(S3FileH
                                                                          const string &method, bool use_version_id,
                                                                          REQUEST request) {
 	return RunS3RequestWithAuthRefreshInternal(
-	    s3_url, [&]() { return CreateS3HandleRequestData(s3_handle, s3_url, method, use_version_id); }, request,
+	    s3_url, IsTransientRetryEligibleMethod(method),
+	    [&]() { return CreateS3HandleRequestData(s3_handle, s3_url, method, use_version_id); }, request,
 	    [&](const S3AuthParams &request_auth_params, const S3RefreshableHTTPParams &request_http_params) {
 		    return s3_handle.TryRefreshAuthParams(request_auth_params, request_http_params);
 	    },

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -407,12 +407,11 @@ static optional_idx GetRegionRedirect(const ErrorData &error, const S3AuthParams
 	return optional_idx(0);
 }
 
-// Defined later in this file; needed here to read the S3 error <Code> out of an error body.
+// Defined later in this file.
 optional_idx FindTagContents(const string &response, const string &tag, idx_t cur_pos, string &result);
 
-// Some S3 conditions are transient but surface as an HTTP status core does not retry (e.g. a stalled
-// socket -> HTTP 400 with <Code>RequestTimeout</Code>). The real reason lives in the S3 error <Code>,
-// which is why this is classified here in the S3 layer rather than in core's status-only retry.
+// Some transient S3 conditions surface as a status core won't retry (e.g. a stalled socket -> HTTP 400
+// with <Code>RequestTimeout</Code>); the discriminator is only in the S3 error <Code>, hence classified here.
 static bool IsRetryableS3ErrorCode(const string &code) {
 	return code == "RequestTimeout";
 }
@@ -463,9 +462,7 @@ template <class CREATE_DATA, class REQUEST, class REFRESH, class SET_REGION>
 static unique_ptr<HTTPResponse> RunS3RequestWithAuthRefreshInternal(const string &s3_url, CREATE_DATA create_data,
                                                                     REQUEST request, REFRESH refresh_auth_params,
                                                                     SET_REGION set_region) {
-	// create_data snapshots signed request material, request sends it, refresh_auth_params reloads changed
-	// credentials, set_region handles region redirects, and transient S3 errors are retried with backoff.
-	// auth refresh and region redirect are one-shot; transient retries are bounded by http_retries.
+	// Auth refresh and region redirect are one-shot; transient S3 errors are retried with backoff up to http_retries.
 	bool retried_auth_refresh = false;
 	bool retried_region = false;
 	idx_t transient_retries = 0;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -407,16 +407,72 @@ static optional_idx GetRegionRedirect(const ErrorData &error, const S3AuthParams
 	return optional_idx(0);
 }
 
+// Defined later in this file; needed here to read the S3 error <Code> out of an error body.
+optional_idx FindTagContents(const string &response, const string &tag, idx_t cur_pos, string &result);
+
+// Some S3 conditions are transient but surface as an HTTP status core does not retry (e.g. a stalled
+// socket -> HTTP 400 with <Code>RequestTimeout</Code>). The real reason lives in the S3 error <Code>,
+// which is why this is classified here in the S3 layer rather than in core's status-only retry.
+static bool IsRetryableS3ErrorCode(const string &code) {
+	return code == "RequestTimeout";
+}
+
+static bool ParseTransientS3Error(int status_code, const string &body, string &code_out) {
+	if (status_code < 400 || body.empty()) {
+		return false;
+	}
+	string code;
+	if (!FindTagContents(body, "Code", 0, code).IsValid() || !IsRetryableS3ErrorCode(code)) {
+		return false;
+	}
+	code_out = std::move(code);
+	return true;
+}
+
+static bool IsTransientS3Error(const HTTPResponse &response, string &code_out) {
+	return ParseTransientS3Error(static_cast<int>(response.status), response.body, code_out);
+}
+
+static bool IsTransientS3Error(const ErrorData &error, string &code_out) {
+	auto &extra_info = error.ExtraInfo();
+	auto status_entry = extra_info.find("status_code");
+	auto body_entry = extra_info.find("response_body");
+	if (status_entry == extra_info.end() || body_entry == extra_info.end()) {
+		return false;
+	}
+	int status_code;
+	try {
+		status_code = std::stoi(status_entry->second);
+	} catch (...) {
+		return false;
+	}
+	return ParseTransientS3Error(status_code, body_entry->second, code_out);
+}
+
+// No wait on the first retry, then retry_wait_ms scaled by retry_backoff (mirrors core's backoff).
+static void SleepForTransientRetry(const HTTPFSParams &http_params, idx_t transient_retries, double &wait_ms) {
+	if (transient_retries == 0) {
+		wait_ms = static_cast<double>(http_params.retry_wait_ms);
+		return;
+	}
+	ThreadUtil::SleepMs(static_cast<idx_t>(wait_ms));
+	wait_ms *= http_params.retry_backoff;
+}
+
 template <class CREATE_DATA, class REQUEST, class REFRESH, class SET_REGION>
 static unique_ptr<HTTPResponse> RunS3RequestWithAuthRefreshInternal(const string &s3_url, CREATE_DATA create_data,
                                                                     REQUEST request, REFRESH refresh_auth_params,
                                                                     SET_REGION set_region) {
-	// create_data snapshots signed request material, request sends it,
-	// refresh_auth_params reloads changed credentials, and set_region handles region redirects.
+	// create_data snapshots signed request material, request sends it, refresh_auth_params reloads changed
+	// credentials, set_region handles region redirects, and transient S3 errors are retried with backoff.
+	// auth refresh and region redirect are one-shot; transient retries are bounded by http_retries.
 	bool retried_auth_refresh = false;
 	bool retried_region = false;
-	for (idx_t attempt = 0; attempt < 3; attempt++) {
+	idx_t transient_retries = 0;
+	double transient_wait_ms = 0;
+	for (;;) {
 		auto request_data = create_data();
+		auto &http_params = request_data.http_params->template Cast<HTTPFSParams>();
 		try {
 			auto result = request(request_data);
 			if (result && !retried_auth_refresh && IsAuthRefreshStatus(*result) &&
@@ -429,6 +485,12 @@ static unique_ptr<HTTPResponse> RunS3RequestWithAuthRefreshInternal(const string
 			    GetRegionRedirect(*result, request_data.auth_params, correct_region).IsValid()) {
 				set_region(std::move(correct_region));
 				retried_region = true;
+				continue;
+			}
+			string s3_error_code;
+			if (result && transient_retries < http_params.retries && IsTransientS3Error(*result, s3_error_code)) {
+				SleepForTransientRetry(http_params, transient_retries, transient_wait_ms);
+				transient_retries++;
 				continue;
 			}
 			return result;
@@ -445,10 +507,15 @@ static unique_ptr<HTTPResponse> RunS3RequestWithAuthRefreshInternal(const string
 				retried_region = true;
 				continue;
 			}
+			string s3_error_code;
+			if (transient_retries < http_params.retries && IsTransientS3Error(error, s3_error_code)) {
+				SleepForTransientRetry(http_params, transient_retries, transient_wait_ms);
+				transient_retries++;
+				continue;
+			}
 			throw;
 		}
 	}
-	throw InternalException("Exceeded S3 request retry count for '%s'", s3_url);
 }
 
 template <class REQUEST>

--- a/test/unittest/httpfs_refresh_test.cpp
+++ b/test/unittest/httpfs_refresh_test.cpp
@@ -468,7 +468,74 @@ static void RunMultipleStaleHandlesSingleRefreshScenario() {
 	AssertSingleRefresh(test_id);
 }
 
+static void RunTransientPutRetryScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	// Use a refresh target that writes never exercise, so credential refresh never triggers here.
+	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.transient_put_failures = 2;
+	config.put_failure_is_request_timeout = true;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureRefreshTest(db, con, server, client_implementation, false);
+
+	RequireQueryOk(con, "SET http_retries=3");
+	RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	WriteMultipartPayload(con);
+	RequireQueryOk(con, "COMMIT");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	// The transient RequestTimeout 400s were surfaced, retried, and the same part eventually succeeded.
+	REQUIRE(MockS3HasObservation(observations, "PUT", STALE_KEY_ID, 400, string(), "partNumber"));
+	REQUIRE(MockS3HasObservation(observations, "PUT", STALE_KEY_ID, 200, string(), "partNumber"));
+	// The multipart upload completed successfully.
+	REQUIRE(MockS3HasObservation(observations, "POST", STALE_KEY_ID, 200, string(), "uploadId"));
+}
+
+static void RunNonRetryablePutFailureScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	// Fail every part upload with a non-RequestTimeout 400, which must NOT be retried.
+	config.transient_put_failures = 1000;
+	config.put_failure_is_request_timeout = false;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureRefreshTest(db, con, server, client_implementation, false);
+
+	RequireQueryOk(con, "SET http_retries=3");
+	RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	REQUIRE_THROWS(WriteMultipartPayload(con));
+	RequireQueryOk(con, "ROLLBACK");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(MockS3HasObservation(observations, "PUT", STALE_KEY_ID, 400, string(), "partNumber"));
+	// A generic 400 is fatal: no part upload is retried into a success.
+	REQUIRE(CountObservations(observations, "PUT", STALE_KEY_ID, 200) == 0);
+}
+
 } // namespace
+
+TEST_CASE("HTTPFS retries transient S3 RequestTimeout on multipart upload", "[httpfs][s3][upload]") {
+	SECTION("httplib retries the stalled part and completes the upload") {
+		RunTransientPutRetryScenario("httplib");
+	}
+	SECTION("a non-RequestTimeout 400 is not retried") {
+		RunNonRetryablePutFailureScenario("httplib");
+	}
+}
 
 TEST_CASE("HTTPFS refreshes S3 credentials across request methods", "[httpfs][s3][refresh]") {
 	SECTION("httplib without connection caching") {

--- a/test/unittest/httpfs_refresh_test.cpp
+++ b/test/unittest/httpfs_refresh_test.cpp
@@ -526,11 +526,46 @@ static void RunNonRetryablePutFailureScenario(const string &client_implementatio
 	REQUIRE(CountObservations(observations, "PUT", STALE_KEY_ID, 200) == 0);
 }
 
+static void RunTransientGetRetryScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.transient_get_failures = 2;
+	auto object_data = config.object_data;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureRefreshTest(db, con, server, client_implementation, false);
+
+	RequireQueryOk(con, "SET http_retries=3");
+	RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	RequireQueryOk(con, "SET force_download=true");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(S3_PATH, FileFlags::FILE_FLAGS_READ);
+	string buffer(8, '\0');
+	handle->Read(QueryContext(*con.context), &buffer[0], buffer.size(), 0);
+	REQUIRE(buffer == object_data.substr(0, buffer.size()));
+	RequireQueryOk(con, "COMMIT");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	// The read hit transient RequestTimeout 400s (thrown path) and was retried until it succeeded.
+	REQUIRE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 400));
+	REQUIRE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 200));
+}
+
 } // namespace
 
-TEST_CASE("HTTPFS retries transient S3 RequestTimeout on multipart upload", "[httpfs][s3][upload]") {
-	SECTION("httplib retries the stalled part and completes the upload") {
+TEST_CASE("HTTPFS retries transient S3 RequestTimeout across request types", "[httpfs][s3][upload]") {
+	SECTION("multipart part upload (returned-response path) retries and completes") {
 		RunTransientPutRetryScenario("httplib");
+	}
+	SECTION("object read (thrown-exception path) retries and completes") {
+		RunTransientGetRetryScenario("httplib");
 	}
 	SECTION("a non-RequestTimeout 400 is not retried") {
 		RunNonRetryablePutFailureScenario("httplib");

--- a/test/unittest/httpfs_refresh_test.cpp
+++ b/test/unittest/httpfs_refresh_test.cpp
@@ -629,23 +629,122 @@ static void RunTransientGetRetryScenario(const string &client_implementation) {
 	REQUIRE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 200));
 }
 
+static void RunTransientDeleteRetryScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	// Use a refresh target that deletes never exercise, so credential refresh never triggers here.
+	config.refresh_target = MockS3RefreshTarget::PUT;
+	config.transient_delete_failures = 2;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureRefreshTest(db, con, server, client_implementation, false);
+
+	RequireQueryOk(con, "SET http_retries=3");
+	RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	fs.RemoveFile(S3_PATH);
+	RequireQueryOk(con, "COMMIT");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(CountObservations(observations, "DELETE", STALE_KEY_ID, 400) == 2);
+	REQUIRE(CountObservations(observations, "DELETE", STALE_KEY_ID, 204) == 1);
+}
+
+// HEAD responses carry no body, so a RequestTimeout 400 cannot be classified as transient:
+// the HEAD is not retried and the open recovers through httpfs's range-GET fallback instead.
+static void RunHeadNotRetriedScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.transient_head_failures = 1000;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureRefreshTest(db, con, server, client_implementation, false);
+
+	RequireQueryOk(con, "SET http_retries=3");
+	RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(S3_PATH, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	REQUIRE(handle);
+	RequireQueryOk(con, "COMMIT");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(CountObservations(observations, "HEAD", STALE_KEY_ID, 400) == 1);
+	REQUIRE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 206, "bytes=0-1"));
+}
+
+// Like multipart-init, a multipart-complete POST must not be replayed even on RequestTimeout.
+static void RunMultipartCompleteNotRetriedScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.transient_complete_post_failures = 1000;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureRefreshTest(db, con, server, client_implementation, false);
+
+	RequireQueryOk(con, "SET http_retries=3");
+	RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	REQUIRE_THROWS(WriteMultipartPayload(con));
+	RequireQueryOk(con, "ROLLBACK");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(CountObservationsTarget(observations, "POST", 400, "uploadId") == 1);
+}
+
+static void RunAllTransientRetryScenarios(const string &client_implementation) {
+	SECTION("multipart part upload (returned-response path) retries and completes") {
+		RunTransientPutRetryScenario(client_implementation);
+	}
+	SECTION("object read (thrown-exception path) retries and completes") {
+		RunTransientGetRetryScenario(client_implementation);
+	}
+	SECTION("object delete retries and completes") {
+		RunTransientDeleteRetryScenario(client_implementation);
+	}
+	SECTION("a generic 400 is not retried") {
+		RunGenericErrorNotRetriedScenario(client_implementation);
+	}
+	SECTION("a multipart-init POST is not retried even on RequestTimeout") {
+		RunMultipartInitNotRetriedScenario(client_implementation);
+	}
+	SECTION("a multipart-complete POST is not retried even on RequestTimeout") {
+		RunMultipartCompleteNotRetriedScenario(client_implementation);
+	}
+	SECTION("a HEAD 400 is not retried because HEAD responses carry no error body") {
+		RunHeadNotRetriedScenario(client_implementation);
+	}
+	SECTION("retries are bounded by http_retries") {
+		RunRetryBudgetScenario(client_implementation);
+	}
+}
+
 } // namespace
 
 TEST_CASE("HTTPFS retries transient S3 RequestTimeout across request types", "[httpfs][s3][upload]") {
-	SECTION("multipart part upload (returned-response path) retries and completes") {
-		RunTransientPutRetryScenario("httplib");
+	SECTION("httplib") {
+		RunAllTransientRetryScenarios("httplib");
 	}
-	SECTION("object read (thrown-exception path) retries and completes") {
-		RunTransientGetRetryScenario("httplib");
-	}
-	SECTION("a generic 400 is not retried") {
-		RunGenericErrorNotRetriedScenario("httplib");
-	}
-	SECTION("a multipart-init POST is not retried even on RequestTimeout") {
-		RunMultipartInitNotRetriedScenario("httplib");
-	}
-	SECTION("retries are bounded by http_retries") {
-		RunRetryBudgetScenario("httplib");
+	SECTION("curl") {
+		RunAllTransientRetryScenarios("curl");
 	}
 }
 

--- a/test/unittest/httpfs_refresh_test.cpp
+++ b/test/unittest/httpfs_refresh_test.cpp
@@ -304,6 +304,16 @@ static void WriteMultipartPayload(Connection &con) {
 	handle->Close();
 }
 
+// A payload small enough to be a single-shot PUT (no multipart), so the S3 request loop is the only
+// retry layer and the PUT count reflects exactly that loop's behavior.
+static void WriteSinglePutPayload(Connection &con) {
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(S3_PATH, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	string payload = "single-shot payload";
+	handle->Write(QueryContext(*con.context), &payload[0], payload.size());
+	handle->Close();
+}
+
 static void RunMultipartInitiatePostRefreshScenario(const string &client_implementation, bool connection_caching) {
 	auto observations =
 	    RunRefreshScenario(MockS3RefreshTarget::MULTIPART_INITIATE_POST, client_implementation, connection_caching,
@@ -476,7 +486,6 @@ static void RunTransientPutRetryScenario(const string &client_implementation) {
 	// Use a refresh target that writes never exercise, so credential refresh never triggers here.
 	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
 	config.transient_put_failures = 2;
-	config.put_failure_is_request_timeout = true;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -498,15 +507,53 @@ static void RunTransientPutRetryScenario(const string &client_implementation) {
 	REQUIRE(MockS3HasObservation(observations, "POST", STALE_KEY_ID, 200, string(), "uploadId"));
 }
 
-static void RunNonRetryablePutFailureScenario(const string &client_implementation) {
+static idx_t CountObservationsTarget(const vector<MockS3RequestObservation> &observations, const string &method,
+                                     int status, const string &target_contains) {
+	idx_t result = 0;
+	for (auto &observation : observations) {
+		if (observation.method == method && observation.status == status &&
+		    (target_contains.empty() || observation.target.find(target_contains) != string::npos)) {
+			result++;
+		}
+	}
+	return result;
+}
+
+// A generic (non-RequestTimeout) 400 must fail on the first try. Uses a single-shot PUT so exactly one
+// request is expected, distinguishing "not retried" from "retried N times and still failed".
+static void RunGenericErrorNotRetriedScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
 	config.bucket = BUCKET;
 	config.object_key = OBJECT_KEY;
 	config.stale_key_id = STALE_KEY_ID;
 	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
-	// Fail every part upload with a non-RequestTimeout 400, which must NOT be retried.
 	config.transient_put_failures = 1000;
-	config.put_failure_is_request_timeout = false;
+	config.failure_is_request_timeout = false;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureRefreshTest(db, con, server, client_implementation, false);
+
+	RequireQueryOk(con, "SET http_retries=3");
+	RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	REQUIRE_THROWS(WriteSinglePutPayload(con));
+	RequireQueryOk(con, "ROLLBACK");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(CountObservations(observations, "PUT", STALE_KEY_ID, 400) == 1);
+}
+
+// Even a retryable RequestTimeout must NOT replay a multipart-init POST (it would orphan an upload id).
+static void RunMultipartInitNotRetriedScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.transient_post_failures = 1000;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -521,9 +568,33 @@ static void RunNonRetryablePutFailureScenario(const string &client_implementatio
 
 	auto observations = server.Observations();
 	INFO(MockS3DescribeObservations(observations));
-	REQUIRE(MockS3HasObservation(observations, "PUT", STALE_KEY_ID, 400, string(), "partNumber"));
-	// A generic 400 is fatal: no part upload is retried into a success.
-	REQUIRE(CountObservations(observations, "PUT", STALE_KEY_ID, 200) == 0);
+	REQUIRE(CountObservationsTarget(observations, "POST", 400, "uploads") == 1);
+}
+
+// A RequestTimeout that never clears exhausts exactly http_retries retries (one initial + http_retries).
+static void RunRetryBudgetScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.transient_put_failures = 1000;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureRefreshTest(db, con, server, client_implementation, false);
+
+	RequireQueryOk(con, "SET http_retries=2");
+	RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	REQUIRE_THROWS(WriteSinglePutPayload(con));
+	RequireQueryOk(con, "ROLLBACK");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	// One initial attempt plus http_retries (2) retries.
+	REQUIRE(CountObservations(observations, "PUT", STALE_KEY_ID, 400) == 3);
 }
 
 static void RunTransientGetRetryScenario(const string &client_implementation) {
@@ -567,8 +638,14 @@ TEST_CASE("HTTPFS retries transient S3 RequestTimeout across request types", "[h
 	SECTION("object read (thrown-exception path) retries and completes") {
 		RunTransientGetRetryScenario("httplib");
 	}
-	SECTION("a non-RequestTimeout 400 is not retried") {
-		RunNonRetryablePutFailureScenario("httplib");
+	SECTION("a generic 400 is not retried") {
+		RunGenericErrorNotRetriedScenario("httplib");
+	}
+	SECTION("a multipart-init POST is not retried even on RequestTimeout") {
+		RunMultipartInitNotRetriedScenario("httplib");
+	}
+	SECTION("retries are bounded by http_retries") {
+		RunRetryBudgetScenario("httplib");
 	}
 }
 

--- a/test/unittest/httpfs_refresh_test.cpp
+++ b/test/unittest/httpfs_refresh_test.cpp
@@ -546,6 +546,44 @@ static void RunGenericErrorNotRetriedScenario(const string &client_implementatio
 	REQUIRE(CountObservations(observations, "PUT", STALE_KEY_ID, 400) == 1);
 }
 
+// A truncated error body (an open <Code> with no closing tag) must degrade to a plain HTTP error:
+// not classified as transient (no retry) and never escalated to a DB-invalidating InternalException.
+static void RunTruncatedErrorBodyScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.transient_put_failures = 1000;
+	config.truncated_failure_body = true;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureRefreshTest(db, con, server, client_implementation, false);
+
+	RequireQueryOk(con, "SET http_retries=3");
+	RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	bool threw = false;
+	bool threw_internal = false;
+	try {
+		WriteSinglePutPayload(con);
+	} catch (std::exception &ex) {
+		threw = true;
+		ErrorData error(ex);
+		threw_internal = error.Type() == ExceptionType::INTERNAL || error.Type() == ExceptionType::FATAL;
+	}
+	REQUIRE(threw);
+	REQUIRE_FALSE(threw_internal);
+	// The database must still be usable (an InternalException would have invalidated it).
+	RequireQueryOk(con, "ROLLBACK");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(CountObservations(observations, "PUT", STALE_KEY_ID, 400) == 1);
+}
+
 // Even a retryable RequestTimeout must NOT replay a multipart-init POST (it would orphan an upload id).
 static void RunMultipartInitNotRetriedScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
@@ -722,6 +760,9 @@ static void RunAllTransientRetryScenarios(const string &client_implementation) {
 	}
 	SECTION("a generic 400 is not retried") {
 		RunGenericErrorNotRetriedScenario(client_implementation);
+	}
+	SECTION("a truncated error body is not retried and does not invalidate the database") {
+		RunTruncatedErrorBodyScenario(client_implementation);
 	}
 	SECTION("a multipart-init POST is not retried even on RequestTimeout") {
 		RunMultipartInitNotRetriedScenario(client_implementation);

--- a/test/unittest/httpfs_refresh_test.cpp
+++ b/test/unittest/httpfs_refresh_test.cpp
@@ -609,6 +609,45 @@ static void RunMultipartInitNotRetriedScenario(const string &client_implementati
 	REQUIRE(CountObservationsTarget(observations, "POST", 400, "uploads") == 1);
 }
 
+// With curl connection caching, the retry must run on a fresh connection instead of the stalled cached one.
+static void RunCachedConnectionRetryScenario() {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.transient_put_failures = 1;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureRefreshTest(db, con, server, "curl", true);
+
+	RequireQueryOk(con, "SET http_retries=3");
+	RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	WriteSinglePutPayload(con);
+	RequireQueryOk(con, "COMMIT");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	int failed_port = 0;
+	int success_port = 0;
+	for (auto &observation : observations) {
+		if (observation.method != "PUT") {
+			continue;
+		}
+		if (observation.status == 400) {
+			failed_port = observation.remote_port;
+		} else if (observation.status == 200) {
+			success_port = observation.remote_port;
+		}
+	}
+	REQUIRE(failed_port != 0);
+	REQUIRE(success_port != 0);
+	REQUIRE(failed_port != success_port);
+}
+
 // A RequestTimeout that never clears exhausts exactly http_retries retries (one initial + http_retries).
 static void RunRetryBudgetScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
@@ -662,7 +701,7 @@ static void RunTransientGetRetryScenario(const string &client_implementation) {
 
 	auto observations = server.Observations();
 	INFO(MockS3DescribeObservations(observations));
-	// The read hit transient RequestTimeout 400s (thrown path) and was retried until it succeeded.
+	// The read hit transient RequestTimeout 400s and was retried until it succeeded.
 	REQUIRE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 400));
 	REQUIRE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 200));
 }
@@ -749,10 +788,10 @@ static void RunMultipartCompleteNotRetriedScenario(const string &client_implemen
 }
 
 static void RunAllTransientRetryScenarios(const string &client_implementation) {
-	SECTION("multipart part upload (returned-response path) retries and completes") {
+	SECTION("multipart part upload retries and completes") {
 		RunTransientPutRetryScenario(client_implementation);
 	}
-	SECTION("object read (thrown-exception path) retries and completes") {
+	SECTION("object read retries and completes") {
 		RunTransientGetRetryScenario(client_implementation);
 	}
 	SECTION("object delete retries and completes") {
@@ -786,6 +825,9 @@ TEST_CASE("HTTPFS retries transient S3 RequestTimeout across request types", "[h
 	}
 	SECTION("curl") {
 		RunAllTransientRetryScenarios("curl");
+	}
+	SECTION("curl with connection caching retries on a fresh connection") {
+		RunCachedConnectionRetryScenario();
 	}
 }
 

--- a/test/unittest/mock_s3_server.cpp
+++ b/test/unittest/mock_s3_server.cpp
@@ -62,6 +62,7 @@ struct MockS3Server::Impl {
 	explicit Impl(MockS3ServerConfig config_p) : config(std::move(config_p)) {
 		remaining_put_failures = config.transient_put_failures;
 		remaining_get_failures = config.transient_get_failures;
+		remaining_post_failures = config.transient_post_failures;
 		RegisterRoutes();
 		port = server.bind_to_any_port("127.0.0.1");
 		if (port <= 0) {
@@ -241,7 +242,7 @@ struct MockS3Server::Impl {
 			}
 			if (remaining_get_failures.load() > 0) {
 				remaining_get_failures--;
-				SendS3Error400(request, response, true);
+				SendS3Error400(request, response, config.failure_is_request_timeout);
 				return;
 			}
 
@@ -287,9 +288,9 @@ struct MockS3Server::Impl {
 				SendForbidden(request, response);
 				return;
 			}
-			if (request.target.find("partNumber") != string::npos && remaining_put_failures.load() > 0) {
+			if (remaining_put_failures.load() > 0) {
 				remaining_put_failures--;
-				SendS3Error400(request, response, config.put_failure_is_request_timeout);
+				SendS3Error400(request, response, config.failure_is_request_timeout);
 				return;
 			}
 			SendPutSuccess(request, response);
@@ -298,6 +299,11 @@ struct MockS3Server::Impl {
 		server.Post(path, [this](const httplib::Request &request, httplib::Response &response) {
 			if (ShouldRejectStaleCredentials(request)) {
 				SendForbidden(request, response);
+				return;
+			}
+			if (request.target.find("uploads") != string::npos && remaining_post_failures.load() > 0) {
+				remaining_post_failures--;
+				SendS3Error400(request, response, config.failure_is_request_timeout);
 				return;
 			}
 			SendMultipartPostSuccess(request, response);
@@ -329,6 +335,7 @@ struct MockS3Server::Impl {
 	int port = 0;
 	mutable std::atomic<idx_t> remaining_put_failures {0};
 	mutable std::atomic<idx_t> remaining_get_failures {0};
+	mutable std::atomic<idx_t> remaining_post_failures {0};
 	mutable std::mutex observation_lock;
 	mutable vector<MockS3RequestObservation> observations;
 };

--- a/test/unittest/mock_s3_server.cpp
+++ b/test/unittest/mock_s3_server.cpp
@@ -134,6 +134,7 @@ struct MockS3Server::Impl {
 		observation.range = GetHeader(request, "Range");
 		observation.key_id = ExtractCredentialKey(GetHeader(request, "Authorization"));
 		observation.status = status;
+		observation.remote_port = request.remote_port;
 
 		std::lock_guard<std::mutex> lock(observation_lock);
 		observations.push_back(std::move(observation));

--- a/test/unittest/mock_s3_server.cpp
+++ b/test/unittest/mock_s3_server.cpp
@@ -160,7 +160,10 @@ struct MockS3Server::Impl {
 
 	void SendS3Error400(const httplib::Request &request, httplib::Response &response, bool request_timeout) const {
 		response.status = 400;
-		if (request_timeout) {
+		if (config.truncated_failure_body) {
+			response.set_content("<?xml version=\"1.0\" encoding=\"UTF-8\"?><Error><Code>RequestTimeout",
+			                     "application/xml");
+		} else if (request_timeout) {
 			response.set_content("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
 			                     "<Error><Code>RequestTimeout</Code><Message>Your socket connection to the server "
 			                     "was not read from or written to within the timeout period.</Message></Error>",

--- a/test/unittest/mock_s3_server.cpp
+++ b/test/unittest/mock_s3_server.cpp
@@ -5,6 +5,7 @@
 
 #include "httplib.hpp"
 
+#include <atomic>
 #include <cstring>
 #include <mutex>
 #include <thread>
@@ -59,6 +60,7 @@ static string GetHeader(const httplib::Request &request, const string &header) {
 
 struct MockS3Server::Impl {
 	explicit Impl(MockS3ServerConfig config_p) : config(std::move(config_p)) {
+		remaining_put_failures = config.transient_put_failures;
 		RegisterRoutes();
 		port = server.bind_to_any_port("127.0.0.1");
 		if (port <= 0) {
@@ -148,6 +150,21 @@ struct MockS3Server::Impl {
 	void SendPutSuccess(const httplib::Request &request, httplib::Response &response) const {
 		response.status = 200;
 		response.set_header("ETag", "\"httpfs-refresh-test-upload-etag\"");
+		Record(request, response.status);
+	}
+
+	void SendPutFailure(const httplib::Request &request, httplib::Response &response) const {
+		response.status = 400;
+		if (config.put_failure_is_request_timeout) {
+			response.set_content("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+			                     "<Error><Code>RequestTimeout</Code><Message>Your socket connection to the server "
+			                     "was not read from or written to within the timeout period.</Message></Error>",
+			                     "application/xml");
+		} else {
+			response.set_content("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+			                     "<Error><Code>InvalidRequest</Code><Message>malformed request</Message></Error>",
+			                     "application/xml");
+		}
 		Record(request, response.status);
 	}
 
@@ -264,6 +281,11 @@ struct MockS3Server::Impl {
 				SendForbidden(request, response);
 				return;
 			}
+			if (request.target.find("partNumber") != string::npos && remaining_put_failures.load() > 0) {
+				remaining_put_failures--;
+				SendPutFailure(request, response);
+				return;
+			}
 			SendPutSuccess(request, response);
 		});
 
@@ -299,6 +321,7 @@ struct MockS3Server::Impl {
 	httplib::Server server;
 	std::thread server_thread;
 	int port = 0;
+	mutable std::atomic<idx_t> remaining_put_failures {0};
 	mutable std::mutex observation_lock;
 	mutable vector<MockS3RequestObservation> observations;
 };

--- a/test/unittest/mock_s3_server.cpp
+++ b/test/unittest/mock_s3_server.cpp
@@ -61,6 +61,7 @@ static string GetHeader(const httplib::Request &request, const string &header) {
 struct MockS3Server::Impl {
 	explicit Impl(MockS3ServerConfig config_p) : config(std::move(config_p)) {
 		remaining_put_failures = config.transient_put_failures;
+		remaining_get_failures = config.transient_get_failures;
 		RegisterRoutes();
 		port = server.bind_to_any_port("127.0.0.1");
 		if (port <= 0) {
@@ -153,9 +154,9 @@ struct MockS3Server::Impl {
 		Record(request, response.status);
 	}
 
-	void SendPutFailure(const httplib::Request &request, httplib::Response &response) const {
+	void SendS3Error400(const httplib::Request &request, httplib::Response &response, bool request_timeout) const {
 		response.status = 400;
-		if (config.put_failure_is_request_timeout) {
+		if (request_timeout) {
 			response.set_content("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
 			                     "<Error><Code>RequestTimeout</Code><Message>Your socket connection to the server "
 			                     "was not read from or written to within the timeout period.</Message></Error>",
@@ -238,6 +239,11 @@ struct MockS3Server::Impl {
 				SendForbidden(request, response);
 				return;
 			}
+			if (remaining_get_failures.load() > 0) {
+				remaining_get_failures--;
+				SendS3Error400(request, response, true);
+				return;
+			}
 
 			auto range = GetHeader(request, "Range");
 			if (range.empty()) {
@@ -283,7 +289,7 @@ struct MockS3Server::Impl {
 			}
 			if (request.target.find("partNumber") != string::npos && remaining_put_failures.load() > 0) {
 				remaining_put_failures--;
-				SendPutFailure(request, response);
+				SendS3Error400(request, response, config.put_failure_is_request_timeout);
 				return;
 			}
 			SendPutSuccess(request, response);
@@ -322,6 +328,7 @@ struct MockS3Server::Impl {
 	std::thread server_thread;
 	int port = 0;
 	mutable std::atomic<idx_t> remaining_put_failures {0};
+	mutable std::atomic<idx_t> remaining_get_failures {0};
 	mutable std::mutex observation_lock;
 	mutable vector<MockS3RequestObservation> observations;
 };

--- a/test/unittest/mock_s3_server.cpp
+++ b/test/unittest/mock_s3_server.cpp
@@ -62,7 +62,10 @@ struct MockS3Server::Impl {
 	explicit Impl(MockS3ServerConfig config_p) : config(std::move(config_p)) {
 		remaining_put_failures = config.transient_put_failures;
 		remaining_get_failures = config.transient_get_failures;
+		remaining_head_failures = config.transient_head_failures;
+		remaining_delete_failures = config.transient_delete_failures;
 		remaining_post_failures = config.transient_post_failures;
+		remaining_complete_post_failures = config.transient_complete_post_failures;
 		RegisterRoutes();
 		port = server.bind_to_any_port("127.0.0.1");
 		if (port <= 0) {
@@ -229,6 +232,11 @@ struct MockS3Server::Impl {
 				SendForbidden(request, response);
 				return httplib::Server::HandlerResponse::Handled;
 			}
+			if (remaining_head_failures.load() > 0) {
+				remaining_head_failures--;
+				SendS3Error400(request, response, config.failure_is_request_timeout);
+				return httplib::Server::HandlerResponse::Handled;
+			}
 			response.status = 200;
 			SetObjectHeaders(response);
 			Record(request, response.status);
@@ -306,6 +314,11 @@ struct MockS3Server::Impl {
 				SendS3Error400(request, response, config.failure_is_request_timeout);
 				return;
 			}
+			if (request.target.find("uploadId") != string::npos && remaining_complete_post_failures.load() > 0) {
+				remaining_complete_post_failures--;
+				SendS3Error400(request, response, config.failure_is_request_timeout);
+				return;
+			}
 			SendMultipartPostSuccess(request, response);
 		});
 
@@ -324,6 +337,11 @@ struct MockS3Server::Impl {
 				SendForbidden(request, response);
 				return;
 			}
+			if (remaining_delete_failures.load() > 0) {
+				remaining_delete_failures--;
+				SendS3Error400(request, response, config.failure_is_request_timeout);
+				return;
+			}
 			response.status = 204;
 			Record(request, response.status);
 		});
@@ -335,7 +353,10 @@ struct MockS3Server::Impl {
 	int port = 0;
 	mutable std::atomic<idx_t> remaining_put_failures {0};
 	mutable std::atomic<idx_t> remaining_get_failures {0};
+	mutable std::atomic<idx_t> remaining_head_failures {0};
+	mutable std::atomic<idx_t> remaining_delete_failures {0};
 	mutable std::atomic<idx_t> remaining_post_failures {0};
+	mutable std::atomic<idx_t> remaining_complete_post_failures {0};
 	mutable std::mutex observation_lock;
 	mutable vector<MockS3RequestObservation> observations;
 };

--- a/test/unittest/mock_s3_server.hpp
+++ b/test/unittest/mock_s3_server.hpp
@@ -23,6 +23,10 @@ struct MockS3ServerConfig {
 	string stale_key_id = "STALE_KEY";
 	string etag = "\"httpfs-refresh-test-etag\"";
 	MockS3RefreshTarget refresh_target = MockS3RefreshTarget::HEAD;
+	//! Number of multipart part uploads (PUT with partNumber) to fail before succeeding
+	idx_t transient_put_failures = 0;
+	//! When failing a part upload, whether the 400 body is S3's retryable RequestTimeout or a generic error
+	bool put_failure_is_request_timeout = true;
 };
 
 struct MockS3RequestObservation {

--- a/test/unittest/mock_s3_server.hpp
+++ b/test/unittest/mock_s3_server.hpp
@@ -37,6 +37,8 @@ struct MockS3ServerConfig {
 	idx_t transient_complete_post_failures = 0;
 	//! Whether injected 400s carry S3's retryable RequestTimeout code or a generic (non-retryable) code
 	bool failure_is_request_timeout = true;
+	//! Whether injected 400 bodies are truncated mid-XML (an open <Code> with no closing tag)
+	bool truncated_failure_body = false;
 };
 
 struct MockS3RequestObservation {

--- a/test/unittest/mock_s3_server.hpp
+++ b/test/unittest/mock_s3_server.hpp
@@ -27,6 +27,8 @@ struct MockS3ServerConfig {
 	idx_t transient_put_failures = 0;
 	//! When failing a part upload, whether the 400 body is S3's retryable RequestTimeout or a generic error
 	bool put_failure_is_request_timeout = true;
+	//! Number of object GETs to fail with a retryable RequestTimeout 400 before succeeding
+	idx_t transient_get_failures = 0;
 };
 
 struct MockS3RequestObservation {

--- a/test/unittest/mock_s3_server.hpp
+++ b/test/unittest/mock_s3_server.hpp
@@ -48,6 +48,8 @@ struct MockS3RequestObservation {
 	string range;
 	string key_id;
 	int status = 0;
+	//! Client's ephemeral source port; a new connection shows a new port
+	int remote_port = 0;
 };
 
 class MockS3Server {

--- a/test/unittest/mock_s3_server.hpp
+++ b/test/unittest/mock_s3_server.hpp
@@ -23,12 +23,18 @@ struct MockS3ServerConfig {
 	string stale_key_id = "STALE_KEY";
 	string etag = "\"httpfs-refresh-test-etag\"";
 	MockS3RefreshTarget refresh_target = MockS3RefreshTarget::HEAD;
-	//! Number of multipart part uploads (PUT with partNumber) to fail with a 400 before succeeding
+	//! Number of object PUTs to fail with a 400 before succeeding
 	idx_t transient_put_failures = 0;
 	//! Number of object GETs to fail with a 400 before succeeding
 	idx_t transient_get_failures = 0;
+	//! Number of object HEADs to fail with a 400 before succeeding
+	idx_t transient_head_failures = 0;
+	//! Number of object DELETEs to fail with a 400 before succeeding
+	idx_t transient_delete_failures = 0;
 	//! Number of multipart-init POSTs (uploads=) to fail with a 400 before succeeding
 	idx_t transient_post_failures = 0;
+	//! Number of multipart-complete POSTs (uploadId=) to fail with a 400 before succeeding
+	idx_t transient_complete_post_failures = 0;
 	//! Whether injected 400s carry S3's retryable RequestTimeout code or a generic (non-retryable) code
 	bool failure_is_request_timeout = true;
 };

--- a/test/unittest/mock_s3_server.hpp
+++ b/test/unittest/mock_s3_server.hpp
@@ -23,12 +23,14 @@ struct MockS3ServerConfig {
 	string stale_key_id = "STALE_KEY";
 	string etag = "\"httpfs-refresh-test-etag\"";
 	MockS3RefreshTarget refresh_target = MockS3RefreshTarget::HEAD;
-	//! Number of multipart part uploads (PUT with partNumber) to fail before succeeding
+	//! Number of multipart part uploads (PUT with partNumber) to fail with a 400 before succeeding
 	idx_t transient_put_failures = 0;
-	//! When failing a part upload, whether the 400 body is S3's retryable RequestTimeout or a generic error
-	bool put_failure_is_request_timeout = true;
-	//! Number of object GETs to fail with a retryable RequestTimeout 400 before succeeding
+	//! Number of object GETs to fail with a 400 before succeeding
 	idx_t transient_get_failures = 0;
+	//! Number of multipart-init POSTs (uploads=) to fail with a 400 before succeeding
+	idx_t transient_post_failures = 0;
+	//! Whether injected 400s carry S3's retryable RequestTimeout code or a generic (non-retryable) code
+	bool failure_is_request_timeout = true;
 };
 
 struct MockS3RequestObservation {


### PR DESCRIPTION
S3 returns HTTP 400 with <Code>RequestTimeout</Code> (not 408) when a multipart part's socket stalls past its idle timeout under upload contention. Core's retry classifier (HTTPResponse::ShouldRetry) is status-code-only and covers 408/429/5xx, so this transient failure surfaces to users as a fatal Bad Request (HTTP code 400) and http_retries never engages.

Since the retry loop lives in duckdb core and the discriminator (RequestTimeout) only exists in the S3 XML body, this fixes it in the S3 layer: a part PUT is idempotent, so UploadBufferImplementation retries this specific 400 using the existing http_retries / http_retry_wait_ms / http_retry_backoff settings. Generic 400s still fail fast. Basically everything else goes through core's machinery for retrying, even other 400s.

**Testing:** Adds fault injection to the mock S3 server and cpp unit tests for both the retried RequestTimeout 400 and a non-retryable generic 400.