### PR TITLE
Merge `v1.5-variegata` into `main` and apply patches

### DIFF
--- a/.github/workflows/IntegrationTests.yml
+++ b/.github/workflows/IntegrationTests.yml
@@ -78,7 +78,7 @@ jobs:
         shell: bash
         run: |
           cmake --build build/release --target unittest_httpfs
-          ./build/release/test/unittest_httpfs "[httpfs][s3][refresh]"
+          ./build/release/test/unittest_httpfs "[httpfs][s3]"
 
       - name: Install test server
         shell: bash

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       extension_name: httpfs
-      duckdb_version: 3a3c412af5
+      duckdb_version: 7f4cbcef36
       ci_tools_version: main
 
   duckdb-stable-deploy:
@@ -27,7 +27,7 @@ jobs:
     secrets: inherit
     with:
       extension_name: httpfs
-      duckdb_version: 3a3c412af5
+      duckdb_version: 7f4cbcef36
       ci_tools_version: main
       deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') }}
       deploy_versioned: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}
@@ -37,7 +37,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main
     with:
       extension_name: httpfs
-      duckdb_version: 3a3c412af5
+      duckdb_version: 7f4cbcef36
       ci_tools_version: main
       extra_toolchains: 'python3'
       format_checks: 'format'

--- a/src/create_secret_functions.cpp
+++ b/src/create_secret_functions.cpp
@@ -1,4 +1,5 @@
 #include "create_secret_functions.hpp"
+#include "duckdb/logging/logger.hpp"
 #include "s3fs.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/common/local_file_system.hpp"

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -1,4 +1,5 @@
 #include "crypto.hpp"
+#include "duckdb/storage/storage_info.hpp"
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/exception.hpp"

--- a/src/hffs.cpp
+++ b/src/hffs.cpp
@@ -265,10 +265,11 @@ unique_ptr<HTTPResponse> HuggingFaceFileSystem::HeadRequest(FileHandle &handle, 
 	return HTTPFileSystem::HeadRequest(handle, http_url, header_map);
 }
 
-unique_ptr<HTTPResponse> HuggingFaceFileSystem::GetRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map) {
+unique_ptr<HTTPResponse> HuggingFaceFileSystem::GetRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
+                                                           CachedFileDownload &download) {
 	auto &hf_handle = handle.Cast<HFFileHandle>();
 	auto http_url = HuggingFaceFileSystem::GetFileUrl(hf_handle.parsed_url);
-	return HTTPFileSystem::GetRequest(handle, http_url, header_map);
+	return HTTPFileSystem::GetRequest(handle, http_url, header_map, download);
 }
 
 unique_ptr<HTTPResponse> HuggingFaceFileSystem::GetRangeRequest(FileHandle &handle, string s3_url,

--- a/src/http_state.cpp
+++ b/src/http_state.cpp
@@ -3,59 +3,121 @@
 
 namespace duckdb {
 
-CachedFileHandle::CachedFileHandle(shared_ptr<CachedFile> &file_p) {
-	// If the file was not yet initialized, we need to grab a lock.
-	if (!file_p->initialized) {
-		lock = unique_ptr<lock_guard<mutex>>(new lock_guard<mutex>(file_p->lock));
-	}
-	file = file_p;
+unique_ptr<CachedFileHandle> CachedFile::GetHandle() {
+	return make_uniq<CachedFileHandle>(shared_from_this());
 }
 
-void CachedFileHandle::SetInitialized(idx_t total_size) {
-	if (file->initialized) {
-		throw InternalException("Cannot set initialized on cached file that was already initialized");
+unique_ptr<CachedFileDownload> CachedFile::StartDownload(Allocator &allocator) {
+	annotated_unique_lock<annotated_mutex> guard(lock);
+	while (downloading) {
+		download_complete.wait(guard, [&]() DUCKDB_REQUIRES(lock) { return !downloading; });
 	}
-	if (!lock) {
-		throw InternalException("Cannot set initialized on cached file without lock");
+	if (initialized) {
+		return nullptr;
 	}
-	file->size = total_size;
-	file->initialized = true;
-	lock = nullptr;
+	auto result = unique_ptr<CachedFileDownload>(new CachedFileDownload(shared_from_this(), allocator));
+	downloading = true;
+	return result;
 }
 
-void CachedFileHandle::AllocateBuffer(idx_t size) {
-	if (file->initialized) {
-		throw InternalException("Cannot allocate a buffer for a cached file that was already initialized");
-	}
-	file->data = shared_ptr<char>(new char[size], std::default_delete<char[]>());
-	file->capacity = size;
+CachedFileHandle::CachedFileHandle(shared_ptr<CachedFile> file_p) : file(std::move(file_p)) {
 }
 
-void CachedFileHandle::ResetBuffer() {
-	if (file->initialized) {
-		throw InternalException("Cannot reset a buffer for a cached file that was already initialized");
+bool CachedFileHandle::Initialized() const {
+	annotated_lock_guard<annotated_mutex> guard(file->lock);
+	return file->initialized;
+}
+
+const char *CachedFileHandle::GetData() const {
+	annotated_lock_guard<annotated_mutex> guard(file->lock);
+	D_ASSERT(file->initialized);
+	return const_char_ptr_cast(file->data.get());
+}
+
+idx_t CachedFileHandle::GetSize() const {
+	annotated_lock_guard<annotated_mutex> guard(file->lock);
+	D_ASSERT(file->initialized);
+	return file->size;
+}
+
+CachedFileDownload::CachedFileDownload(shared_ptr<CachedFile> file_p, Allocator &allocator_p)
+    : file(std::move(file_p)), allocator(allocator_p) {
+}
+
+CachedFileDownload::~CachedFileDownload() {
+	Abort();
+}
+
+void CachedFileDownload::ReserveInternal(idx_t capacity) {
+	if (capacity <= file->capacity) {
+		return;
 	}
-	if (!lock) {
-		throw InternalException("Cannot reset a buffer for a cached file without lock");
+	auto new_data = allocator.Allocate(capacity);
+	if (file->size > 0) {
+		memcpy(new_data.get(), file->data.get(), file->size);
 	}
-	file->data.reset();
+	file->data = std::move(new_data);
+	file->capacity = capacity;
+}
+
+void CachedFileDownload::Reserve(idx_t capacity) {
+	annotated_lock_guard<annotated_mutex> guard(file->lock);
+	ReserveInternal(capacity);
+}
+
+void CachedFileDownload::Append(const_data_ptr_t data, idx_t length) {
+	if (length == 0) {
+		return;
+	}
+	annotated_lock_guard<annotated_mutex> guard(file->lock);
+	if (length > NumericLimits<idx_t>::Maximum() - file->size) {
+		throw OutOfMemoryException("Cached file size exceeds the maximum allocation size");
+	}
+	const auto required_capacity = file->size + length;
+	if (required_capacity > file->capacity) {
+		auto new_capacity = MaxValue<idx_t>(file->capacity, length);
+		while (new_capacity < required_capacity) {
+			if (new_capacity > NumericLimits<idx_t>::Maximum() / 2) {
+				new_capacity = required_capacity;
+				break;
+			}
+			new_capacity *= 2;
+		}
+		ReserveInternal(new_capacity);
+	}
+	memcpy(file->data.get() + file->size, data, length);
+	file->size += length;
+}
+
+void CachedFileDownload::Reset() {
+	annotated_lock_guard<annotated_mutex> guard(file->lock);
+	file->data.Reset();
 	file->capacity = 0;
 	file->size = 0;
 }
 
-void CachedFileHandle::GrowBuffer(idx_t new_capacity, idx_t bytes_to_copy) {
-	// copy shared ptr to old data
-	auto old_data = file->data;
-	// allocate new buffer that can hold the new capacity
-	AllocateBuffer(new_capacity);
-	// copy the old data
-	Write(old_data.get(), bytes_to_copy);
+void CachedFileDownload::Finalize() {
+	annotated_lock_guard<annotated_mutex> guard(file->lock);
+	D_ASSERT(file->downloading);
+	D_ASSERT(!file->initialized);
+	file->initialized = true;
+	file->downloading = false;
+	active = false;
+	file->download_complete.notify_all();
 }
 
-void CachedFileHandle::Write(const char *buffer, idx_t length, idx_t offset) {
-	//! Only write to non-initialized files with a lock;
-	D_ASSERT(!file->initialized && lock);
-	memcpy(file->data.get() + offset, buffer, length);
+void CachedFileDownload::Abort() {
+	if (!active) {
+		return;
+	}
+	annotated_lock_guard<annotated_mutex> guard(file->lock);
+	D_ASSERT(file->downloading);
+	file->data.Reset();
+	file->capacity = 0;
+	file->size = 0;
+	file->downloading = false;
+	active = false;
+	file->download_complete.notify_all();
 }
 
 void HTTPState::Reset() {
@@ -68,8 +130,9 @@ void HTTPState::Reset() {
 	total_bytes_received = 0;
 	total_bytes_sent = 0;
 
-	// Reset cached files
-	cached_files.clear();
+	// Reset per-path state
+	annotated_lock_guard<annotated_mutex> lock(file_states_mutex);
+	file_states.clear();
 }
 
 shared_ptr<HTTPState> HTTPState::TryGetState(ClientContext &context) {
@@ -109,19 +172,19 @@ void HTTPState::WriteProfilingInformation(std::ostream &ss) {
 	ss << "└─────────────────────────────────────┘\n";
 }
 
-//! Get cache entry, create if not exists
-shared_ptr<CachedFile> HTTPState::GetCachedFile(const string &path) {
-	lock_guard<mutex> lock(cached_files_mutex);
-	auto &cache_entry_ref = cached_files[path];
-	if (!cache_entry_ref) {
-		cache_entry_ref = make_shared_ptr<CachedFile>();
+//! Get per-path state, create if it does not exist
+shared_ptr<HTTPFileState> HTTPState::GetFileState(const string &path) {
+	annotated_lock_guard<annotated_mutex> lock(file_states_mutex);
+	auto &file_state = file_states[path];
+	if (!file_state) {
+		file_state = make_shared_ptr<HTTPFileState>();
 	}
-	return cache_entry_ref;
+	return file_state;
 }
 
-void HTTPState::EraseCachedFile(const string &path) {
-	lock_guard<mutex> lock(cached_files_mutex);
-	cached_files.erase(path);
+void HTTPState::EraseFileState(const string &path) {
+	annotated_lock_guard<annotated_mutex> lock(file_states_mutex);
+	file_states.erase(path);
 }
 
 } // namespace duckdb

--- a/src/http_state.cpp
+++ b/src/http_state.cpp
@@ -3,8 +3,12 @@
 
 namespace duckdb {
 
-unique_ptr<CachedFileHandle> CachedFile::GetHandle() {
-	return make_uniq<CachedFileHandle>(shared_from_this());
+unique_ptr<CachedFileHandle> CachedFile::TryGetHandle() {
+	annotated_lock_guard<annotated_mutex> guard(lock);
+	if (!cached_data) {
+		return nullptr;
+	}
+	return make_uniq<CachedFileHandle>(cached_data);
 }
 
 unique_ptr<CachedFileDownload> CachedFile::StartDownload(Allocator &allocator) {
@@ -12,7 +16,7 @@ unique_ptr<CachedFileDownload> CachedFile::StartDownload(Allocator &allocator) {
 	while (downloading) {
 		download_complete.wait(guard, [&]() DUCKDB_REQUIRES(lock) { return !downloading; });
 	}
-	if (initialized) {
+	if (cached_data) {
 		return nullptr;
 	}
 	auto result = unique_ptr<CachedFileDownload>(new CachedFileDownload(shared_from_this(), allocator));
@@ -20,23 +24,19 @@ unique_ptr<CachedFileDownload> CachedFile::StartDownload(Allocator &allocator) {
 	return result;
 }
 
-CachedFileHandle::CachedFileHandle(shared_ptr<CachedFile> file_p) : file(std::move(file_p)) {
+void CachedFile::Invalidate() {
+	annotated_lock_guard<annotated_mutex> guard(lock);
+	cached_data.reset();
 }
 
-bool CachedFileHandle::Initialized() const {
-	annotated_lock_guard<annotated_mutex> guard(file->lock);
-	return file->initialized;
+CachedFileHandle::CachedFileHandle(shared_ptr<CachedFileData> file_p) : file(std::move(file_p)) {
 }
 
 const char *CachedFileHandle::GetData() const {
-	annotated_lock_guard<annotated_mutex> guard(file->lock);
-	D_ASSERT(file->initialized);
 	return const_char_ptr_cast(file->data.get());
 }
 
 idx_t CachedFileHandle::GetSize() const {
-	annotated_lock_guard<annotated_mutex> guard(file->lock);
-	D_ASSERT(file->initialized);
 	return file->size;
 }
 
@@ -49,19 +49,18 @@ CachedFileDownload::~CachedFileDownload() {
 }
 
 void CachedFileDownload::ReserveInternal(idx_t capacity) {
-	if (capacity <= file->capacity) {
+	if (capacity <= this->capacity) {
 		return;
 	}
 	auto new_data = allocator.Allocate(capacity);
-	if (file->size > 0) {
-		memcpy(new_data.get(), file->data.get(), file->size);
+	if (size > 0) {
+		memcpy(new_data.get(), data.get(), size);
 	}
-	file->data = std::move(new_data);
-	file->capacity = capacity;
+	data = std::move(new_data);
+	this->capacity = capacity;
 }
 
 void CachedFileDownload::Reserve(idx_t capacity) {
-	annotated_lock_guard<annotated_mutex> guard(file->lock);
 	ReserveInternal(capacity);
 }
 
@@ -69,13 +68,12 @@ void CachedFileDownload::Append(const_data_ptr_t data, idx_t length) {
 	if (length == 0) {
 		return;
 	}
-	annotated_lock_guard<annotated_mutex> guard(file->lock);
-	if (length > NumericLimits<idx_t>::Maximum() - file->size) {
+	if (length > NumericLimits<idx_t>::Maximum() - size) {
 		throw OutOfMemoryException("Cached file size exceeds the maximum allocation size");
 	}
-	const auto required_capacity = file->size + length;
-	if (required_capacity > file->capacity) {
-		auto new_capacity = MaxValue<idx_t>(file->capacity, length);
+	const auto required_capacity = size + length;
+	if (required_capacity > capacity) {
+		auto new_capacity = MaxValue<idx_t>(capacity, length);
 		while (new_capacity < required_capacity) {
 			if (new_capacity > NumericLimits<idx_t>::Maximum() / 2) {
 				new_capacity = required_capacity;
@@ -85,25 +83,26 @@ void CachedFileDownload::Append(const_data_ptr_t data, idx_t length) {
 		}
 		ReserveInternal(new_capacity);
 	}
-	memcpy(file->data.get() + file->size, data, length);
-	file->size += length;
+	memcpy(this->data.get() + size, data, length);
+	size += length;
 }
 
 void CachedFileDownload::Reset() {
-	annotated_lock_guard<annotated_mutex> guard(file->lock);
-	file->data.Reset();
-	file->capacity = 0;
-	file->size = 0;
+	data.Reset();
+	capacity = 0;
+	size = 0;
 }
 
-void CachedFileDownload::Finalize() {
+unique_ptr<CachedFileHandle> CachedFileDownload::Finalize() {
 	annotated_lock_guard<annotated_mutex> guard(file->lock);
 	D_ASSERT(file->downloading);
-	D_ASSERT(!file->initialized);
-	file->initialized = true;
+	D_ASSERT(!file->cached_data);
+	auto cached_data = make_shared_ptr<CachedFileData>(std::move(data), size);
+	file->cached_data = cached_data;
 	file->downloading = false;
 	active = false;
 	file->download_complete.notify_all();
+	return make_uniq<CachedFileHandle>(std::move(cached_data));
 }
 
 void CachedFileDownload::Abort() {
@@ -112,9 +111,6 @@ void CachedFileDownload::Abort() {
 	}
 	annotated_lock_guard<annotated_mutex> guard(file->lock);
 	D_ASSERT(file->downloading);
-	file->data.Reset();
-	file->capacity = 0;
-	file->size = 0;
 	file->downloading = false;
 	active = false;
 	file->download_complete.notify_all();

--- a/src/http_state.cpp
+++ b/src/http_state.cpp
@@ -98,13 +98,18 @@ void HTTPState::WriteProfilingInformation(std::ostream &ss) {
 }
 
 //! Get cache entry, create if not exists
-shared_ptr<CachedFile> &HTTPState::GetCachedFile(const string &path) {
+shared_ptr<CachedFile> HTTPState::GetCachedFile(const string &path) {
 	lock_guard<mutex> lock(cached_files_mutex);
 	auto &cache_entry_ref = cached_files[path];
 	if (!cache_entry_ref) {
 		cache_entry_ref = make_shared_ptr<CachedFile>();
 	}
 	return cache_entry_ref;
+}
+
+void HTTPState::EraseCachedFile(const string &path) {
+	lock_guard<mutex> lock(cached_files_mutex);
+	cached_files.erase(path);
 }
 
 } // namespace duckdb

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -243,16 +243,15 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunPutRequest(string url, HTTPHeaders h
 }
 
 unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRequest(HTTPFileHandle &hfh, string url, HTTPHeaders header_map,
-                                                       HTTPFSParams &http_params, HTTPErrorCallback get_error,
-                                                       HTTPSendCallback send_request) {
-	D_ASSERT(hfh.cached_file_download);
+                                                       HTTPFSParams &http_params, CachedFileDownload &download,
+                                                       HTTPErrorCallback get_error, HTTPSendCallback send_request) {
 	GetRequestInfo get_request(
 	    url, header_map, http_params,
 	    [&](const HTTPResponse &response) {
 		    if (static_cast<int>(response.status) >= 400) {
 			    throw get_error(response);
 		    }
-		    hfh.cached_file_download->Reset();
+		    download.Reset();
 		    optional_idx content_length;
 		    if (response.HasHeader("Content-Length")) {
 			    try {
@@ -262,7 +261,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRequest(HTTPFileHandle &hfh, stri
 			    }
 		    }
 		    if (content_length.IsValid() && content_length.GetIndex() > 0) {
-			    hfh.cached_file_download->Reserve(content_length.GetIndex());
+			    download.Reserve(content_length.GetIndex());
 		    }
 		    if (http_params.s3_version_id_pinning && response.HasHeader("x-amz-version-id")) {
 			    lock_guard<mutex> lck(hfh.mu);
@@ -273,7 +272,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRequest(HTTPFileHandle &hfh, stri
 		    return true;
 	    },
 	    [&](const_data_ptr_t data, idx_t data_length) {
-		    hfh.cached_file_download->Append(data, data_length);
+		    download.Append(data, data_length);
 		    return true;
 	    });
 
@@ -299,8 +298,8 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh,
 	string range_expr = "bytes=" + to_string(file_offset) + "-" + to_string(file_offset + buffer_out_len - 1);
 	header_map.Insert("Range", range_expr);
 
-	D_ASSERT(http_params.state);
-	auto range_request = http_params.state->GetFileState(hfh.path)->BeginRangeRequest();
+	D_ASSERT(hfh.file_state);
+	auto range_request = hfh.file_state->BeginRangeRequest(auto_fallback_to_full_file_download);
 	if (range_request.Support() == RangeRequestSupport::NOT_SUPPORTED && auto_fallback_to_full_file_download) {
 		auto response = make_uniq<HTTPResponse>(HTTPStatusCode::INVALID);
 		SetRangeRequestNotSupported(*response);
@@ -460,14 +459,15 @@ HTTPException HTTPFileSystem::GetHTTPError(FileHandle &, const HTTPResponse &res
 	return HTTPException(response, error);
 }
 
-unique_ptr<HTTPResponse> HTTPFileSystem::GetRequest(FileHandle &handle, string url, HTTPHeaders header_map) {
+unique_ptr<HTTPResponse> HTTPFileSystem::GetRequest(FileHandle &handle, string url, HTTPHeaders header_map,
+                                                    CachedFileDownload &download) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
 	AddUserAgentIfAvailable(hfh.http_params, header_map);
 	AddHandleHeaders(hfh.http_params, header_map);
 
 	auto http_client = hfh.GetClient();
 	auto response = RunGetRequest(
-	    hfh, url, header_map, hfh.http_params,
+	    hfh, url, header_map, hfh.http_params, download,
 	    [&](const HTTPResponse &response) { return GetHTTPError(handle, response, url); },
 	    [&](BaseRequest &request) { return hfh.http_params.http_util.Request(request, http_client); });
 	hfh.StoreClient(std::move(http_client));
@@ -690,17 +690,20 @@ bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders
 bool HTTPFileSystem::ReadInternal(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
 
-	D_ASSERT(hfh.http_params.state);
-	if (hfh.cached_file_handle) {
-		if (!hfh.cached_file_handle->Initialized()) {
-			throw InternalException("Cached file not initialized properly");
-		}
-		if (hfh.cached_file_handle->GetSize() < location + nr_bytes) {
+	D_ASSERT(hfh.file_state);
+	auto cached_file = hfh.file_state->TryGetCachedFileHandle();
+	if (cached_file) {
+		if (cached_file->GetSize() < location + nr_bytes) {
 			throw IOException("Cached file length can't satisfy the requested Read. You can try to resolve this by "
 			                  "enabling `SET force_download=true`");
 		}
-		memcpy(buffer, hfh.cached_file_handle->GetData() + location, nr_bytes);
+		memcpy(buffer, cached_file->GetData() + location, nr_bytes);
 		DUCKDB_LOG_FILE_SYSTEM_READ(handle, nr_bytes, location);
+		if (hfh.flags.RequireParallelAccess()) {
+			std::lock_guard<mutex> lck(hfh.mu);
+			hfh.file_offset = location + nr_bytes;
+			return true;
+		}
 		hfh.file_offset = location + nr_bytes;
 		return true;
 	}
@@ -807,12 +810,12 @@ void HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, id
 	const auto head_reported_length = hfh.length;
 
 	bool should_write_cache = false;
-	hfh.FullDownload(*this, should_write_cache);
+	auto cached_file = FullDownload(hfh, should_write_cache);
 
-	const auto downloaded_length = hfh.cached_file_handle->GetSize();
+	const auto downloaded_length = cached_file->GetSize();
 	if (downloaded_length != head_reported_length) {
+		hfh.file_state->InvalidateCachedFile();
 		hfh.http_params.state->EraseFileState(hfh.path);
-		hfh.cached_file_handle.reset();
 		throw HTTPException(Exception::ConstructMessage(
 		    "The size reported by HEAD for '%s' was %llu bytes, but the full GET downloaded %llu bytes. You can try "
 		    "to resolve this by enabling `SET force_download=true`",
@@ -917,36 +920,28 @@ static optional_ptr<HTTPMetadataCache> TryGetMetadataCache(optional_ptr<FileOpen
 	return nullptr;
 }
 
-void HTTPFileHandle::FullDownload(HTTPFileSystem &hfs, bool &should_write_cache) {
-	lock_guard<mutex> guard(full_download_mutex);
-	if (cached_file_handle && cached_file_handle->Initialized()) {
-		length = cached_file_handle->GetSize();
-		should_write_cache = false;
-		return;
-	}
-	auto file_state = http_params.state->GetFileState(path);
-	cached_file_handle = file_state->GetCachedFileHandle();
-	cached_file_download = file_state->StartCachedFileDownload(*buffer_allocator);
-	if (cached_file_download) {
-		try {
-			auto full_download_result = hfs.GetRequest(*this, path, {});
-			if (full_download_result->status != HTTPStatusCode::OK_200) {
-				throw HTTPException(*full_download_result, "Full download failed to to URL \"%s\": %d (%s)",
-				                    full_download_result->url, static_cast<int>(full_download_result->status),
-				                    full_download_result->GetError());
-			}
-		} catch (...) {
-			ResetDownloadState();
-			cached_file_handle.reset();
-			throw;
-		}
-		cached_file_download->Finalize();
-		cached_file_download.reset();
-		length = cached_file_handle->GetSize();
-	} else {
-		length = cached_file_handle->GetSize();
-	}
+unique_ptr<CachedFileHandle> HTTPFileSystem::FullDownload(HTTPFileHandle &hfh, bool &should_write_cache) {
+	D_ASSERT(hfh.file_state);
+	D_ASSERT(hfh.buffer_allocator);
 	should_write_cache = false;
+
+	while (true) {
+		if (auto cached_file = hfh.file_state->TryGetCachedFileHandle()) {
+			return cached_file;
+		}
+
+		auto download = hfh.file_state->StartCachedFileDownload(*hfh.buffer_allocator);
+		if (!download) {
+			continue;
+		}
+		auto full_download_result = GetRequest(hfh, hfh.path, {}, *download);
+		if (full_download_result->status != HTTPStatusCode::OK_200) {
+			throw HTTPException(*full_download_result, "Full download failed to to URL \"%s\": %d (%s)",
+			                    full_download_result->url, static_cast<int>(full_download_result->status),
+			                    full_download_result->GetError());
+		}
+		return download->Finalize();
+	}
 }
 
 bool HTTPFileSystem::TryParseLastModifiedTime(const string &timestamp, timestamp_t &result) {
@@ -992,23 +987,14 @@ optional_idx TryParseContentLength(const HTTPHeaders &headers) {
 	}
 }
 
-void HTTPFileHandle::ResetDownloadState() {
-	cached_file_download.reset();
-	length = 0;
-}
-
 void HTTPFileHandle::LoadFileInfo() {
 
 	// Check if file is already fully cached (e.g., from a prior force_download_threshold open)
-	if (http_params.state) {
-		auto file_state = http_params.state->GetFileState(path);
-		auto handle = file_state->GetCachedFileHandle();
-		if (handle->Initialized()) {
-			length = handle->GetSize();
-			cached_file_handle = std::move(handle);
-			initialized = true;
-			return;
-		}
+	D_ASSERT(file_state);
+	if (auto cached_file = file_state->TryGetCachedFileHandle()) {
+		length = cached_file->GetSize();
+		initialized = true;
+		return;
 	}
 
 	if (initialized || force_full_download) {
@@ -1076,7 +1062,7 @@ void HTTPFileHandle::LoadFileInfo() {
 		auto accept_ranges = res->headers.GetHeaderValue("Accept-Ranges");
 		StringUtil::Trim(accept_ranges);
 		if (StringUtil::CIEquals(accept_ranges, "bytes")) {
-			http_params.state->GetFileState(path)->MarkRangeRequestsSupported();
+			file_state->MarkRangeRequestsSupported();
 		}
 	}
 	initialized = true;
@@ -1134,6 +1120,7 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 	if (!http_params.state) {
 		http_params.state = make_shared_ptr<HTTPState>();
 	}
+	file_state = http_params.state->GetFileState(path);
 
 	if (opener) {
 		TryAddLogger(*opener);
@@ -1144,7 +1131,7 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 	bool should_write_cache = false;
 	if (flags.OpenForReading()) {
 		if (http_params.force_download) {
-			FullDownload(hfs, should_write_cache);
+			length = hfs.FullDownload(*this, should_write_cache)->GetSize();
 			return;
 		}
 
@@ -1154,16 +1141,6 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 
 			if (found) {
 				InitializeFromCacheEntry(value);
-
-				// If a full file download exists in HTTPState, reuse it
-				// instead of falling through to range requests that may not be supported.
-				if (http_params.state) {
-					auto file_state = http_params.state->GetFileState(path);
-					auto handle = file_state->GetCachedFileHandle();
-					if (handle->Initialized()) {
-						cached_file_handle = std::move(handle);
-					}
-				}
 
 				if (flags.OpenForReading() && !SkipBuffer()) {
 					AllocateReadBuffer(opener);
@@ -1185,7 +1162,7 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 		const auto should_full_download = has_cache_state || meets_threshold || always_download;
 
 		if (should_full_download) {
-			FullDownload(hfs, should_write_cache);
+			length = hfs.FullDownload(*this, should_write_cache)->GetSize();
 		}
 		if (should_write_cache) {
 			current_cache->Insert(path, GetCacheEntry());

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -245,12 +245,24 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunPutRequest(string url, HTTPHeaders h
 unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRequest(HTTPFileHandle &hfh, string url, HTTPHeaders header_map,
                                                        HTTPFSParams &http_params, HTTPErrorCallback get_error,
                                                        HTTPSendCallback send_request) {
-	D_ASSERT(hfh.cached_file_handle);
+	D_ASSERT(hfh.cached_file_download);
 	GetRequestInfo get_request(
 	    url, header_map, http_params,
 	    [&](const HTTPResponse &response) {
 		    if (static_cast<int>(response.status) >= 400) {
 			    throw get_error(response);
+		    }
+		    hfh.cached_file_download->Reset();
+		    optional_idx content_length;
+		    if (response.HasHeader("Content-Length")) {
+			    try {
+				    content_length = std::stoull(response.GetHeaderValue("Content-Length"));
+			    } catch (const std::exception &) {
+				    // Grow the buffer incrementally when Content-Length is not numeric.
+			    }
+		    }
+		    if (content_length.IsValid() && content_length.GetIndex() > 0) {
+			    hfh.cached_file_download->Reserve(content_length.GetIndex());
 		    }
 		    if (http_params.s3_version_id_pinning && response.HasHeader("x-amz-version-id")) {
 			    lock_guard<mutex> lck(hfh.mu);
@@ -261,23 +273,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRequest(HTTPFileHandle &hfh, stri
 		    return true;
 	    },
 	    [&](const_data_ptr_t data, idx_t data_length) {
-		    if (!hfh.cached_file_handle->GetCapacity()) {
-			    hfh.cached_file_handle->AllocateBuffer(data_length);
-			    hfh.length = data_length;
-			    hfh.cached_file_handle->Write(const_char_ptr_cast(data), data_length);
-		    } else {
-			    auto new_capacity = hfh.cached_file_handle->GetCapacity();
-			    while (new_capacity < hfh.length + data_length) {
-				    new_capacity *= 2;
-			    }
-			    // Grow buffer when running out of space
-			    if (new_capacity != hfh.cached_file_handle->GetCapacity()) {
-				    hfh.cached_file_handle->GrowBuffer(new_capacity, hfh.length);
-			    }
-			    // We can just copy stuff
-			    hfh.cached_file_handle->Write(const_char_ptr_cast(data), data_length, hfh.length);
-			    hfh.length += data_length;
-		    }
+		    hfh.cached_file_download->Append(data, data_length);
 		    return true;
 	    });
 
@@ -295,6 +291,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh,
 	header_map.Insert("Range", range_expr);
 
 	idx_t out_offset = 0;
+	bool range_request_not_supported = false;
 	GetRequestInfo get_request(
 	    url, header_map, http_params,
 	    [&](const HTTPResponse &response) {
@@ -340,7 +337,8 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh,
 					    // Content-Length header contains a non-numeric value, so skip validation.
 				    }
 				    if (parsed && (idx_t)content_length != buffer_out_len) {
-					    RangeRequestNotSupportedException::Throw();
+					    range_request_not_supported = true;
+					    return false;
 				    }
 			    }
 		    }
@@ -360,6 +358,15 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh,
 
 	get_request.try_request = auto_fallback_to_full_file_download;
 	auto response = send_request(get_request);
+	if (range_request_not_supported) {
+		try {
+			RangeRequestNotSupportedException::Throw();
+		} catch (HTTPException &ex) {
+			response->request_error = ex.what();
+			response->success = false;
+		}
+		return response;
+	}
 	if (response && !response->HasRequestError() && response->Success() && buffer_out != nullptr &&
 	    out_offset != buffer_out_len) {
 		throw IOException("Short read for HTTP GET to '%s': requested range %s (%llu bytes), but received %llu bytes",
@@ -626,6 +633,12 @@ static bool RespondedWithRangeRequestNotSupported(const HTTPResponse &res) {
 bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders header_map, idx_t file_offset,
                                      char *buffer_out, idx_t buffer_out_len) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
+	auto file_state = hfh.http_params.state->GetFileState(hfh.path);
+	auto range_request = file_state->LockRangeRequestState();
+	if (range_request.Support() == RangeRequestSupport::NOT_SUPPORTED &&
+	    hfh.http_params.auto_fallback_to_full_download) {
+		return false;
+	}
 
 	const auto timestamp_before = std::chrono::steady_clock::now();
 	auto res = GetRangeRequest(handle, url, header_map, file_offset, buffer_out, buffer_out_len);
@@ -633,9 +646,9 @@ bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders
 	if (res) {
 		// Request failed and we have a request error
 		if (res->HasRequestError()) {
-
 			// Special case: we can do a retry with a full file download
 			if (RespondedWithRangeRequestNotSupported(*res)) {
+				range_request.MarkNotSupported();
 				if (hfh.http_params.auto_fallback_to_full_download) {
 					return false;
 				}
@@ -647,6 +660,7 @@ bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders
 		// Request succeeded TODO: fix upstream that 206 is not considered success
 		if (res->Success() || res->status == HTTPStatusCode::PartialContent_206 ||
 		    res->status == HTTPStatusCode::Accepted_202) {
+			range_request.MarkSupported();
 
 			if (!hfh.flags.RequireParallelAccess()) {
 				// Update range request statistics
@@ -789,7 +803,7 @@ void HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, id
 
 	const auto downloaded_length = hfh.cached_file_handle->GetSize();
 	if (downloaded_length != head_reported_length) {
-		hfh.http_params.state->EraseCachedFile(hfh.path);
+		hfh.http_params.state->EraseFileState(hfh.path);
 		hfh.cached_file_handle.reset();
 		throw HTTPException(Exception::ConstructMessage(
 		    "The size reported by HEAD for '%s' was %llu bytes, but the full GET downloaded %llu bytes. You can try "
@@ -902,9 +916,10 @@ void HTTPFileHandle::FullDownload(HTTPFileSystem &hfs, bool &should_write_cache)
 		should_write_cache = false;
 		return;
 	}
-	auto cache_entry = http_params.state->GetCachedFile(path);
-	cached_file_handle = cache_entry->GetHandle();
-	if (!cached_file_handle->Initialized()) {
+	auto file_state = http_params.state->GetFileState(path);
+	cached_file_handle = file_state->GetCachedFileHandle();
+	cached_file_download = file_state->StartCachedFileDownload(*buffer_allocator);
+	if (cached_file_download) {
 		try {
 			auto full_download_result = hfs.GetRequest(*this, path, {});
 			if (full_download_result->status != HTTPStatusCode::OK_200) {
@@ -917,7 +932,9 @@ void HTTPFileHandle::FullDownload(HTTPFileSystem &hfs, bool &should_write_cache)
 			cached_file_handle.reset();
 			throw;
 		}
-		cached_file_handle->SetInitialized(length);
+		cached_file_download->Finalize();
+		cached_file_download.reset();
+		length = cached_file_handle->GetSize();
 	} else {
 		length = cached_file_handle->GetSize();
 	}
@@ -968,9 +985,7 @@ optional_idx TryParseContentLength(const HTTPHeaders &headers) {
 }
 
 void HTTPFileHandle::ResetDownloadState() {
-	if (cached_file_handle) {
-		cached_file_handle->ResetBuffer();
-	}
+	cached_file_download.reset();
 	length = 0;
 }
 
@@ -978,8 +993,8 @@ void HTTPFileHandle::LoadFileInfo() {
 
 	// Check if file is already fully cached (e.g., from a prior force_download_threshold open)
 	if (http_params.state) {
-		auto cache_entry = http_params.state->GetCachedFile(path);
-		auto handle = cache_entry->GetHandle();
+		auto file_state = http_params.state->GetFileState(path);
+		auto handle = file_state->GetCachedFileHandle();
 		if (handle->Initialized()) {
 			length = handle->GetSize();
 			cached_file_handle = std::move(handle);
@@ -1093,6 +1108,13 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
 
 void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 	auto &hfs = file_system.Cast<HTTPFileSystem>();
+	auto client_context = FileOpener::TryGetClientContext(opener);
+	if (client_context) {
+		buffer_allocator = BufferAllocator::Get(*client_context);
+	} else {
+		auto database = FileOpener::TryGetDatabase(opener);
+		buffer_allocator = database ? BufferAllocator::Get(*database) : Allocator::DefaultAllocator();
+	}
 	http_params.state = HTTPState::TryGetState(opener);
 	if (!http_params.state) {
 		http_params.state = make_shared_ptr<HTTPState>();
@@ -1121,8 +1143,8 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 				// If a full file download exists in HTTPState, reuse it
 				// instead of falling through to range requests that may not be supported.
 				if (http_params.state) {
-					auto cache_entry = http_params.state->GetCachedFile(path);
-					auto handle = cache_entry->GetHandle();
+					auto file_state = http_params.state->GetFileState(path);
+					auto handle = file_state->GetCachedFileHandle();
 					if (handle->Initialized()) {
 						cached_file_handle = std::move(handle);
 					}

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -1,4 +1,6 @@
 #include "httpfs.hpp"
+#include "duckdb/logging/logger.hpp"
+#include "duckdb/logging/log_manager.hpp"
 
 #include "duckdb/common/atomic.hpp"
 #include "duckdb/common/exception/http_exception.hpp"

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -357,7 +357,14 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh,
 	    });
 
 	get_request.try_request = auto_fallback_to_full_file_download;
-	return send_request(get_request);
+	auto response = send_request(get_request);
+	if (response && !response->HasRequestError() && response->Success() && buffer_out != nullptr &&
+	    out_offset != buffer_out_len) {
+		throw IOException("Short read for HTTP GET to '%s': requested range %s (%llu bytes), but received %llu bytes",
+		                  url, range_expr, static_cast<unsigned long long>(buffer_out_len),
+		                  static_cast<unsigned long long>(out_offset));
+	}
+	return response;
 }
 
 unique_ptr<HTTPResponse> HTTPFileSystem::PostRequest(HTTPInput &input, string url, HTTPHeaders header_map,
@@ -579,6 +586,19 @@ bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders
 	auto res = GetRangeRequest(handle, url, header_map, file_offset, buffer_out, buffer_out_len);
 
 	if (res) {
+		// Request failed and we have a request error
+		if (res->HasRequestError()) {
+
+			// Special case: we can do a retry with a full file download
+			if (RespondedWithRangeRequestNotSupported(*res)) {
+				if (hfh.http_params.auto_fallback_to_full_download) {
+					return false;
+				}
+			}
+			ErrorData error(res->GetRequestError());
+			error.Throw();
+		}
+
 		// Request succeeded TODO: fix upstream that 206 is not considered success
 		if (res->Success() || res->status == HTTPStatusCode::PartialContent_206 ||
 		    res->status == HTTPStatusCode::Accepted_202) {
@@ -594,19 +614,6 @@ bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders
 			return true;
 		}
 
-		// Request failed and we have a request error
-		if (res->HasRequestError()) {
-
-			// Special case: we can do a retry with a full file download
-			if (RespondedWithRangeRequestNotSupported(*res)) {
-				auto &hfh = handle.Cast<HTTPFileHandle>();
-				if (hfh.http_params.auto_fallback_to_full_download) {
-					return false;
-				}
-			}
-			ErrorData error(res->GetRequestError());
-			error.Throw();
-		}
 		throw HTTPException(*res, "Request returned HTTP %d for HTTP %s to '%s'", static_cast<int>(res->status),
 		                    EnumUtil::ToString(RequestType::GET_REQUEST), url);
 	}
@@ -730,9 +737,21 @@ void HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, id
 	}
 
 	auto &hfh = handle.Cast<HTTPFileHandle>();
+	const auto head_reported_length = hfh.length;
 
 	bool should_write_cache = false;
 	hfh.FullDownload(*this, should_write_cache);
+
+	const auto downloaded_length = hfh.cached_file_handle->GetSize();
+	if (downloaded_length != head_reported_length) {
+		hfh.http_params.state->EraseCachedFile(hfh.path);
+		hfh.cached_file_handle.reset();
+		throw HTTPException(Exception::ConstructMessage(
+		    "The size reported by HEAD for '%s' was %llu bytes, but the full GET downloaded %llu bytes. You can try "
+		    "to resolve this by enabling `SET force_download=true`",
+		    hfh.path, static_cast<unsigned long long>(head_reported_length),
+		    static_cast<unsigned long long>(downloaded_length)));
+	}
 
 	if (!ReadInternal(handle, buffer, nr_bytes, location)) {
 		throw HTTPException("Failed to read from HTTP file after automatically retrying a full file download.");
@@ -833,7 +852,7 @@ static optional_ptr<HTTPMetadataCache> TryGetMetadataCache(optional_ptr<FileOpen
 
 void HTTPFileHandle::FullDownload(HTTPFileSystem &hfs, bool &should_write_cache) {
 	// We are going to download the file at full, we don't need to do no head request.
-	const auto &cache_entry = http_params.state->GetCachedFile(path);
+	auto cache_entry = http_params.state->GetCachedFile(path);
 	cached_file_handle = cache_entry->GetHandle();
 	if (!cached_file_handle->Initialized()) {
 		// Try to fully download the file first
@@ -901,7 +920,7 @@ void HTTPFileHandle::LoadFileInfo() {
 
 	// Check if file is already fully cached (e.g., from a prior force_download_threshold open)
 	if (http_params.state) {
-		const auto &cache_entry = http_params.state->GetCachedFile(path);
+		auto cache_entry = http_params.state->GetCachedFile(path);
 		auto handle = cache_entry->GetHandle();
 		if (handle->Initialized()) {
 			length = handle->GetSize();
@@ -1044,7 +1063,7 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 				// If a full file download exists in HTTPState, reuse it
 				// instead of falling through to range requests that may not be supported.
 				if (http_params.state) {
-					auto &cache_entry = http_params.state->GetCachedFile(path);
+					auto cache_entry = http_params.state->GetCachedFile(path);
 					auto handle = cache_entry->GetHandle();
 					if (handle->Initialized()) {
 						cached_file_handle = std::move(handle);

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -1166,14 +1166,29 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 	}
 }
 
-unique_ptr<HTTPClient> HTTPFileHandle::GetClient() {
-	// Try to fetch a cached client
-	auto cached_client = client_cache.GetClient();
-	if (cached_client) {
-		return cached_client;
+//! Whether clients are checked out from the shared connection pool instead of the per-handle cache.
+//! Only the curl util pools clients (one pool per database instance); every other configuration
+//! keeps per-handle reuse so it does not pay a fresh connection per request.
+static bool UseSharedConnectionPool(const HTTPParams &http_params) {
+#ifndef EMSCRIPTEN
+	auto &util = http_params.http_util;
+	if (util.GetName() == "HTTPFS-Curl") {
+		return static_cast<const HTTPFSCurlUtil &>(util).connection_caching_enabled;
 	}
+#endif
+	return false;
+}
 
-	// Create a new client
+unique_ptr<HTTPClient> HTTPFileHandle::GetClient() {
+	if (!UseSharedConnectionPool(http_params)) {
+		// no shared pool for this configuration - reuse this handle's cached client
+		auto cached_client = client_cache.GetClient();
+		if (cached_client) {
+			return cached_client;
+		}
+	}
+	// with the shared pool enabled InitializeClient consults the pool, so that concurrent handles
+	// share connections instead of each hoarding a private pool
 	return CreateClient();
 }
 
@@ -1184,7 +1199,12 @@ unique_ptr<HTTPClient> HTTPFileHandle::CreateClient() {
 }
 
 void HTTPFileHandle::StoreClient(unique_ptr<HTTPClient> client) {
-	client_cache.StoreClient(std::move(client));
+	if (!UseSharedConnectionPool(http_params)) {
+		client_cache.StoreClient(std::move(client));
+		return;
+	}
+	// return the client to the shared connection pool so other handles can reuse it
+	http_params.http_util.CloseClient(std::move(client));
 }
 
 HTTPFileHandle::~HTTPFileHandle() {

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -280,6 +280,15 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRequest(HTTPFileHandle &hfh, stri
 	return send_request(get_request);
 }
 
+static void SetRangeRequestNotSupported(HTTPResponse &response) {
+	try {
+		RangeRequestNotSupportedException::Throw();
+	} catch (HTTPException &ex) {
+		response.request_error = ex.what();
+		response.success = false;
+	}
+}
+
 unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh, string url, HTTPHeaders header_map,
                                                             HTTPFSParams &http_params, const string &etag,
                                                             bool auto_fallback_to_full_file_download, idx_t file_offset,
@@ -289,6 +298,14 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh,
 	// send the Range header to read only subset of file
 	string range_expr = "bytes=" + to_string(file_offset) + "-" + to_string(file_offset + buffer_out_len - 1);
 	header_map.Insert("Range", range_expr);
+
+	D_ASSERT(http_params.state);
+	auto range_request = http_params.state->GetFileState(hfh.path)->BeginRangeRequest();
+	if (range_request.Support() == RangeRequestSupport::NOT_SUPPORTED && auto_fallback_to_full_file_download) {
+		auto response = make_uniq<HTTPResponse>(HTTPStatusCode::INVALID);
+		SetRangeRequestNotSupported(*response);
+		return response;
+	}
 
 	idx_t out_offset = 0;
 	bool range_request_not_supported = false;
@@ -338,8 +355,12 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh,
 				    }
 				    if (parsed && (idx_t)content_length != buffer_out_len) {
 					    range_request_not_supported = true;
+					    range_request.MarkNotSupported();
 					    return false;
 				    }
+			    }
+			    if (response.status == HTTPStatusCode::PartialContent_206) {
+				    range_request.MarkSupported();
 			    }
 		    }
 		    return true;
@@ -359,12 +380,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh,
 	get_request.try_request = auto_fallback_to_full_file_download;
 	auto response = send_request(get_request);
 	if (range_request_not_supported) {
-		try {
-			RangeRequestNotSupportedException::Throw();
-		} catch (HTTPException &ex) {
-			response->request_error = ex.what();
-			response->success = false;
-		}
+		SetRangeRequestNotSupported(*response);
 		return response;
 	}
 	if (response && !response->HasRequestError() && response->Success() && buffer_out != nullptr &&
@@ -377,6 +393,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh,
 	// Feed the prefetch cost model a network measurement for this ranged GET
 	if (response && (response->Success() || response->status == HTTPStatusCode::PartialContent_206 ||
 	                 response->status == HTTPStatusCode::Accepted_202)) {
+		range_request.MarkSupported();
 		const auto elapsed_nanos =
 		    TimePoint::ElapsedNanos(get_request.request_monotonic_start, get_request.request_monotonic_end);
 		const double total_seconds = elapsed_nanos > 0 ? static_cast<double>(elapsed_nanos) / 1e9 : 0;
@@ -633,12 +650,6 @@ static bool RespondedWithRangeRequestNotSupported(const HTTPResponse &res) {
 bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders header_map, idx_t file_offset,
                                      char *buffer_out, idx_t buffer_out_len) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
-	auto file_state = hfh.http_params.state->GetFileState(hfh.path);
-	auto range_request = file_state->LockRangeRequestState();
-	if (range_request.Support() == RangeRequestSupport::NOT_SUPPORTED &&
-	    hfh.http_params.auto_fallback_to_full_download) {
-		return false;
-	}
 
 	const auto timestamp_before = std::chrono::steady_clock::now();
 	auto res = GetRangeRequest(handle, url, header_map, file_offset, buffer_out, buffer_out_len);
@@ -648,7 +659,6 @@ bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders
 		if (res->HasRequestError()) {
 			// Special case: we can do a retry with a full file download
 			if (RespondedWithRangeRequestNotSupported(*res)) {
-				range_request.MarkNotSupported();
 				if (hfh.http_params.auto_fallback_to_full_download) {
 					return false;
 				}
@@ -660,8 +670,6 @@ bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders
 		// Request succeeded TODO: fix upstream that 206 is not considered success
 		if (res->Success() || res->status == HTTPStatusCode::PartialContent_206 ||
 		    res->status == HTTPStatusCode::Accepted_202) {
-			range_request.MarkSupported();
-
 			if (!hfh.flags.RequireParallelAccess()) {
 				// Update range request statistics
 				const auto timestamp_after = std::chrono::steady_clock::now();
@@ -1063,6 +1071,13 @@ void HTTPFileHandle::LoadFileInfo() {
 	}
 	if (http_params.s3_version_id_pinning && res->headers.HasHeader("x-amz-version-id")) {
 		version_id = res->headers.GetHeaderValue("x-amz-version-id");
+	}
+	if (res->headers.HasHeader("Accept-Ranges")) {
+		auto accept_ranges = res->headers.GetHeaderValue("Accept-Ranges");
+		StringUtil::Trim(accept_ranges);
+		if (StringUtil::CIEquals(accept_ranges, "bytes")) {
+			http_params.state->GetFileState(path)->MarkRangeRequestsSupported();
+		}
 	}
 	initialized = true;
 }

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -128,7 +128,7 @@ unique_ptr<HTTPParams> HTTPFSParams::Clone() const {
 	result->override_verify_ssl = override_verify_ssl;
 	result->verify_ssl = verify_ssl;
 	result->http_proxy = http_proxy;
-	result->http_proxy_port = http_proxy_port;
+	result->http_proxy_port = http_proxy.empty() ? 0 : http_proxy_port;
 	result->http_proxy_username = http_proxy_username;
 	result->http_proxy_password = http_proxy_password;
 	result->extra_headers = extra_headers;

--- a/src/httpfs_connection_caching.cpp
+++ b/src/httpfs_connection_caching.cpp
@@ -27,10 +27,9 @@ unique_ptr<HTTPClient> HTTPClientConnectionCache::Find(const string &base_url) {
 	for (size_t i = 0; i < POOL_COUNT; i++) {
 		const size_t idx = (start + i) & (POOL_COUNT - 1);
 		auto &pool = pools[idx];
-		unique_lock<mutex> lock(pool.lock, std::try_to_lock);
-		if (!lock) {
-			continue;
-		}
+		// block instead of skipping: a spurious miss dials a new connection (DNS + TLS),
+		// which is far more expensive than waiting for this short critical section
+		lock_guard<mutex> lock(pool.lock);
 		for (auto &entry : pool.entries) {
 			if (entry && entry->GetBaseUrl() == base_url) {
 				cache_pool_idx = idx;
@@ -46,14 +45,11 @@ void HTTPClientConnectionCache::Store(unique_ptr<HTTPClient> &&client) {
 		return;
 	}
 	const size_t start = cache_pool_idx;
-	// Pass 1: prefer an empty slot in any reachable pool
+	// Pass 1: prefer an empty slot in any pool
 	for (size_t i = 0; i < POOL_COUNT; i++) {
 		const size_t idx = (start + i) & (POOL_COUNT - 1);
 		auto &pool = pools[idx];
-		unique_lock<mutex> lock(pool.lock, std::try_to_lock);
-		if (!lock) {
-			continue;
-		}
+		lock_guard<mutex> lock(pool.lock);
 		for (auto &entry : pool.entries) {
 			if (!entry) {
 				entry = std::move(client);
@@ -62,21 +58,12 @@ void HTTPClientConnectionCache::Store(unique_ptr<HTTPClient> &&client) {
 			}
 		}
 	}
-	// Pass 2: every reachable pool is full — evict at random in the first lockable pool
+	// Pass 2: every pool is full — evict at random in the starting pool
 	RandomEngine engine;
-	for (size_t i = 0; i < POOL_COUNT; i++) {
-		const size_t idx = (start + i) & (POOL_COUNT - 1);
-		auto &pool = pools[idx];
-		unique_lock<mutex> lock(pool.lock, std::try_to_lock);
-		if (!lock) {
-			continue;
-		}
-		const size_t slot = engine.NextRandomInteger() % pool.entries.size();
-		pool.entries[slot] = std::move(client);
-		cache_pool_idx = idx;
-		return;
-	}
-	// Every pool busy — drop the client; will reconnect next time.
+	auto &pool = pools[start];
+	lock_guard<mutex> lock(pool.lock);
+	const size_t slot = engine.NextRandomInteger() % pool.entries.size();
+	pool.entries[slot] = std::move(client);
 }
 
 void HTTPClientConnectionCache::Clear() {

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -324,7 +324,6 @@ public:
 			curl_easy_setopt(*curl, CURLOPT_POSTFIELDS, nullptr);
 			curl_easy_setopt(*curl, CURLOPT_POSTFIELDSIZE, 0);
 			curl_url_cleanup(url);
-			curl_easy_setopt(*curl, CURLOPT_TIMEOUT, info.params.timeout);
 		}
 
 		curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, &request_info->response_code);

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -182,10 +182,13 @@ public:
 			                 0L); // Override default, don't verify that the cert matches the hostname
 		}
 
-		// set read timeout
-		curl_easy_setopt(*curl, CURLOPT_TIMEOUT, http_params.timeout);
 		// set connection timeout
 		curl_easy_setopt(*curl, CURLOPT_CONNECTTIMEOUT, http_params.timeout);
+		// Do NOT impose a hard timeout on the whole transfer
+		curl_easy_setopt(*curl, CURLOPT_TIMEOUT, 0L);                         // no hard timeout for uploads
+		curl_easy_setopt(*curl, CURLOPT_LOW_SPEED_LIMIT, 1024L);              // abort if < 1 KB/s...
+		curl_easy_setopt(*curl, CURLOPT_LOW_SPEED_TIME, http_params.timeout); // ...for 'timeout' consecutive seconds
+
 		// accept content as-is (i.e no decompressing)
 		curl_easy_setopt(*curl, CURLOPT_ACCEPT_ENCODING, NULL);
 		// follow redirects
@@ -306,10 +309,6 @@ public:
 
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
 			curl_easy_setopt(*curl, CURLOPT_CURLU, url);
-
-			curl_easy_setopt(*curl, CURLOPT_TIMEOUT, 0L);                         // no hard timeout for uploads
-			curl_easy_setopt(*curl, CURLOPT_LOW_SPEED_LIMIT, 1024L);              // abort if < 1 KB/s...
-			curl_easy_setopt(*curl, CURLOPT_LOW_SPEED_TIME, info.params.timeout); // ...for X consecutive seconds
 
 			// Perform PUT
 			curl_easy_setopt(*curl, CURLOPT_CUSTOMREQUEST, "PUT");

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -231,11 +231,15 @@ public:
 	public:
 		GetTransferState(HTTPFSCurlClient &client_p, GetRequestInfo &request_p)
 		    : client(client_p), request(request_p), stream_content(bool(request.content_handler)) {
+			curl_easy_setopt(*client.curl, CURLOPT_HEADERFUNCTION, HeaderCallback);
+			curl_easy_setopt(*client.curl, CURLOPT_HEADERDATA, this);
 			curl_easy_setopt(*client.curl, CURLOPT_WRITEFUNCTION, WriteCallback);
 			curl_easy_setopt(*client.curl, CURLOPT_WRITEDATA, this);
 		}
 
 		~GetTransferState() {
+			curl_easy_setopt(*client.curl, CURLOPT_HEADERFUNCTION, RequestHeaderCallback);
+			curl_easy_setopt(*client.curl, CURLOPT_HEADERDATA, &client.request_info->header_collection);
 			curl_easy_setopt(*client.curl, CURLOPT_WRITEFUNCTION, RequestWriteCallback);
 			curl_easy_setopt(*client.curl, CURLOPT_WRITEDATA, &client.request_info->body);
 		}
@@ -271,6 +275,24 @@ public:
 		}
 
 	private:
+		static size_t HeaderCallback(void *contents, size_t size, size_t nmemb, void *userp) {
+			auto &state = *static_cast<GetTransferState *>(userp);
+			const auto total_size = RequestHeaderCallback(
+			    contents, size, nmemb, static_cast<void *>(&state.client.request_info->header_collection));
+			if (total_size == 0 || !state.IsEndOfHeaders(contents, total_size) || state.IsProxyConnectResponse()) {
+				return total_size;
+			}
+			try {
+				if (!state.response_started && !state.StartResponse()) {
+					return state.stopped ? 0 : total_size;
+				}
+			} catch (...) {
+				state.error = std::current_exception();
+				return 0;
+			}
+			return total_size;
+		}
+
 		static size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *userp) {
 			auto &state = *static_cast<GetTransferState *>(userp);
 			const auto total_size = size * nmemb;
@@ -280,6 +302,23 @@ public:
 				state.error = std::current_exception();
 				return 0;
 			}
+		}
+
+		bool IsEndOfHeaders(void *contents, idx_t size) const {
+			auto header = static_cast<const char *>(contents);
+			return (size == 2 && header[0] == '\r' && header[1] == '\n') || (size == 1 && header[0] == '\n');
+		}
+
+		bool IsProxyConnectResponse() const {
+			if (client.request_info->header_collection.empty()) {
+				return false;
+			}
+			auto &headers = client.request_info->header_collection.back();
+			if (!headers.HasHeader("__RESPONSE_STATUS__")) {
+				return false;
+			}
+			auto status = StringUtil::Lower(headers.GetHeaderValue("__RESPONSE_STATUS__"));
+			return status.find("connection established") != string::npos;
 		}
 
 		size_t Write(void *contents, idx_t size) {
@@ -302,7 +341,7 @@ public:
 				throw IOException("Failed to read the HTTP response status");
 			}
 			client.request_info->response_code = NumericCast<uint16_t>(response_code);
-			if (response_code >= 300 && response_code < 400) {
+			if (response_code < 200 || (response_code >= 300 && response_code < 400)) {
 				return false;
 			}
 			response_started = true;

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -284,7 +284,7 @@ public:
 		}
 
 		const char *data = request_info->body.c_str();
-		if (info.content_handler) {
+		if (info.content_handler && res == CURLcode::CURLE_OK) {
 			info.content_handler(const_data_ptr_cast(data), bytes_received);
 		}
 

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -368,20 +368,6 @@ public:
 				request.time_to_fst_byte_sec = starttransfer_seconds;
 			}
 
-			if (!client.request_info->header_collection.empty() &&
-			    client.request_info->header_collection.back().HasHeader("content-length")) {
-				try {
-					// Content-Length can exceed INT_MAX for files larger than 2GB.
-					const idx_t content_length_received =
-					    std::stoull(client.request_info->header_collection.back().GetHeaderValue("content-length"));
-					if (bytes_received != content_length_received) {
-						// The caller decides whether a short response is an error.
-					}
-				} catch (const std::exception &) {
-					// Content-Length is not numeric, so skip validation.
-				}
-			}
-
 			if (client.state) {
 				client.state->total_bytes_received += bytes_received;
 			}

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -227,6 +227,138 @@ public:
 		}
 	}
 
+	class GetTransferState {
+	public:
+		GetTransferState(HTTPFSCurlClient &client_p, GetRequestInfo &request_p)
+		    : client(client_p), request(request_p), stream_content(bool(request.content_handler)) {
+			curl_easy_setopt(*client.curl, CURLOPT_WRITEFUNCTION, WriteCallback);
+			curl_easy_setopt(*client.curl, CURLOPT_WRITEDATA, this);
+		}
+
+		~GetTransferState() {
+			curl_easy_setopt(*client.curl, CURLOPT_WRITEFUNCTION, RequestWriteCallback);
+			curl_easy_setopt(*client.curl, CURLOPT_WRITEDATA, &client.request_info->body);
+		}
+
+		unique_ptr<HTTPResponse> Finish(CURLcode result) {
+			curl_easy_getinfo(*client.curl, CURLINFO_RESPONSE_CODE, &client.request_info->response_code);
+			const bool include_body = !stream_content || client.request_info->response_code >= 400;
+			unique_ptr<HTTPResponse> response;
+			try {
+				if (error) {
+					std::rethrow_exception(error);
+				}
+				if (stopped) {
+					result = CURLE_OK;
+				}
+
+				if (result == CURLE_OK && !response_handler_called) {
+					response_handler_called = true;
+					response = client.TransformResponseCurl(result, include_body);
+					if (request.response_handler) {
+						request.response_handler(*response);
+					}
+				}
+			} catch (...) {
+				RecordMetrics();
+				throw;
+			}
+			RecordMetrics();
+			if (!response) {
+				response = client.TransformResponseCurl(result, include_body);
+			}
+			return response;
+		}
+
+	private:
+		static size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *userp) {
+			auto &state = *static_cast<GetTransferState *>(userp);
+			const auto total_size = size * nmemb;
+			try {
+				return state.Write(contents, total_size);
+			} catch (...) {
+				state.error = std::current_exception();
+				return 0;
+			}
+		}
+
+		size_t Write(void *contents, idx_t size) {
+			if (!response_started && !StartResponse()) {
+				return stopped ? 0 : size;
+			}
+			if (!stream_content || client.request_info->response_code >= 400) {
+				client.request_info->body.append(static_cast<char *>(contents), size);
+			} else if (!request.content_handler(const_data_ptr_cast(contents), size)) {
+				stopped = true;
+				return 0;
+			}
+			bytes_received += size;
+			return size;
+		}
+
+		bool StartResponse() {
+			long response_code;
+			if (curl_easy_getinfo(*client.curl, CURLINFO_RESPONSE_CODE, &response_code) != CURLE_OK) {
+				throw IOException("Failed to read the HTTP response status");
+			}
+			client.request_info->response_code = NumericCast<uint16_t>(response_code);
+			if (response_code >= 300 && response_code < 400) {
+				return false;
+			}
+			response_started = true;
+			if (!stream_content || response_code >= 400) {
+				return true;
+			}
+			response_handler_called = true;
+			if (request.response_handler) {
+				auto response = client.TransformResponseCurl(CURLE_OK, false);
+				if (!request.response_handler(*response)) {
+					stopped = true;
+					return false;
+				}
+			}
+			return true;
+		}
+
+		void RecordMetrics() {
+			request.bytes_received = bytes_received;
+			double starttransfer_seconds = 0;
+			if (curl_easy_getinfo(*client.curl, CURLINFO_STARTTRANSFER_TIME, &starttransfer_seconds) == CURLE_OK &&
+			    starttransfer_seconds > 0) {
+				request.have_time_to_fst_byte = true;
+				request.time_to_fst_byte_sec = starttransfer_seconds;
+			}
+
+			if (!client.request_info->header_collection.empty() &&
+			    client.request_info->header_collection.back().HasHeader("content-length")) {
+				try {
+					// Content-Length can exceed INT_MAX for files larger than 2GB.
+					const idx_t content_length_received =
+					    std::stoull(client.request_info->header_collection.back().GetHeaderValue("content-length"));
+					if (bytes_received != content_length_received) {
+						// The caller decides whether a short response is an error.
+					}
+				} catch (const std::exception &) {
+					// Content-Length is not numeric, so skip validation.
+				}
+			}
+
+			if (client.state) {
+				client.state->total_bytes_received += bytes_received;
+			}
+		}
+
+	private:
+		HTTPFSCurlClient &client;
+		GetRequestInfo &request;
+		const bool stream_content;
+		std::exception_ptr error;
+		idx_t bytes_received = 0;
+		bool response_started = false;
+		bool response_handler_called = false;
+		bool stopped = false;
+	};
+
 	unique_ptr<HTTPResponse> Get(GetRequestInfo &info) override {
 		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
 		ResetRequestInfo();
@@ -249,56 +381,11 @@ public:
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
 			curl_easy_setopt(*curl, CURLOPT_CURLU, url);
 			curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers ? curl_headers.headers : nullptr);
-
+			GetTransferState transfer(*this, info);
 			res = curl->Execute();
 			curl_url_cleanup(url);
+			return transfer.Finish(res);
 		}
-
-		curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, &request_info->response_code);
-
-		const idx_t bytes_received = request_info->body.size();
-
-		//  libcurl reports latency via CURLINFO_STARTTRANSFER_TIME
-		info.bytes_received = bytes_received;
-		double starttransfer_seconds = 0;
-		if (curl_easy_getinfo(*curl, CURLINFO_STARTTRANSFER_TIME, &starttransfer_seconds) == CURLE_OK &&
-		    starttransfer_seconds > 0) {
-			info.have_time_to_fst_byte = true;
-			info.time_to_fst_byte_sec = starttransfer_seconds;
-		}
-
-		if (!request_info->header_collection.empty() &&
-		    request_info->header_collection.back().HasHeader("content-length")) {
-			try {
-				// Use stoull (not stoi) — Content-Length can exceed INT_MAX for files >2GB.
-				const idx_t content_length_received =
-				    std::stoull(request_info->header_collection.back().GetHeaderValue("content-length"));
-				if (bytes_received != content_length_received) {
-					// Something is off, might happen in case of unreliable network
-					// TODO: consider logging this
-				}
-			} catch (const std::exception &) {
-				// Content-Length header contains a non-numeric value — skip validation.
-			}
-		}
-
-		if (state) {
-			state->total_bytes_received += bytes_received;
-		}
-
-		if (info.response_handler) {
-			auto response = TransformResponseCurl(res);
-			if (!info.response_handler(*response)) {
-				return response;
-			}
-		}
-
-		const char *data = request_info->body.c_str();
-		if (info.content_handler && res == CURLcode::CURLE_OK) {
-			info.content_handler(const_data_ptr_cast(data), bytes_received);
-		}
-
-		return TransformResponseCurl(res);
 	}
 
 	unique_ptr<HTTPResponse> Put(PutRequestInfo &info) override {
@@ -543,14 +630,16 @@ private:
 		request_info->response_code = 0;
 	}
 
-	unique_ptr<HTTPResponse> TransformResponseCurl(CURLcode res) {
+	unique_ptr<HTTPResponse> TransformResponseCurl(CURLcode res, bool include_body = true) {
 		auto status_code = HTTPStatusCode(request_info->response_code);
 		auto response = make_uniq<HTTPResponse>(status_code);
 		if (res != CURLcode::CURLE_OK) {
 			response->request_error = curl_easy_strerror(res);
 			return response;
 		}
-		response->body = request_info->body;
+		if (include_body) {
+			response->body = request_info->body;
+		}
 		response->url = request_info->url;
 		response->reason = HTTPUtil::GetStatusMessage(HTTPUtil::ToStatusCode(request_info->response_code));
 		if (!request_info->header_collection.empty()) {

--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -1,4 +1,5 @@
 #include "httpfs_extension.hpp"
+#include "duckdb/logging/logger.hpp"
 
 #include "httpfs_client.hpp"
 #include "create_secret_functions.hpp"

--- a/src/httpfs_httplib_client.cpp
+++ b/src/httpfs_httplib_client.cpp
@@ -70,11 +70,21 @@ public:
 			const auto request_monotonic_start = TimePoint::Tick();
 			idx_t total_bytes = 0;
 			bool first_chunk = true;
-			auto result = TransformResult(client->Get(
+			unique_ptr<HTTPResponse> deferred_response;
+			unique_ptr<HTTPResponse> stopped_response;
+			auto client_result = client->Get(
 			    info.path.c_str(), headers,
 			    [&](const duckdb_httplib_openssl::Response &response) {
 				    auto http_response = TransformResponse(response);
-				    return info.response_handler(*http_response);
+				    if (static_cast<int>(http_response->status) >= 400) {
+					    deferred_response = std::move(http_response);
+					    return true;
+				    }
+				    if (info.response_handler && !info.response_handler(*http_response)) {
+					    stopped_response = std::move(http_response);
+					    return false;
+				    }
+				    return true;
 			    },
 			    [&](const char *data, size_t data_length) {
 				    if (first_chunk) {
@@ -88,10 +98,23 @@ public:
 				    if (state) {
 					    state->total_bytes_received += data_length;
 				    }
-				    return info.content_handler(const_data_ptr_cast(data), data_length);
-			    }));
+				    if (deferred_response) {
+					    deferred_response->body.append(data, data_length);
+					    return true;
+				    }
+				    return !info.content_handler || info.content_handler(const_data_ptr_cast(data), data_length);
+			    });
 			info.bytes_received = total_bytes;
-			return result;
+			if (deferred_response) {
+				if (info.response_handler) {
+					info.response_handler(*deferred_response);
+				}
+				return deferred_response;
+			}
+			if (stopped_response) {
+				return stopped_response;
+			}
+			return TransformResult(std::move(client_result));
 		}
 	}
 	unique_ptr<HTTPResponse> Put(PutRequestInfo &info) override {

--- a/src/include/hffs.hpp
+++ b/src/include/hffs.hpp
@@ -25,7 +25,8 @@ public:
 	vector<OpenFileInfo> Glob(const string &path, FileOpener *opener = nullptr) override;
 
 	duckdb::unique_ptr<HTTPResponse> HeadRequest(FileHandle &handle, string hf_url, HTTPHeaders header_map) override;
-	duckdb::unique_ptr<HTTPResponse> GetRequest(FileHandle &handle, string hf_url, HTTPHeaders header_map) override;
+	duckdb::unique_ptr<HTTPResponse> GetRequest(FileHandle &handle, string hf_url, HTTPHeaders header_map,
+	                                            CachedFileDownload &download) override;
 	duckdb::unique_ptr<HTTPResponse> GetRangeRequest(FileHandle &handle, string hf_url, HTTPHeaders header_map,
 	                                                 idx_t file_offset, char *buffer_out,
 	                                                 idx_t buffer_out_len) override;

--- a/src/include/http_state.hpp
+++ b/src/include/http_state.hpp
@@ -73,7 +73,9 @@ public:
 	//! Reset all counters and cached files
 	void Reset();
 	//! Get cache entry, create if not exists
-	shared_ptr<CachedFile> &GetCachedFile(const string &path);
+	shared_ptr<CachedFile> GetCachedFile(const string &path);
+	//! Erase a cached full download
+	void EraseCachedFile(const string &path);
 	//! Helper functions to get the HTTP state
 	static shared_ptr<HTTPState> TryGetState(ClientContext &context);
 	static shared_ptr<HTTPState> TryGetState(optional_ptr<FileOpener> opener);

--- a/src/include/http_state.hpp
+++ b/src/include/http_state.hpp
@@ -1,83 +1,161 @@
 #pragma once
 
+#include "duckdb/common/allocator.hpp"
 #include "duckdb/common/file_opener.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/client_data.hpp"
 #include "duckdb/common/atomic.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/main/client_context_state.hpp"
 
+#include <condition_variable>
+
 namespace duckdb {
 
 class CachedFileHandle;
+class CachedFileDownload;
+
+enum class RangeRequestSupport : uint8_t { UNKNOWN, SUPPORTED, NOT_SUPPORTED };
+
+class RangeRequestState {
+public:
+	class Guard {
+	public:
+		explicit Guard(RangeRequestState &state_p) : state(state_p), support(state.support.load()), lock() {
+			if (support == RangeRequestSupport::UNKNOWN) {
+				lock = annotated_unique_lock<annotated_mutex>(state.state_mutex);
+				support = state.support.load();
+				if (support != RangeRequestSupport::UNKNOWN) {
+					lock.unlock();
+				}
+			}
+		}
+
+		RangeRequestSupport Support() const {
+			return support;
+		}
+		void MarkSupported() {
+			if (support == RangeRequestSupport::UNKNOWN) {
+				state.support = RangeRequestSupport::SUPPORTED;
+				support = RangeRequestSupport::SUPPORTED;
+			}
+		}
+		void MarkNotSupported() {
+			state.support = RangeRequestSupport::NOT_SUPPORTED;
+			support = RangeRequestSupport::NOT_SUPPORTED;
+		}
+
+	private:
+		RangeRequestState &state;
+		RangeRequestSupport support;
+		annotated_unique_lock<annotated_mutex> lock;
+	};
+
+	Guard Lock() {
+		return Guard(*this);
+	}
+
+private:
+	annotated_mutex state_mutex;
+	atomic<RangeRequestSupport> support = {RangeRequestSupport::UNKNOWN};
+};
 
 //! Represents a file that is intended to be fully downloaded, then used in parallel by multiple threads
 class CachedFile : public enable_shared_from_this<CachedFile> {
 	friend class CachedFileHandle;
+	friend class CachedFileDownload;
 
 public:
-	unique_ptr<CachedFileHandle> GetHandle() {
-		auto this_ptr = shared_from_this();
-		return make_uniq<CachedFileHandle>(this_ptr);
-	}
+	unique_ptr<CachedFileHandle> GetHandle();
+	unique_ptr<CachedFileDownload> StartDownload(Allocator &allocator);
 
 private:
+	//! Protects the download state and cached data
+	mutable annotated_mutex lock;
+	//! Notifies handles waiting for an in-progress download
+	mutable std::condition_variable download_complete DUCKDB_GUARDED_BY(lock);
 	//! Cached Data
-	shared_ptr<char> data;
+	AllocatedData data DUCKDB_GUARDED_BY(lock);
 	//! Data capacity
-	uint64_t capacity = 0;
+	uint64_t capacity DUCKDB_GUARDED_BY(lock) = 0;
 	//! Size of file
-	idx_t size;
-	//! Lock for initializing the file
-	mutex lock;
-	//! When initialized is set to true, the file is safe for parallel reading without holding the lock
-	atomic<bool> initialized = {false};
+	idx_t size DUCKDB_GUARDED_BY(lock) = 0;
+	//! Whether a download is currently populating the cache
+	bool downloading DUCKDB_GUARDED_BY(lock) = false;
+	//! When initialized is true, the cached data is immutable
+	bool initialized DUCKDB_GUARDED_BY(lock) = false;
 };
 
 //! Handle to a CachedFile
 class CachedFileHandle {
 public:
-	explicit CachedFileHandle(shared_ptr<CachedFile> &file_p);
+	explicit CachedFileHandle(shared_ptr<CachedFile> file_p);
 
-	//! allocate a buffer for the file
-	void AllocateBuffer(idx_t size);
-	//! Reset an uninitialized buffer after a failed full download
-	void ResetBuffer();
-	//! Indicate the file is fully downloaded and safe for parallel reading without lock
-	void SetInitialized(idx_t total_size);
-	//! Grow buffer to new size, copying over `bytes_to_copy` to the new buffer
-	void GrowBuffer(idx_t new_capacity, idx_t bytes_to_copy);
-	//! Write to the buffer
-	void Write(const char *buffer, idx_t length, idx_t offset = 0);
-
-	bool Initialized() {
-		return file->initialized;
-	}
-	const char *GetData() {
-		return file->data.get();
-	}
-	uint64_t GetCapacity() {
-		return file->capacity;
-	}
+	bool Initialized() const;
+	const char *GetData() const;
 	//! Return the size of the initialized file
-	idx_t GetSize() {
-		D_ASSERT(file->initialized);
-		return file->size;
+	idx_t GetSize() const;
+
+private:
+	shared_ptr<CachedFile> file;
+};
+
+//! Exclusive handle for populating an uninitialized CachedFile
+class CachedFileDownload {
+	friend class CachedFile;
+
+public:
+	~CachedFileDownload();
+
+	//! Reserve capacity without changing the number of downloaded bytes
+	void Reserve(idx_t capacity);
+	//! Append downloaded bytes, growing the allocation as needed
+	void Append(const_data_ptr_t data, idx_t length);
+	//! Reset bytes written by a prior request attempt
+	void Reset();
+	//! Indicate the file is fully downloaded and safe for parallel reading
+	void Finalize();
+
+private:
+	CachedFileDownload(shared_ptr<CachedFile> file_p, Allocator &allocator_p);
+	void ReserveInternal(idx_t capacity) DUCKDB_REQUIRES(file->lock);
+	void Abort();
+
+	shared_ptr<CachedFile> file;
+	Allocator &allocator;
+	bool active = true;
+};
+
+//! Per-path state shared by all HTTP file handles in a query
+class HTTPFileState {
+public:
+	HTTPFileState() : cached_file(make_shared_ptr<CachedFile>()) {
+	}
+
+	unique_ptr<CachedFileHandle> GetCachedFileHandle() {
+		return cached_file->GetHandle();
+	}
+	unique_ptr<CachedFileDownload> StartCachedFileDownload(Allocator &allocator) {
+		return cached_file->StartDownload(allocator);
+	}
+	RangeRequestState::Guard LockRangeRequestState() {
+		return range_request_state.Lock();
 	}
 
 private:
-	unique_ptr<lock_guard<mutex>> lock;
-	shared_ptr<CachedFile> file;
+	shared_ptr<CachedFile> cached_file;
+	RangeRequestState range_request_state;
 };
 
 class HTTPState : public ClientContextState {
 public:
-	//! Reset all counters and cached files
+	//! Reset all counters and per-path state
 	void Reset();
-	//! Get cache entry, create if not exists
-	shared_ptr<CachedFile> GetCachedFile(const string &path);
-	//! Erase a cached full download
-	void EraseCachedFile(const string &path);
+	//! Get per-path state, creating it if needed
+	shared_ptr<HTTPFileState> GetFileState(const string &path);
+	//! Erase all state for a path
+	void EraseFileState(const string &path);
 	//! Helper functions to get the HTTP state
 	static shared_ptr<HTTPState> TryGetState(ClientContext &context);
 	static shared_ptr<HTTPState> TryGetState(optional_ptr<FileOpener> opener);
@@ -107,10 +185,10 @@ public:
 private:
 	//! Serializes credential provider refreshes after auth failures.
 	mutex credential_refresh_mutex;
-	//! Mutex to lock when getting the cached file(Parallel Only)
-	mutex cached_files_mutex;
-	//! In case of fully downloading the file, the cached files of this query
-	unordered_map<string, shared_ptr<CachedFile>> cached_files;
+	//! Protects the per-path state map
+	annotated_mutex file_states_mutex;
+	//! Per-path state shared by all file handles in this query
+	unordered_map<string, shared_ptr<HTTPFileState>> file_states DUCKDB_GUARDED_BY(file_states_mutex);
 };
 
 } // namespace duckdb

--- a/src/include/http_state.hpp
+++ b/src/include/http_state.hpp
@@ -22,13 +22,29 @@ class RangeRequestState {
 public:
 	class Guard {
 	public:
-		explicit Guard(RangeRequestState &state_p) : state(state_p), support(state.support.load()), lock() {
+		explicit Guard(RangeRequestState &state_p) : state(state_p), support(state.support.load()), owns_probe(false) {
 			if (support == RangeRequestSupport::UNKNOWN) {
-				lock = annotated_unique_lock<annotated_mutex>(state.state_mutex);
-				support = state.support.load();
-				if (support != RangeRequestSupport::UNKNOWN) {
-					lock.unlock();
+				annotated_unique_lock<annotated_mutex> lock(state.state_mutex);
+				while (state.probing && state.support.load() == RangeRequestSupport::UNKNOWN) {
+					state.probe_complete.wait(lock, [&]() DUCKDB_REQUIRES(state.state_mutex) {
+						return !state.probing || state.support.load() != RangeRequestSupport::UNKNOWN;
+					});
 				}
+				support = state.support.load();
+				if (support == RangeRequestSupport::UNKNOWN) {
+					state.probing = true;
+					owns_probe = true;
+				}
+			}
+		}
+		Guard(const Guard &) = delete;
+		Guard &operator=(const Guard &) = delete;
+		Guard(Guard &&other) : state(other.state), support(other.support), owns_probe(other.owns_probe) {
+			other.owns_probe = false;
+		}
+		~Guard() {
+			if (owns_probe) {
+				state.AbortProbe();
 			}
 		}
 
@@ -37,27 +53,45 @@ public:
 		}
 		void MarkSupported() {
 			if (support == RangeRequestSupport::UNKNOWN) {
-				state.support = RangeRequestSupport::SUPPORTED;
+				state.ResolveProbe(RangeRequestSupport::SUPPORTED);
 				support = RangeRequestSupport::SUPPORTED;
+				owns_probe = false;
 			}
 		}
 		void MarkNotSupported() {
-			state.support = RangeRequestSupport::NOT_SUPPORTED;
+			state.ResolveProbe(RangeRequestSupport::NOT_SUPPORTED);
 			support = RangeRequestSupport::NOT_SUPPORTED;
+			owns_probe = false;
 		}
 
 	private:
 		RangeRequestState &state;
 		RangeRequestSupport support;
-		annotated_unique_lock<annotated_mutex> lock;
+		bool owns_probe;
 	};
 
-	Guard Lock() {
+	Guard BeginRequest() {
 		return Guard(*this);
 	}
 
 private:
+	void ResolveProbe(RangeRequestSupport new_support) {
+		annotated_lock_guard<annotated_mutex> lock(state_mutex);
+		support = new_support;
+		probing = false;
+		probe_complete.notify_all();
+	}
+	void AbortProbe() {
+		annotated_lock_guard<annotated_mutex> lock(state_mutex);
+		if (support.load() == RangeRequestSupport::UNKNOWN) {
+			probing = false;
+			probe_complete.notify_all();
+		}
+	}
+
 	annotated_mutex state_mutex;
+	std::condition_variable probe_complete DUCKDB_GUARDED_BY(state_mutex);
+	bool probing DUCKDB_GUARDED_BY(state_mutex) = false;
 	atomic<RangeRequestSupport> support = {RangeRequestSupport::UNKNOWN};
 };
 
@@ -139,8 +173,12 @@ public:
 	unique_ptr<CachedFileDownload> StartCachedFileDownload(Allocator &allocator) {
 		return cached_file->StartDownload(allocator);
 	}
-	RangeRequestState::Guard LockRangeRequestState() {
-		return range_request_state.Lock();
+	RangeRequestState::Guard BeginRangeRequest() {
+		return range_request_state.BeginRequest();
+	}
+	void MarkRangeRequestsSupported() {
+		auto guard = range_request_state.BeginRequest();
+		guard.MarkSupported();
 	}
 
 private:

--- a/src/include/http_state.hpp
+++ b/src/include/http_state.hpp
@@ -22,7 +22,12 @@ class RangeRequestState {
 public:
 	class Guard {
 	public:
-		explicit Guard(RangeRequestState &state_p) : state(state_p), support(state.support.load()), owns_probe(false) {
+		explicit Guard(RangeRequestState &state_p, bool enabled_p)
+		    : state(state_p), support(RangeRequestSupport::SUPPORTED), enabled(enabled_p), owns_probe(false) {
+			if (!enabled) {
+				return;
+			}
+			support = state.support.load();
 			if (support == RangeRequestSupport::UNKNOWN) {
 				annotated_unique_lock<annotated_mutex> lock(state.state_mutex);
 				while (state.probing && state.support.load() == RangeRequestSupport::UNKNOWN) {
@@ -39,7 +44,8 @@ public:
 		}
 		Guard(const Guard &) = delete;
 		Guard &operator=(const Guard &) = delete;
-		Guard(Guard &&other) : state(other.state), support(other.support), owns_probe(other.owns_probe) {
+		Guard(Guard &&other)
+		    : state(other.state), support(other.support), enabled(other.enabled), owns_probe(other.owns_probe) {
 			other.owns_probe = false;
 		}
 		~Guard() {
@@ -52,13 +58,16 @@ public:
 			return support;
 		}
 		void MarkSupported() {
-			if (support == RangeRequestSupport::UNKNOWN) {
+			if (enabled && support == RangeRequestSupport::UNKNOWN) {
 				state.ResolveProbe(RangeRequestSupport::SUPPORTED);
 				support = RangeRequestSupport::SUPPORTED;
 				owns_probe = false;
 			}
 		}
 		void MarkNotSupported() {
+			if (!enabled) {
+				return;
+			}
 			state.ResolveProbe(RangeRequestSupport::NOT_SUPPORTED);
 			support = RangeRequestSupport::NOT_SUPPORTED;
 			owns_probe = false;
@@ -67,11 +76,12 @@ public:
 	private:
 		RangeRequestState &state;
 		RangeRequestSupport support;
+		bool enabled;
 		bool owns_probe;
 	};
 
-	Guard BeginRequest() {
-		return Guard(*this);
+	Guard BeginRequest(bool enabled = true) {
+		return Guard(*this, enabled);
 	}
 
 private:
@@ -101,38 +111,44 @@ class CachedFile : public enable_shared_from_this<CachedFile> {
 	friend class CachedFileDownload;
 
 public:
-	unique_ptr<CachedFileHandle> GetHandle();
+	unique_ptr<CachedFileHandle> TryGetHandle();
 	unique_ptr<CachedFileDownload> StartDownload(Allocator &allocator);
+	void Invalidate();
 
 private:
 	//! Protects the download state and cached data
 	mutable annotated_mutex lock;
 	//! Notifies handles waiting for an in-progress download
 	mutable std::condition_variable download_complete DUCKDB_GUARDED_BY(lock);
-	//! Cached Data
-	AllocatedData data DUCKDB_GUARDED_BY(lock);
-	//! Data capacity
-	uint64_t capacity DUCKDB_GUARDED_BY(lock) = 0;
-	//! Size of file
-	idx_t size DUCKDB_GUARDED_BY(lock) = 0;
+	//! Published immutable file data
+	shared_ptr<class CachedFileData> cached_data DUCKDB_GUARDED_BY(lock);
 	//! Whether a download is currently populating the cache
 	bool downloading DUCKDB_GUARDED_BY(lock) = false;
-	//! When initialized is true, the cached data is immutable
-	bool initialized DUCKDB_GUARDED_BY(lock) = false;
+};
+
+//! Immutable data published after a full download completes
+class CachedFileData {
+public:
+	CachedFileData(AllocatedData data_p, idx_t size_p) : data(std::move(data_p)), size(size_p) {
+	}
+
+private:
+	friend class CachedFileHandle;
+	AllocatedData data;
+	idx_t size;
 };
 
 //! Handle to a CachedFile
 class CachedFileHandle {
 public:
-	explicit CachedFileHandle(shared_ptr<CachedFile> file_p);
+	explicit CachedFileHandle(shared_ptr<CachedFileData> file_p);
 
-	bool Initialized() const;
 	const char *GetData() const;
 	//! Return the size of the initialized file
 	idx_t GetSize() const;
 
 private:
-	shared_ptr<CachedFile> file;
+	shared_ptr<CachedFileData> file;
 };
 
 //! Exclusive handle for populating an uninitialized CachedFile
@@ -149,15 +165,18 @@ public:
 	//! Reset bytes written by a prior request attempt
 	void Reset();
 	//! Indicate the file is fully downloaded and safe for parallel reading
-	void Finalize();
+	unique_ptr<CachedFileHandle> Finalize();
 
 private:
 	CachedFileDownload(shared_ptr<CachedFile> file_p, Allocator &allocator_p);
-	void ReserveInternal(idx_t capacity) DUCKDB_REQUIRES(file->lock);
+	void ReserveInternal(idx_t capacity);
 	void Abort();
 
 	shared_ptr<CachedFile> file;
 	Allocator &allocator;
+	AllocatedData data;
+	idx_t capacity = 0;
+	idx_t size = 0;
 	bool active = true;
 };
 
@@ -167,14 +186,17 @@ public:
 	HTTPFileState() : cached_file(make_shared_ptr<CachedFile>()) {
 	}
 
-	unique_ptr<CachedFileHandle> GetCachedFileHandle() {
-		return cached_file->GetHandle();
+	unique_ptr<CachedFileHandle> TryGetCachedFileHandle() {
+		return cached_file->TryGetHandle();
 	}
 	unique_ptr<CachedFileDownload> StartCachedFileDownload(Allocator &allocator) {
 		return cached_file->StartDownload(allocator);
 	}
-	RangeRequestState::Guard BeginRangeRequest() {
-		return range_request_state.BeginRequest();
+	void InvalidateCachedFile() {
+		cached_file->Invalidate();
+	}
+	RangeRequestState::Guard BeginRangeRequest(bool coordinate_requests = true) {
+		return range_request_state.BeginRequest(coordinate_requests);
 	}
 	void MarkRangeRequestsSupported() {
 		auto guard = range_request_state.BeginRequest();

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -106,10 +106,8 @@ public:
 	// In write overwrite mode, we are not interested in the current state of the file: we're overwriting it.
 	bool write_overwrite_mode = false;
 
-	// When using full file download, the full file will be written to a cached file handle
-	mutex full_download_mutex;
-	unique_ptr<CachedFileHandle> cached_file_handle;
-	unique_ptr<CachedFileDownload> cached_file_download;
+	// Per-path download and range-support state shared by all handles in this query
+	shared_ptr<HTTPFileState> file_state;
 	optional_ptr<Allocator> buffer_allocator;
 
 	// Read info
@@ -177,18 +175,11 @@ protected:
 	virtual unique_ptr<HTTPClient> CreateClient();
 	//! Perform a HEAD request to get the file info (if not yet loaded)
 	void LoadFileInfo();
-	//! Reset download state so a full download can be retried from scratch
-	void ResetDownloadState();
-
 	//! TODO: make base function virtual?
 	void TryAddLogger(FileOpener &opener);
 
 	virtual void InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cache_entry);
 	virtual HTTPMetadataCacheEntry GetCacheEntry() const;
-
-public:
-	//! Fully downloads a file
-	void FullDownload(HTTPFileSystem &hfs, bool &should_write_cache);
 };
 
 class HTTPFileSystem : public FileSystem {
@@ -249,13 +240,16 @@ public:
 	virtual unique_ptr<HTTPResponse> GetRangeRequest(FileHandle &handle, string url, HTTPHeaders header_map,
 	                                                 idx_t file_offset, char *buffer_out, idx_t buffer_out_len);
 	// Get Request without a range (i.e., downloads full file)
-	virtual unique_ptr<HTTPResponse> GetRequest(FileHandle &handle, string url, HTTPHeaders header_map);
+	virtual unique_ptr<HTTPResponse> GetRequest(FileHandle &handle, string url, HTTPHeaders header_map,
+	                                            CachedFileDownload &download);
 	// Post Request that can handle variable sized responses without a content-length header (needed for s3 multipart)
 	virtual unique_ptr<HTTPResponse> PostRequest(HTTPInput &input, string url, HTTPHeaders header_map, string &result,
 	                                             char *buffer_in, idx_t buffer_in_len, string params = "");
 	virtual unique_ptr<HTTPResponse> PutRequest(HTTPInput &input, string url, HTTPHeaders header_map, char *buffer_in,
 	                                            idx_t buffer_in_len, string params = "");
 	virtual unique_ptr<HTTPResponse> DeleteRequest(FileHandle &handle, string url, HTTPHeaders header_map);
+	//! Fully download a file, or wait for an in-progress download of the same path
+	unique_ptr<CachedFileHandle> FullDownload(HTTPFileHandle &handle, bool &should_write_cache);
 
 protected:
 	//! FileSystem extension points used by HTTP handle setup.
@@ -287,8 +281,8 @@ protected:
 	                                       char *buffer_in, idx_t buffer_in_len, const string &content_type,
 	                                       HTTPSendCallback send_request);
 	unique_ptr<HTTPResponse> RunGetRequest(HTTPFileHandle &handle, string url, HTTPHeaders header_map,
-	                                       HTTPFSParams &http_params, HTTPErrorCallback get_error,
-	                                       HTTPSendCallback send_request);
+	                                       HTTPFSParams &http_params, CachedFileDownload &download,
+	                                       HTTPErrorCallback get_error, HTTPSendCallback send_request);
 	unique_ptr<HTTPResponse> RunGetRangeRequest(HTTPFileHandle &handle, string url, HTTPHeaders header_map,
 	                                            HTTPFSParams &http_params, const string &etag,
 	                                            bool auto_fallback_to_full_file_download, idx_t file_offset,

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -109,6 +109,8 @@ public:
 	// When using full file download, the full file will be written to a cached file handle
 	mutex full_download_mutex;
 	unique_ptr<CachedFileHandle> cached_file_handle;
+	unique_ptr<CachedFileDownload> cached_file_download;
+	optional_ptr<Allocator> buffer_allocator;
 
 	// Read info
 	idx_t buffer_available;

--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -61,7 +61,7 @@ struct HTTPFSParams : public HTTPParams {
 class HTTPClientConnectionCache {
 public:
 	static constexpr size_t POOL_COUNT = 16;
-	static constexpr size_t POOL_SIZE = 16;
+	static constexpr size_t POOL_SIZE = 32;
 	static_assert((POOL_COUNT & (POOL_COUNT - 1)) == 0, "POOL_COUNT must be a power of two");
 
 	unique_ptr<HTTPClient> Find(const string &base_url);

--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -30,6 +30,7 @@ class HTTPState;
 
 struct HTTPFSParams : public HTTPParams {
 	HTTPFSParams(HTTPUtil &http_util) : HTTPParams(http_util) {
+		http_proxy_port = 0;
 	}
 
 	unique_ptr<HTTPParams> Clone() const;

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -213,7 +213,8 @@ public:
 
 	//! HTTP request overrides.
 	unique_ptr<HTTPResponse> HeadRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map) override;
-	unique_ptr<HTTPResponse> GetRequest(FileHandle &handle, string url, HTTPHeaders header_map) override;
+	unique_ptr<HTTPResponse> GetRequest(FileHandle &handle, string url, HTTPHeaders header_map,
+	                                    CachedFileDownload &download) override;
 	unique_ptr<HTTPResponse> GetRangeRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
 	                                         idx_t file_offset, char *buffer_out, idx_t buffer_out_len) override;
 	unique_ptr<HTTPResponse> PostRequest(HTTPInput &input, string s3_url, HTTPHeaders header_map, string &buffer_out,

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1,4 +1,5 @@
 #include "s3fs.hpp"
+#include "duckdb/logging/logger.hpp"
 #include "hash_functions.hpp"
 #include "duckdb.hpp"
 #include "duckdb/common/exception/http_exception.hpp"

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1312,6 +1312,11 @@ static string CreateDeleteBatchKey(const S3DeleteBatchUrlInfo &url_info,
 	return key_builder.Build();
 }
 
+static string GetS3BucketPath(const ParsedS3Url &parsed_url) {
+	auto bucket_path = parsed_url.path.substr(0, parsed_url.path.length() - parsed_url.key.length());
+	return bucket_path.empty() ? "/" : bucket_path;
+}
+
 void S3FileSystem::RemoveFiles(const vector<string> &paths, optional_ptr<FileOpener> opener) {
 	if (paths.empty()) {
 		return;
@@ -1325,10 +1330,7 @@ void S3FileSystem::RemoveFiles(const vector<string> &paths, optional_ptr<FileOpe
 		auto parsed_url = S3UrlParse(path, auth_params);
 		ReadQueryParams(parsed_url.query_param, auth_params);
 
-		string bucket_path = parsed_url.path.substr(0, parsed_url.path.length() - parsed_url.key.length());
-		if (bucket_path.empty()) {
-			bucket_path = "/";
-		}
+		auto bucket_path = GetS3BucketPath(parsed_url);
 		S3DeleteBatchUrlInfo url_info = {parsed_url.prefix, parsed_url.http_proto, parsed_url.host, bucket_path,
 		                                 auth_params};
 		auto refreshable_http_params = ReadRefreshableHTTPParams(opener, path);
@@ -1392,12 +1394,14 @@ void S3FileSystem::RemoveFiles(const vector<string> &paths, optional_ptr<FileOpe
 				auto &http_util = HTTPFSUtil::GetHTTPUtil(opener);
 				auto http_params = http_util.InitializeParameters(opener, info);
 				auto request_http_params = SnapshotRefreshableHTTPParams(http_params->Cast<HTTPFSParams>());
+				auto request_url = S3UrlParse(secret_lookup_url, url_info.auth_params);
+				auto request_path = GetS3BucketPath(request_url);
 				auto headers =
-				    CreateS3Header(url_info.path, http_query_param_for_sig, url_info.host, "s3", "POST",
+				    CreateS3Header(request_path, http_query_param_for_sig, request_url.host, "s3", "POST",
 				                   url_info.auth_params, "", "", payload_hash, "application/xml", content_md5);
 
-				string http_url = url_info.http_proto + url_info.host + S3FileSystem::UrlEncode(url_info.path) + "?" +
-				                  http_query_param_for_url;
+				string http_url = request_url.http_proto + request_url.host + S3FileSystem::UrlEncode(request_path) +
+				                  "?" + http_query_param_for_url;
 				S3HTTPInput http_input(std::move(http_params), url_info.auth_params, S3ConfigParams::ReadFrom(opener));
 
 				result.clear();
@@ -1406,13 +1410,6 @@ void S3FileSystem::RemoveFiles(const vector<string> &paths, optional_ptr<FileOpe
 				if (!retried_auth_refresh && res && IsAuthRefreshStatus(*res) &&
 				    TryRefreshS3AuthParams(opener, secret_lookup_url, http_input.http_params, url_info.auth_params,
 				                           request_auth_params, request_http_params)) {
-					auto refreshed_url = S3UrlParse(secret_lookup_url, url_info.auth_params);
-					auto refreshed_bucket_path =
-					    refreshed_url.path.substr(0, refreshed_url.path.length() - refreshed_url.key.length());
-					url_info.prefix = refreshed_url.prefix;
-					url_info.http_proto = refreshed_url.http_proto;
-					url_info.host = refreshed_url.host;
-					url_info.path = refreshed_bucket_path.empty() ? "/" : refreshed_bucket_path;
 					retried_auth_refresh = true;
 					continue;
 				}

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1406,6 +1406,13 @@ void S3FileSystem::RemoveFiles(const vector<string> &paths, optional_ptr<FileOpe
 				if (!retried_auth_refresh && res && IsAuthRefreshStatus(*res) &&
 				    TryRefreshS3AuthParams(opener, secret_lookup_url, http_input.http_params, url_info.auth_params,
 				                           request_auth_params, request_http_params)) {
+					auto refreshed_url = S3UrlParse(secret_lookup_url, url_info.auth_params);
+					auto refreshed_bucket_path =
+					    refreshed_url.path.substr(0, refreshed_url.path.length() - refreshed_url.key.length());
+					url_info.prefix = refreshed_url.prefix;
+					url_info.http_proto = refreshed_url.http_proto;
+					url_info.host = refreshed_url.host;
+					url_info.path = refreshed_bucket_path.empty() ? "/" : refreshed_bucket_path;
 					retried_auth_refresh = true;
 					continue;
 				}

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1042,12 +1042,13 @@ unique_ptr<HTTPResponse> S3FileSystem::HeadRequest(FileHandle &handle, string s3
 	});
 }
 
-unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map) {
+unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
+                                                  CachedFileDownload &download) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
 	return RunS3HandleRequestWithAuthRefresh(s3_handle, s3_url, "GET", true, [&](S3RequestData &request_data) {
 		auto &params = request_data.http_params->Cast<HTTPFSParams>();
 		return RunGetRequest(
-		    s3_handle, request_data.http_url, request_data.headers, params,
+		    s3_handle, request_data.http_url, request_data.headers, params, download,
 		    [&](const HTTPResponse &response) { return GetS3RequestError(request_data, response); },
 		    [&](BaseRequest &request) { return SendS3HandleRequestWithClientCache(s3_handle, params, request); });
 	});
@@ -1056,8 +1057,6 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_
 unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
                                                        idx_t file_offset, char *buffer_out, idx_t buffer_out_len) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
-	D_ASSERT(s3_handle.http_params.state);
-	s3_handle.http_params.state->GetFileState(s3_handle.path)->MarkRangeRequestsSupported();
 	return RunS3HandleRequestWithAuthRefresh(s3_handle, s3_url, "GET", true, [&](S3RequestData &request_data) {
 		auto &params = request_data.http_params->Cast<HTTPFSParams>();
 		return RunGetRangeRequest(
@@ -1178,7 +1177,6 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 			    path, auth_params.region, correct_region);
 			SetRegion(std::move(correct_region));
 		}
-		ResetDownloadState();
 		HTTPFileHandle::Initialize(opener);
 	}
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1056,6 +1056,8 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_
 unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
                                                        idx_t file_offset, char *buffer_out, idx_t buffer_out_len) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
+	D_ASSERT(s3_handle.http_params.state);
+	s3_handle.http_params.state->GetFileState(s3_handle.path)->MarkRangeRequestsSupported();
 	return RunS3HandleRequestWithAuthRefresh(s3_handle, s3_url, "GET", true, [&](S3RequestData &request_data) {
 		auto &params = request_data.http_params->Cast<HTTPFSParams>();
 		return RunGetRangeRequest(

--- a/test/sql/connection_caching.test
+++ b/test/sql/connection_caching.test
@@ -12,8 +12,11 @@ set ignore_error_messages
 statement ok
 SET enable_logging=true;
 
-statement ok
-SET httpfs_connection_caching=true;
+# connection caching is on by default
+query I
+SELECT current_setting('httpfs_connection_caching');
+----
+true
 
 statement ok
 CALL enable_logging('HTTPFSInfo');

--- a/test/sql/connection_caching.test
+++ b/test/sql/connection_caching.test
@@ -18,7 +18,7 @@ SET httpfs_connection_caching=true;
 statement ok
 CALL enable_logging('HTTPFSInfo');
 
-# First request — should be a cache miss
+# First request — a single cold connection is dialed to the host (cache miss)
 statement ok
 FROM 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_role_type.parquet';
 
@@ -27,23 +27,29 @@ SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_miss%';
 ----
 1
 
-# Second request to the same file — should be a cache hit
+# Second request to the same file — served from the process-wide pool. Every request checks a
+# connection out and back in, so reuse is logged as a hit and no new cold connection is dialed.
 statement ok
 FROM 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_role_type.parquet';
 
 query I
-SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_hit%';
+SELECT count(*) > 0 FROM duckdb_logs WHERE message LIKE '%connection_cache_hit%';
+----
+true
+
+query I
+SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_miss%';
 ----
 1
 
-# Different file on the same host — should still be a cache hit (same base_url)
+# Different file on the same host — still served by the pooled connection (keyed on base_url), no new cold connect
 statement ok
 SELECT * FROM 'https://github.com/duckdb/duckdb/raw/9cf66f950dde0173e1a863a7659b3ecf11bf3978/data/csv/customer.csv';
 
 query I
-SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_hit%';
+SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_miss%';
 ----
-2
+1
 
 # Clear of caching disabled temporarily
 mode skip

--- a/test/sql/connection_caching_default.test
+++ b/test/sql/connection_caching_default.test
@@ -35,6 +35,6 @@ statement ok
 FROM 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_role_type.parquet';
 
 query I
-SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache_hit%';
+SELECT count(*) > 0 FROM duckdb_logs WHERE message LIKE '%connection_cache_hit%';
 ----
-1
+true

--- a/test/sql/connection_caching_httplib.test
+++ b/test/sql/connection_caching_httplib.test
@@ -1,0 +1,43 @@
+# name: test/sql/connection_caching_httplib.test
+# description: The httplib backend keeps per-handle connection reuse and never touches the shared pool
+# group: [sql]
+
+require httpfs
+
+require parquet
+
+# override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
+set ignore_error_messages
+
+statement ok
+SET httpfs_client_implementation='httplib';
+
+statement ok
+SET enable_logging=true;
+
+statement ok
+CALL enable_logging('HTTPFSInfo');
+
+statement ok
+FROM 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_role_type.parquet';
+
+statement ok
+FROM 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_role_type.parquet';
+
+# the shared connection pool is curl-only: the httplib backend must not log any pool activity
+query I
+SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache%';
+----
+0
+
+# enabling connection caching does not reroute httplib to the pool either
+statement ok
+SET httpfs_connection_caching=true;
+
+statement ok
+FROM 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_role_type.parquet';
+
+query I
+SELECT count(*) FROM duckdb_logs WHERE message LIKE '%connection_cache%';
+----
+0

--- a/test/sql/full_file_download_fallback.test
+++ b/test/sql/full_file_download_fallback.test
@@ -12,7 +12,7 @@ require-env PYTHON_HTTP_SERVER_URL
 require-env PYTHON_HTTP_SERVER_DIR
 
 statement ok
-CALL enable_logging();
+CALL enable_logging('HTTP');
 
 statement ok
 call dbgen(sf=1);
@@ -24,19 +24,52 @@ statement ok
 drop table lineitem;
 
 statement ok
-CREATE view lineitem AS FROM '{PYTHON_HTTP_SERVER_URL}/lineitem.csv';
+CREATE TEMP TABLE range_requests_before AS
+SELECT count(*) AS count
+FROM duckdb_logs_parsed('HTTP')
+WHERE request.type='GET' AND request.headers['Range'] IS NOT NULL;
+
+statement ok
+CREATE VIEW lineitem AS
+SELECT * FROM read_csv('{PYTHON_HTTP_SERVER_URL}/lineitem.csv', auto_detect=false, header=true, columns={
+    'l_orderkey': 'BIGINT',
+    'l_partkey': 'BIGINT',
+    'l_suppkey': 'BIGINT',
+    'l_linenumber': 'BIGINT',
+    'l_quantity': 'DECIMAL(15,2)',
+    'l_extendedprice': 'DECIMAL(15,2)',
+    'l_discount': 'DECIMAL(15,2)',
+    'l_tax': 'DECIMAL(15,2)',
+    'l_returnflag': 'VARCHAR',
+    'l_linestatus': 'VARCHAR',
+    'l_shipdate': 'DATE',
+    'l_commitdate': 'DATE',
+    'l_receiptdate': 'DATE',
+    'l_shipinstruct': 'VARCHAR',
+    'l_shipmode': 'VARCHAR',
+    'l_comment': 'VARCHAR'
+});
+
+# Binding the explicitly typed CSV does not read its contents.
+query I
+SELECT count(*) - (SELECT count FROM range_requests_before)
+FROM duckdb_logs_parsed('HTTP')
+WHERE request.type='GET' AND request.headers['Range'] IS NOT NULL;
+----
+0
 
 query I
 pragma tpch(6);
 ----
 123141078.22829981
 
-# Parallel readers may all observe the unsupported range request before the first
-# full download finishes, so the exact warning count depends on scheduling.
+# Concurrent readers share one range-capability probe for the path.
 query I
-select count(*) > 0 from duckdb_logs where log_level='WARNING' and message like '%Falling back to full%'
+SELECT count(*) - (SELECT count FROM range_requests_before)
+FROM duckdb_logs_parsed('HTTP')
+WHERE request.type='GET' AND request.headers['Range'] IS NOT NULL;
 ----
-true
+1
 
 # every logged request must carry a User-Agent that identifies duckdb
 query I
@@ -49,7 +82,7 @@ WHERE request.headers['User-Agent'] IS NULL
 statement ok
 set auto_fallback_to_full_download=false
 
-# The successful fallback above can populate the external file cache. Disable it so the negative check below still attempts an HTTP range request.
+# Do not reuse the full download for the negative check below.
 statement ok
 set enable_external_file_cache=false
 
@@ -57,4 +90,3 @@ statement error
 pragma tpch(6);
 ----
 HTTP Error: Content-Length from server mismatches requested range, server may not support range requests. You can try to resolve this by enabling `SET force_download=true`
-

--- a/test/sql/logging/file_system_logging.test
+++ b/test/sql/logging/file_system_logging.test
@@ -32,7 +32,6 @@ CONNECTION	FileSystem	TRACE	{"fs":"LocalFileSystem","test.csv","op":"WRITE","byt
 CONNECTION	FileSystem	TRACE	{"fs":"LocalFileSystem","test.csv","op":"CLOSE"}
 CONNECTION	FileSystem	TRACE	{"fs":"LocalFileSystem","test.csv","op":"OPEN"}
 CONNECTION	FileSystem	TRACE	{"fs":"LocalFileSystem","test.csv","op":"READ","bytes":"4","pos":"0"}
-CONNECTION	FileSystem	TRACE	{"fs":"LocalFileSystem","test.csv","op":"READ","bytes":"0","pos":"4"}
 CONNECTION	FileSystem	TRACE	{"fs":"LocalFileSystem","test.csv","op":"CLOSE"}
 
 statement ok

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -6,7 +6,8 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../src/include)
 
 add_executable(
   unittest_httpfs EXCLUDE_FROM_ALL
-  main.cpp mock_s3_server.cpp httpfs_refresh_test.cpp s3_list_retry_test.cpp)
+  main.cpp mock_s3_server.cpp httpfs_refresh_test.cpp s3_list_retry_test.cpp
+  short_read_test.cpp)
 set_target_properties(unittest_httpfs PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                                  ${CMAKE_BINARY_DIR}/test)
 

--- a/test/unittest/httpfs_refresh_test.cpp
+++ b/test/unittest/httpfs_refresh_test.cpp
@@ -3,6 +3,7 @@
 #include "mock_s3_server.hpp"
 
 #include "create_secret_functions.hpp"
+#include "httpfs_client.hpp"
 #include "httpfs_extension.hpp"
 
 #include "duckdb.hpp"
@@ -12,8 +13,10 @@
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/main/secret/secret.hpp"
 
+#include <array>
 #include <atomic>
 #include <mutex>
+#include <new>
 #include <unordered_map>
 
 namespace duckdb {
@@ -166,6 +169,40 @@ CREATE SECRET refresh_s3 (
 	                                       TEST_PROVIDER, STALE_KEY_ID, STALE_SECRET, test_id, FRESH_KEY_ID,
 	                                       FRESH_SECRET, test_id));
 	return test_id;
+}
+
+static void ConfigureEndpointRefreshTest(DuckDB &db, Connection &con, MockS3Server &stale_server,
+                                         MockS3Server &fresh_server, const string &client_implementation) {
+	auto test_id = NextTestId();
+
+	LoadHTTPFSExtension(db);
+	RegisterRefreshTestProvider(db);
+
+	RequireQueryOk(con, StringUtil::Format("SET httpfs_client_implementation='%s'", client_implementation));
+	RequireQueryOk(con, "SET httpfs_connection_caching=false");
+	RequireQueryOk(con, "SET httpfs_enable_credential_refresh=true");
+	RequireQueryOk(con, "SET s3_region='us-east-1'");
+	RequireQueryOk(con, "SET s3_use_ssl=false");
+	RequireQueryOk(con, "SET s3_url_style='path'");
+
+	RequireQueryOk(con, StringUtil::Format(R"(
+CREATE SECRET refresh_s3 (
+	TYPE S3,
+	PROVIDER %s,
+	SCOPE 's3://refresh-bucket/',
+	KEY_ID '%s',
+	SECRET '%s',
+	ENDPOINT '%s',
+	TEST_ID '%s',
+	REFRESH_INFO MAP {
+		'KEY_ID': '%s',
+		'SECRET': '%s',
+		'ENDPOINT': '%s',
+		'TEST_ID': '%s'
+	}
+))",
+	                                       TEST_PROVIDER, STALE_KEY_ID, STALE_SECRET, stale_server.Endpoint(), test_id,
+	                                       STALE_KEY_ID, STALE_SECRET, fresh_server.Endpoint(), test_id));
 }
 
 static void AssertSingleRefresh(const string &test_id) {
@@ -341,6 +378,38 @@ static void RunBulkDeletePostRefreshScenario(const string &client_implementation
 	                                       });
 	REQUIRE(MockS3HasObservation(observations, "POST", STALE_KEY_ID, 403, string(), "delete"));
 	REQUIRE(MockS3HasObservation(observations, "POST", FRESH_KEY_ID, 200, string(), "delete"));
+}
+
+static void RunBulkDeleteEndpointRefreshScenario(const string &client_implementation) {
+	MockS3ServerConfig stale_config;
+	stale_config.bucket = BUCKET;
+	stale_config.object_key = OBJECT_KEY;
+	stale_config.stale_key_id = STALE_KEY_ID;
+	stale_config.refresh_target = MockS3RefreshTarget::BULK_DELETE_POST;
+	MockS3Server stale_server(std::move(stale_config));
+
+	MockS3ServerConfig fresh_config;
+	fresh_config.bucket = BUCKET;
+	fresh_config.object_key = OBJECT_KEY;
+	fresh_config.stale_key_id = "NEVER_STALE";
+	fresh_config.refresh_target = MockS3RefreshTarget::BULK_DELETE_POST;
+	MockS3Server fresh_server(std::move(fresh_config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureEndpointRefreshTest(db, con, stale_server, fresh_server, client_implementation);
+
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	fs.RemoveFiles({S3_PATH});
+	RequireQueryOk(con, "COMMIT");
+
+	auto stale_observations = stale_server.Observations();
+	auto fresh_observations = fresh_server.Observations();
+	INFO(MockS3DescribeObservations(stale_observations));
+	INFO(MockS3DescribeObservations(fresh_observations));
+	REQUIRE(CountObservations(stale_observations, "POST", STALE_KEY_ID, 403) == 1);
+	REQUIRE(CountObservations(fresh_observations, "POST", STALE_KEY_ID, 200) == 1);
 }
 
 static void RunDeleteRefreshScenario(const string &client_implementation, bool connection_caching) {
@@ -854,6 +923,29 @@ TEST_CASE("HTTPFS can disable S3 credential refresh", "[httpfs][s3][refresh]") {
 
 TEST_CASE("HTTPFS reuses one S3 credential refresh across stale handles", "[httpfs][s3][refresh]") {
 	RunMultipleStaleHandlesSingleRefreshScenario();
+}
+
+TEST_CASE("HTTPFS bulk delete follows a refreshed S3 endpoint", "[httpfs][s3][refresh]") {
+	SECTION("httplib") {
+		RunBulkDeleteEndpointRefreshScenario("httplib");
+	}
+	SECTION("curl") {
+		RunBulkDeleteEndpointRefreshScenario("curl");
+	}
+}
+
+TEST_CASE("HTTPFS clones parameters without a configured proxy", "[httpfs][s3][params]") {
+	alignas(HTTPFSParams) std::array<uint8_t, sizeof(HTTPFSParams)> storage;
+	storage.fill(0xA5);
+
+	HTTPFSUtil http_util;
+	auto params = new (storage.data()) HTTPFSParams(http_util);
+	auto clone = params->Clone();
+	params->~HTTPFSParams();
+
+	auto &cloned_params = clone->Cast<HTTPFSParams>();
+	REQUIRE(cloned_params.http_proxy.empty());
+	REQUIRE(cloned_params.http_proxy_port == 0);
 }
 
 } // namespace duckdb

--- a/test/unittest/httpfs_refresh_test.cpp
+++ b/test/unittest/httpfs_refresh_test.cpp
@@ -934,12 +934,14 @@ TEST_CASE("HTTPFS bulk delete follows a refreshed S3 endpoint", "[httpfs][s3][re
 	}
 }
 
-TEST_CASE("HTTPFS clones parameters without a configured proxy", "[httpfs][s3][params]") {
+TEST_CASE("HTTPFS initializes and clones parameters without a configured proxy", "[httpfs][s3][params]") {
 	alignas(HTTPFSParams) std::array<uint8_t, sizeof(HTTPFSParams)> storage;
 	storage.fill(0xA5);
 
 	HTTPFSUtil http_util;
 	auto params = new (storage.data()) HTTPFSParams(http_util);
+	REQUIRE(params->http_proxy.empty());
+	REQUIRE(params->http_proxy_port == 0);
 	auto clone = params->Clone();
 	params->~HTTPFSParams();
 

--- a/test/unittest/httpfs_refresh_test.cpp
+++ b/test/unittest/httpfs_refresh_test.cpp
@@ -485,6 +485,67 @@ static void RunRangeRefreshDisabledScenario() {
 	AssertNoRefresh(test_id);
 }
 
+static void RunFullGetErrorBodyScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	config.refresh_target = MockS3RefreshTarget::FULL_GET;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto test_id = ConfigureRefreshTest(db, con, server, client_implementation, false, false);
+
+	RequireQueryOk(con, "SET force_download=true");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	string error;
+	try {
+		auto &fs = FileSystem::GetFileSystem(*con.context);
+		fs.OpenFile(S3_PATH, FileFlags::FILE_FLAGS_READ);
+	} catch (std::exception &ex) {
+		error = ex.what();
+	}
+	INFO(error);
+	REQUIRE(error.find("AccessDenied: stale credentials") != string::npos);
+	RequireQueryOk(con, "ROLLBACK");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 403));
+	REQUIRE_FALSE(HasRequestWithKey(observations, FRESH_KEY_ID));
+	AssertNoRefresh(test_id);
+}
+
+static void RunChunkedFullGetScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.chunked_full_get = true;
+	auto object_data = config.object_data;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto test_id = ConfigureRefreshTest(db, con, server, client_implementation, false);
+
+	RequireQueryOk(con, "SET force_download=true");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(S3_PATH, FileFlags::FILE_FLAGS_READ);
+	string result(object_data.size(), '\0');
+	handle->Read(QueryContext(*con.context), &result[0], result.size(), 0);
+	REQUIRE(result == object_data);
+	RequireQueryOk(con, "COMMIT");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 200));
+	AssertNoRefresh(test_id);
+}
+
 static void RunListGlobRefreshDisabledScenario() {
 	MockS3ServerConfig config;
 	config.bucket = BUCKET;
@@ -918,6 +979,24 @@ TEST_CASE("HTTPFS can disable S3 credential refresh", "[httpfs][s3][refresh]") {
 	}
 	SECTION("list glob fails without refresh") {
 		RunListGlobRefreshDisabledScenario();
+	}
+}
+
+TEST_CASE("HTTPFS preserves S3 error bodies for streamed GETs", "[httpfs][s3][errors]") {
+	SECTION("httplib") {
+		RunFullGetErrorBodyScenario("httplib");
+	}
+	SECTION("curl") {
+		RunFullGetErrorBodyScenario("curl");
+	}
+}
+
+TEST_CASE("HTTPFS streams full GETs without Content-Length", "[httpfs][s3][streaming]") {
+	SECTION("httplib") {
+		RunChunkedFullGetScenario("httplib");
+	}
+	SECTION("curl") {
+		RunChunkedFullGetScenario("curl");
 	}
 }
 

--- a/test/unittest/mock_s3_server.cpp
+++ b/test/unittest/mock_s3_server.cpp
@@ -49,6 +49,16 @@ static bool ParseRange(const string &range, idx_t object_size) {
 	return start <= end && end < object_size;
 }
 
+static bool ConsumeBehavior(std::atomic<idx_t> &remaining) {
+	auto current = remaining.load();
+	while (current > 0) {
+		if (remaining.compare_exchange_weak(current, current - 1)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 static string GetHeader(const httplib::Request &request, const string &header) {
 	if (!request.has_header(header)) {
 		return string();
@@ -62,10 +72,14 @@ struct MockS3Server::Impl {
 	explicit Impl(MockS3ServerConfig config_p) : config(std::move(config_p)) {
 		remaining_put_failures = config.transient_put_failures;
 		remaining_get_failures = config.transient_get_failures;
+		remaining_range_behavior_requests = config.range_behavior_requests;
 		remaining_head_failures = config.transient_head_failures;
 		remaining_delete_failures = config.transient_delete_failures;
 		remaining_post_failures = config.transient_post_failures;
 		remaining_complete_post_failures = config.transient_complete_post_failures;
+		if (config.range_behavior == MockS3RangeBehavior::SHORT_SUCCESS && config.range_behavior_requests > 0) {
+			server.set_keep_alive_max_count(1);
+		}
 		RegisterRoutes();
 		port = server.bind_to_any_port("127.0.0.1");
 		if (port <= 0) {
@@ -88,6 +102,10 @@ struct MockS3Server::Impl {
 
 	string S3Path() const {
 		return StringUtil::Format("s3://%s/%s", config.bucket, config.object_key);
+	}
+
+	string HTTPPath() const {
+		return StringUtil::Format("http://%s/%s/%s", Endpoint(), config.bucket, config.object_key);
 	}
 
 	vector<MockS3RequestObservation> Observations() const {
@@ -142,7 +160,9 @@ struct MockS3Server::Impl {
 
 	void SetObjectHeaders(httplib::Response &response) const {
 		response.set_header("Accept-Ranges", "bytes");
-		response.set_header("Content-Length", std::to_string(config.object_data.size()));
+		auto content_length =
+		    config.head_content_length.IsValid() ? config.head_content_length.GetIndex() : config.object_data.size();
+		response.set_header("Content-Length", std::to_string(content_length));
 		response.set_header("ETag", config.etag);
 	}
 
@@ -234,6 +254,17 @@ struct MockS3Server::Impl {
 		const string path = StringUtil::Format("/%s/%s", config.bucket, config.object_key);
 		const string bucket_path = StringUtil::Format("/%s", config.bucket);
 		const string bucket_path_with_slash = bucket_path + "/";
+		server.set_post_routing_handler([this](const httplib::Request &, httplib::Response &response) {
+			if (!response.has_header("X-Mock-Successful-Short-Response")) {
+				return;
+			}
+			auto omitted_bytes = MinValue<idx_t>(config.truncated_range_bytes, response.body.size());
+			response.body.resize(response.body.size() - omitted_bytes);
+			auto content_length = response.headers.equal_range("Content-Length");
+			response.headers.erase(content_length.first, content_length.second);
+			auto marker = response.headers.equal_range("X-Mock-Successful-Short-Response");
+			response.headers.erase(marker.first, marker.second);
+		});
 
 		server.set_pre_routing_handler([this, path](const httplib::Request &request, httplib::Response &response) {
 			if (request.method != "HEAD" || request.path != path) {
@@ -273,6 +304,13 @@ struct MockS3Server::Impl {
 				Record(request, response.status);
 				return;
 			}
+			if (config.range_behavior == MockS3RangeBehavior::IGNORE_RANGE) {
+				response.status = 200;
+				response.set_header("ETag", config.etag);
+				response.set_content(config.object_data, "application/octet-stream");
+				Record(request, response.status);
+				return;
+			}
 
 			if (!ParseRange(range, config.object_data.size())) {
 				response.status = 416;
@@ -283,6 +321,28 @@ struct MockS3Server::Impl {
 			response.status = 206;
 			response.set_header("Accept-Ranges", "bytes");
 			response.set_header("ETag", config.etag);
+			if (config.range_behavior == MockS3RangeBehavior::SHORT_SUCCESS &&
+			    ConsumeBehavior(remaining_range_behavior_requests)) {
+				response.set_header("X-Mock-Successful-Short-Response", "1");
+				response.set_content(config.object_data, "application/octet-stream");
+				Record(request, response.status);
+				return;
+			}
+			if (config.range_behavior == MockS3RangeBehavior::TRUNCATE_TRANSFER &&
+			    ConsumeBehavior(remaining_range_behavior_requests)) {
+				response.set_content_provider(config.object_data.size(), "application/octet-stream",
+				                              [this](size_t offset, size_t length, httplib::DataSink &sink) {
+					                              auto omitted_bytes =
+					                                  MinValue<idx_t>(config.truncated_range_bytes, length);
+					                              auto emitted_bytes = length - omitted_bytes;
+					                              if (emitted_bytes > 0) {
+						                              sink.write(config.object_data.data() + offset, emitted_bytes);
+					                              }
+					                              return false;
+				                              });
+				Record(request, response.status);
+				return;
+			}
 			response.set_content(config.object_data, "application/octet-stream");
 			Record(request, response.status);
 		});
@@ -374,6 +434,7 @@ struct MockS3Server::Impl {
 	int port = 0;
 	mutable std::atomic<idx_t> remaining_put_failures {0};
 	mutable std::atomic<idx_t> remaining_get_failures {0};
+	mutable std::atomic<idx_t> remaining_range_behavior_requests {0};
 	mutable std::atomic<idx_t> remaining_head_failures {0};
 	mutable std::atomic<idx_t> remaining_delete_failures {0};
 	mutable std::atomic<idx_t> remaining_post_failures {0};
@@ -394,6 +455,10 @@ string MockS3Server::Endpoint() const {
 
 string MockS3Server::S3Path() const {
 	return impl->S3Path();
+}
+
+string MockS3Server::HTTPPath() const {
+	return impl->HTTPPath();
 }
 
 const string &MockS3Server::ObjectData() const {

--- a/test/unittest/mock_s3_server.cpp
+++ b/test/unittest/mock_s3_server.cpp
@@ -300,6 +300,25 @@ struct MockS3Server::Impl {
 			if (range.empty()) {
 				response.status = 200;
 				response.set_header("ETag", config.etag);
+				if (config.chunked_full_get) {
+					response.set_chunked_content_provider(
+					    "application/octet-stream", [this](size_t offset, httplib::DataSink &sink) {
+						    if (offset >= config.object_data.size()) {
+							    sink.done();
+							    return true;
+						    }
+						    const auto length = MinValue<size_t>(7, config.object_data.size() - offset);
+						    if (!sink.write(config.object_data.data() + offset, length)) {
+							    return false;
+						    }
+						    if (offset + length == config.object_data.size()) {
+							    sink.done();
+						    }
+						    return true;
+					    });
+					Record(request, response.status);
+					return;
+				}
 				response.set_content(config.object_data, "application/octet-stream");
 				Record(request, response.status);
 				return;

--- a/test/unittest/mock_s3_server.cpp
+++ b/test/unittest/mock_s3_server.cpp
@@ -6,6 +6,7 @@
 #include "httplib.hpp"
 
 #include <atomic>
+#include <condition_variable>
 #include <cstring>
 #include <mutex>
 #include <thread>
@@ -29,7 +30,7 @@ static string ExtractCredentialKey(const string &authorization) {
 	return authorization.substr(credential_pos, end_pos - credential_pos);
 }
 
-static bool ParseRange(const string &range, idx_t object_size) {
+static bool ParseRange(const string &range, idx_t object_size, idx_t &start, idx_t &end) {
 	static constexpr const char *PREFIX = "bytes=";
 	if (range.rfind(PREFIX, 0) != 0) {
 		return false;
@@ -38,8 +39,6 @@ static bool ParseRange(const string &range, idx_t object_size) {
 	if (dash_pos == string::npos) {
 		return false;
 	}
-	idx_t start = 0;
-	idx_t end = 0;
 	try {
 		start = std::stoull(range.substr(strlen(PREFIX), dash_pos - strlen(PREFIX)));
 		end = std::stoull(range.substr(dash_pos + 1));
@@ -159,7 +158,9 @@ struct MockS3Server::Impl {
 	}
 
 	void SetObjectHeaders(httplib::Response &response) const {
-		response.set_header("Accept-Ranges", "bytes");
+		if (config.advertise_ranges) {
+			response.set_header("Accept-Ranges", "bytes");
+		}
 		auto content_length =
 		    config.head_content_length.IsValid() ? config.head_content_length.GetIndex() : config.object_data.size();
 		response.set_header("Content-Length", std::to_string(content_length));
@@ -331,15 +332,40 @@ struct MockS3Server::Impl {
 				return;
 			}
 
-			if (!ParseRange(range, config.object_data.size())) {
+			idx_t range_start;
+			idx_t range_end;
+			if (!ParseRange(range, config.object_data.size(), range_start, range_end)) {
 				response.status = 416;
 				Record(request, response.status);
 				return;
 			}
 
+			idx_t range_request_index;
+			{
+				std::lock_guard<std::mutex> lock(range_request_lock);
+				range_request_index = ++range_requests_seen;
+			}
+			range_request_started.notify_all();
 			response.status = 206;
 			response.set_header("Accept-Ranges", "bytes");
 			response.set_header("ETag", config.etag);
+			if (config.block_first_range_body_until_second_range && range_request_index == 1) {
+				const auto range_length = range_end - range_start + 1;
+				response.set_content_provider(
+				    range_length, "application/octet-stream",
+				    [this, range_start](size_t offset, size_t length, httplib::DataSink &sink) {
+					    if (offset == 0) {
+						    std::unique_lock<std::mutex> lock(range_request_lock);
+						    if (!range_request_started.wait_for(lock, std::chrono::seconds(5),
+						                                        [this]() { return range_requests_seen >= 2; })) {
+							    return false;
+						    }
+					    }
+					    return sink.write(config.object_data.data() + range_start + offset, length);
+				    });
+				Record(request, response.status);
+				return;
+			}
 			if (config.range_behavior == MockS3RangeBehavior::SHORT_SUCCESS &&
 			    ConsumeBehavior(remaining_range_behavior_requests)) {
 				response.set_header("X-Mock-Successful-Short-Response", "1");
@@ -460,6 +486,9 @@ struct MockS3Server::Impl {
 	mutable std::atomic<idx_t> remaining_complete_post_failures {0};
 	mutable std::mutex observation_lock;
 	mutable vector<MockS3RequestObservation> observations;
+	std::mutex range_request_lock;
+	std::condition_variable range_request_started;
+	idx_t range_requests_seen = 0;
 };
 
 MockS3Server::MockS3Server(MockS3ServerConfig config) : impl(make_uniq<Impl>(std::move(config))) {

--- a/test/unittest/mock_s3_server.cpp
+++ b/test/unittest/mock_s3_server.cpp
@@ -112,6 +112,19 @@ struct MockS3Server::Impl {
 		return observations;
 	}
 
+	bool WaitForFullGet() {
+		std::unique_lock<std::mutex> lock(full_get_lock);
+		return full_get_started.wait_for(lock, std::chrono::seconds(5), [this]() { return full_get_seen; });
+	}
+
+	void ReleaseFullGet() {
+		{
+			std::lock_guard<std::mutex> lock(full_get_lock);
+			full_get_released = true;
+		}
+		full_get_release.notify_all();
+	}
+
 	bool MatchesRefreshTarget(const httplib::Request &request) const {
 		auto range = GetHeader(request, "Range");
 		switch (config.refresh_target) {
@@ -160,6 +173,8 @@ struct MockS3Server::Impl {
 	void SetObjectHeaders(httplib::Response &response) const {
 		if (config.advertise_ranges) {
 			response.set_header("Accept-Ranges", "bytes");
+		} else {
+			response.set_header("Accept-Ranges", "none");
 		}
 		auto content_length =
 		    config.head_content_length.IsValid() ? config.head_content_length.GetIndex() : config.object_data.size();
@@ -301,6 +316,24 @@ struct MockS3Server::Impl {
 			if (range.empty()) {
 				response.status = 200;
 				response.set_header("ETag", config.etag);
+				if (config.block_full_get_until_released) {
+					response.set_content_provider(
+					    config.object_data.size(), "application/octet-stream",
+					    [this](size_t offset, size_t length, httplib::DataSink &sink) {
+						    if (offset == 0) {
+							    std::unique_lock<std::mutex> lock(full_get_lock);
+							    full_get_seen = true;
+							    full_get_started.notify_all();
+							    if (!full_get_release.wait_for(lock, std::chrono::seconds(5),
+							                                   [this]() { return full_get_released; })) {
+								    return false;
+							    }
+						    }
+						    return sink.write(config.object_data.data() + offset, length);
+					    });
+					Record(request, response.status);
+					return;
+				}
 				if (config.chunked_full_get) {
 					response.set_chunked_content_provider(
 					    "application/octet-stream", [this](size_t offset, httplib::DataSink &sink) {
@@ -489,6 +522,11 @@ struct MockS3Server::Impl {
 	std::mutex range_request_lock;
 	std::condition_variable range_request_started;
 	idx_t range_requests_seen = 0;
+	std::mutex full_get_lock;
+	std::condition_variable full_get_started;
+	std::condition_variable full_get_release;
+	bool full_get_seen = false;
+	bool full_get_released = false;
 };
 
 MockS3Server::MockS3Server(MockS3ServerConfig config) : impl(make_uniq<Impl>(std::move(config))) {
@@ -515,6 +553,14 @@ const string &MockS3Server::ObjectData() const {
 
 vector<MockS3RequestObservation> MockS3Server::Observations() const {
 	return impl->Observations();
+}
+
+bool MockS3Server::WaitForFullGet() {
+	return impl->WaitForFullGet();
+}
+
+void MockS3Server::ReleaseFullGet() {
+	impl->ReleaseFullGet();
 }
 
 string MockS3RefreshTargetName(MockS3RefreshTarget target) {

--- a/test/unittest/mock_s3_server.hpp
+++ b/test/unittest/mock_s3_server.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb/common/common.hpp"
+#include "duckdb/common/optional_idx.hpp"
 
 namespace duckdb {
 
@@ -15,6 +16,8 @@ enum class MockS3RefreshTarget : uint8_t {
 	DELETE_OBJECT,
 	LIST_OBJECTS_GET
 };
+
+enum class MockS3RangeBehavior : uint8_t { NORMAL, IGNORE_RANGE, TRUNCATE_TRANSFER, SHORT_SUCCESS };
 
 struct MockS3ServerConfig {
 	string bucket = "refresh-bucket";
@@ -31,6 +34,14 @@ struct MockS3ServerConfig {
 	idx_t transient_put_failures = 0;
 	//! Number of object GETs to fail with a 400 before succeeding
 	idx_t transient_get_failures = 0;
+	//! Range response behavior to inject
+	MockS3RangeBehavior range_behavior = MockS3RangeBehavior::NORMAL;
+	//! Number of leading range GETs affected by transient range behaviors
+	idx_t range_behavior_requests = 0;
+	//! Number of bytes to omit from an injected truncated range response
+	idx_t truncated_range_bytes = 1;
+	//! Override the Content-Length reported by HEAD while keeping the GET body unchanged
+	optional_idx head_content_length;
 	//! Number of object HEADs to fail with a 400 before succeeding
 	idx_t transient_head_failures = 0;
 	//! Number of object DELETEs to fail with a 400 before succeeding
@@ -65,6 +76,7 @@ public:
 	MockS3Server &operator=(const MockS3Server &) = delete;
 
 	string Endpoint() const;
+	string HTTPPath() const;
 	string S3Path() const;
 	const string &ObjectData() const;
 	vector<MockS3RequestObservation> Observations() const;

--- a/test/unittest/mock_s3_server.hpp
+++ b/test/unittest/mock_s3_server.hpp
@@ -44,6 +44,10 @@ struct MockS3ServerConfig {
 	optional_idx head_content_length;
 	//! Send successful full GETs with chunked transfer encoding and no Content-Length
 	bool chunked_full_get = false;
+	//! Advertise byte-range support on HEAD responses
+	bool advertise_ranges = true;
+	//! Hold the first range response body until a second range request arrives
+	bool block_first_range_body_until_second_range = false;
 	//! Number of object HEADs to fail with a 400 before succeeding
 	idx_t transient_head_failures = 0;
 	//! Number of object DELETEs to fail with a 400 before succeeding

--- a/test/unittest/mock_s3_server.hpp
+++ b/test/unittest/mock_s3_server.hpp
@@ -48,6 +48,8 @@ struct MockS3ServerConfig {
 	bool advertise_ranges = true;
 	//! Hold the first range response body until a second range request arrives
 	bool block_first_range_body_until_second_range = false;
+	//! Hold a full GET response body until ReleaseFullGet is called
+	bool block_full_get_until_released = false;
 	//! Number of object HEADs to fail with a 400 before succeeding
 	idx_t transient_head_failures = 0;
 	//! Number of object DELETEs to fail with a 400 before succeeding
@@ -86,6 +88,8 @@ public:
 	string S3Path() const;
 	const string &ObjectData() const;
 	vector<MockS3RequestObservation> Observations() const;
+	bool WaitForFullGet();
+	void ReleaseFullGet();
 
 private:
 	struct Impl;

--- a/test/unittest/mock_s3_server.hpp
+++ b/test/unittest/mock_s3_server.hpp
@@ -42,6 +42,8 @@ struct MockS3ServerConfig {
 	idx_t truncated_range_bytes = 1;
 	//! Override the Content-Length reported by HEAD while keeping the GET body unchanged
 	optional_idx head_content_length;
+	//! Send successful full GETs with chunked transfer encoding and no Content-Length
+	bool chunked_full_get = false;
 	//! Number of object HEADs to fail with a 400 before succeeding
 	idx_t transient_head_failures = 0;
 	//! Number of object DELETEs to fail with a 400 before succeeding

--- a/test/unittest/s3_list_retry_test.cpp
+++ b/test/unittest/s3_list_retry_test.cpp
@@ -112,8 +112,9 @@ static void RunExhaustedListRetryTest(const string &client_implementation, int s
 
 	auto observations = server.Observations();
 	INFO(MockS3DescribeObservations(observations));
-	// One initial attempt plus two retries.
-	REQUIRE(CountListObservations(observations, status) == 3);
+	// Core grants five extra retries to 503 throttling responses.
+	const idx_t expected_attempts = status == 503 ? 8 : 3;
+	REQUIRE(CountListObservations(observations, status) == expected_attempts);
 	REQUIRE(CountListObservations(observations, 200) == 0);
 }
 

--- a/test/unittest/short_read_test.cpp
+++ b/test/unittest/short_read_test.cpp
@@ -57,10 +57,21 @@ static idx_t CountRequests(const vector<MockS3RequestObservation> &observations,
 	return count;
 }
 
+static idx_t CountRangeRequests(const vector<MockS3RequestObservation> &observations, int status) {
+	idx_t count = 0;
+	for (auto &observation : observations) {
+		if (observation.method == "GET" && observation.status == status && !observation.range.empty()) {
+			count++;
+		}
+	}
+	return count;
+}
+
 struct ReadOutcome {
 	bool failed = false;
 	bool internal_error = false;
 	string error;
+	string data;
 };
 
 static ReadOutcome TryReadHandle(Connection &con, FileHandle &handle, idx_t offset, idx_t length) {
@@ -68,6 +79,7 @@ static ReadOutcome TryReadHandle(Connection &con, FileHandle &handle, idx_t offs
 	try {
 		string buffer(length, '?');
 		handle.Read(QueryContext(*con.context), &buffer[0], length, offset);
+		outcome.data = std::move(buffer);
 	} catch (std::exception &ex) {
 		outcome.failed = true;
 		outcome.error = ex.what();
@@ -221,6 +233,67 @@ static void RunParallelRangeHeaderRelease(const string &client_implementation) {
 	RequireQueryOk(con, "COMMIT");
 }
 
+static void RunFullDownloadSingleFlight(const string &client_implementation, bool shared_handle) {
+	static constexpr idx_t READ_LENGTH = 1024;
+	const vector<idx_t> offsets {0, 2048, 4096, 6144};
+
+	MockS3ServerConfig config;
+	config.object_data.resize(8192);
+	for (idx_t i = 0; i < config.object_data.size(); i++) {
+		config.object_data[i] = NumericCast<char>('a' + (i % 26));
+	}
+	const auto expected_data = config.object_data;
+	config.advertise_ranges = false;
+	config.range_behavior = MockS3RangeBehavior::IGNORE_RANGE;
+	config.block_full_get_until_released = true;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureHTTPTest(db, con, 0, client_implementation);
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	const auto flags =
+	    FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO | FileFlags::FILE_FLAGS_PARALLEL_ACCESS;
+	vector<unique_ptr<FileHandle>> handles;
+	const auto handle_count = shared_handle ? 1 : offsets.size();
+	for (idx_t i = 0; i < handle_count; i++) {
+		handles.push_back(fs.OpenFile(server.HTTPPath(), flags));
+	}
+
+	std::atomic<bool> start {false};
+	vector<ReadOutcome> outcomes(offsets.size());
+	vector<std::thread> readers;
+	for (idx_t i = 0; i < offsets.size(); i++) {
+		readers.emplace_back([&, i]() {
+			while (!start.load()) {
+				std::this_thread::yield();
+			}
+			auto &handle = shared_handle ? *handles[0] : *handles[i];
+			outcomes[i] = TryReadHandle(con, handle, offsets[i], READ_LENGTH);
+		});
+	}
+	start = true;
+	const auto full_get_started = server.WaitForFullGet();
+	server.ReleaseFullGet();
+	for (auto &reader : readers) {
+		reader.join();
+	}
+
+	REQUIRE(full_get_started);
+	for (idx_t i = 0; i < outcomes.size(); i++) {
+		INFO(outcomes[i].error);
+		REQUIRE_FALSE(outcomes[i].failed);
+		REQUIRE(outcomes[i].data == expected_data.substr(offsets[i], READ_LENGTH));
+	}
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(CountRangeRequests(observations, 200) == 1);
+	REQUIRE(CountRequests(observations, "GET", 200) == 1);
+	RequireQueryOk(con, "COMMIT");
+}
+
 } // namespace
 
 TEST_CASE("HTTP range reads reject truncated response bodies", "[httpfs][short-read]") {
@@ -241,6 +314,21 @@ TEST_CASE("HTTP range readers resume after the first response headers", "[httpfs
 	}
 	SECTION("httplib") {
 		RunParallelRangeHeaderRelease("httplib");
+	}
+}
+
+TEST_CASE("HTTP full-download fallback is single-flight", "[httpfs][full-download][range-probe]") {
+	SECTION("curl with separate handles") {
+		RunFullDownloadSingleFlight("curl", false);
+	}
+	SECTION("curl with a shared handle") {
+		RunFullDownloadSingleFlight("curl", true);
+	}
+	SECTION("httplib with separate handles") {
+		RunFullDownloadSingleFlight("httplib", false);
+	}
+	SECTION("httplib with a shared handle") {
+		RunFullDownloadSingleFlight("httplib", true);
 	}
 }
 

--- a/test/unittest/short_read_test.cpp
+++ b/test/unittest/short_read_test.cpp
@@ -1,0 +1,233 @@
+#include "catch.hpp"
+
+#include "mock_s3_server.hpp"
+
+#include "httpfs.hpp"
+#include "httpfs_extension.hpp"
+
+#include "duckdb.hpp"
+#include "duckdb/common/error_data.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+namespace {
+
+static void LoadHTTPFSExtension(DuckDB &db) {
+	if (db.ExtensionIsLoaded("httpfs")) {
+		return;
+	}
+	ExtensionInfo extension_info;
+	ExtensionActiveLoad load_info(*db.instance, extension_info, "httpfs");
+	ExtensionLoader loader(load_info);
+	HttpfsExtension extension;
+	extension.Load(loader);
+}
+
+static void RequireQueryOk(Connection &con, const string &query) {
+	auto result = con.Query(query);
+	REQUIRE(result);
+	INFO((result->HasError() ? result->GetError() : string()));
+	REQUIRE_FALSE(result->HasError());
+}
+
+static void ConfigureHTTPTest(DuckDB &db, Connection &con, idx_t retries) {
+	LoadHTTPFSExtension(db);
+	RequireQueryOk(con, "SET httpfs_client_implementation='curl'");
+	RequireQueryOk(con, "SET httpfs_connection_caching=false");
+	RequireQueryOk(con, "SET http_retries=" + to_string(retries));
+	RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	RequireQueryOk(con, "SET http_retry_backoff=1");
+}
+
+static idx_t CountRequests(const vector<MockS3RequestObservation> &observations, const string &method, int status,
+                           const string &range = string()) {
+	idx_t count = 0;
+	for (auto &observation : observations) {
+		if (observation.method == method && observation.status == status && observation.range == range) {
+			count++;
+		}
+	}
+	return count;
+}
+
+struct ReadOutcome {
+	bool failed = false;
+	bool internal_error = false;
+	string error;
+};
+
+static ReadOutcome TryReadHandle(Connection &con, FileHandle &handle, idx_t offset, idx_t length) {
+	ReadOutcome outcome;
+	try {
+		string buffer(length, '?');
+		handle.Read(QueryContext(*con.context), &buffer[0], length, offset);
+	} catch (std::exception &ex) {
+		outcome.failed = true;
+		outcome.error = ex.what();
+		ErrorData error(ex);
+		outcome.internal_error = error.Type() == ExceptionType::INTERNAL || error.Type() == ExceptionType::FATAL;
+	} catch (...) {
+		outcome.failed = true;
+		outcome.error = "unknown exception";
+	}
+	return outcome;
+}
+
+static ReadOutcome TryReadRange(Connection &con, const string &path, idx_t offset, idx_t length) {
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	return TryReadHandle(con, *handle, offset, length);
+}
+
+static string ReadRange(Connection &con, const string &path, idx_t offset, idx_t length) {
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	string buffer(length, '?');
+	handle->Read(QueryContext(*con.context), &buffer[0], length, offset);
+	return buffer;
+}
+
+static void RunPersistentShortRead() {
+	static constexpr idx_t READ_OFFSET = 113;
+	static constexpr idx_t READ_LENGTH = 1024;
+	const string expected_range = "bytes=113-1136";
+
+	MockS3ServerConfig config;
+	config.object_data = string(8192, 'x');
+	config.range_behavior = MockS3RangeBehavior::TRUNCATE_TRANSFER;
+	config.range_behavior_requests = 4;
+	config.truncated_range_bytes = 17;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureHTTPTest(db, con, 3);
+
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto outcome = TryReadRange(con, server.HTTPPath(), READ_OFFSET, READ_LENGTH);
+	RequireQueryOk(con, "ROLLBACK");
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	INFO(outcome.error);
+	REQUIRE(outcome.failed);
+	REQUIRE_FALSE(outcome.internal_error);
+	REQUIRE(CountRequests(observations, "GET", 206, expected_range) == 4);
+}
+
+static void RunTransientShortRead() {
+	static constexpr idx_t READ_OFFSET = 113;
+	static constexpr idx_t READ_LENGTH = 1024;
+	const string expected_range = "bytes=113-1136";
+
+	MockS3ServerConfig config;
+	config.object_data = string(8192, 'x');
+	config.range_behavior = MockS3RangeBehavior::TRUNCATE_TRANSFER;
+	config.range_behavior_requests = 1;
+	config.truncated_range_bytes = 17;
+	auto expected = config.object_data.substr(READ_OFFSET, READ_LENGTH);
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureHTTPTest(db, con, 1);
+
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto actual = ReadRange(con, server.HTTPPath(), READ_OFFSET, READ_LENGTH);
+	RequireQueryOk(con, "COMMIT");
+	REQUIRE(actual == expected);
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(CountRequests(observations, "GET", 206, expected_range) == 2);
+}
+
+static void RunSuccessfulShortResponse() {
+	static constexpr idx_t READ_OFFSET = 113;
+	static constexpr idx_t READ_LENGTH = 1024;
+	const string expected_range = "bytes=113-1136";
+
+	MockS3ServerConfig config;
+	config.object_data = string(8192, 'x');
+	config.range_behavior = MockS3RangeBehavior::SHORT_SUCCESS;
+	config.range_behavior_requests = 1;
+	config.truncated_range_bytes = 17;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureHTTPTest(db, con, 0);
+
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto outcome = TryReadRange(con, server.HTTPPath(), READ_OFFSET, READ_LENGTH);
+	RequireQueryOk(con, "ROLLBACK");
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	INFO(outcome.error);
+	REQUIRE(outcome.failed);
+	REQUIRE_FALSE(outcome.internal_error);
+	REQUIRE(outcome.error.find("Short read for HTTP GET") != string::npos);
+	REQUIRE(CountRequests(observations, "GET", 206, expected_range) == 1);
+}
+
+} // namespace
+
+TEST_CASE("HTTP range reads reject truncated response bodies", "[httpfs][short-read]") {
+	SECTION("persistent transfer truncation exhausts retries") {
+		RunPersistentShortRead();
+	}
+	SECTION("transient transfer truncation is replaced by a complete retry") {
+		RunTransientShortRead();
+	}
+	SECTION("a cleanly terminated short response is rejected") {
+		RunSuccessfulShortResponse();
+	}
+}
+
+TEST_CASE("HTTP full-download fallback rejects HEAD and GET length mismatches", "[httpfs][full-download][issue-354]") {
+	MockS3ServerConfig config;
+	config.object_data = "AB";
+	config.head_content_length = 3;
+	config.range_behavior = MockS3RangeBehavior::IGNORE_RANGE;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureHTTPTest(db, con, 0);
+	RequireQueryOk(con, "SET enable_http_metadata_cache=true");
+
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto initial_outcome = TryReadRange(con, server.HTTPPath(), 0, 1);
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	INFO(initial_outcome.error);
+	REQUIRE(initial_outcome.failed);
+	REQUIRE_FALSE(initial_outcome.internal_error);
+	REQUIRE(initial_outcome.error.find("size reported by HEAD") != string::npos);
+	REQUIRE(initial_outcome.error.find("full GET downloaded") != string::npos);
+	REQUIRE(CountRequests(observations, "HEAD", 200) == 1);
+	REQUIRE(CountRequests(observations, "GET", 200, "bytes=0-0") == 1);
+	REQUIRE(CountRequests(observations, "GET", 200) == 1);
+
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto reopened = fs.OpenFile(server.HTTPPath(), FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	REQUIRE(reopened->Cast<HTTPFileHandle>().etag == "\"httpfs-refresh-test-etag\"");
+	auto reopened_outcome = TryReadHandle(con, *reopened, 0, 1);
+	INFO(reopened_outcome.error);
+	REQUIRE(reopened_outcome.failed);
+	REQUIRE_FALSE(reopened_outcome.internal_error);
+
+	observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(CountRequests(observations, "HEAD", 200) == 1);
+	REQUIRE(CountRequests(observations, "GET", 200, "bytes=0-0") == 2);
+	REQUIRE(CountRequests(observations, "GET", 200) == 2);
+	RequireQueryOk(con, "SELECT 42");
+
+	RequireQueryOk(con, "SET force_download=true");
+	REQUIRE(ReadRange(con, server.HTTPPath(), 0, 2) == "AB");
+	RequireQueryOk(con, "COMMIT");
+}
+
+} // namespace duckdb

--- a/test/unittest/short_read_test.cpp
+++ b/test/unittest/short_read_test.cpp
@@ -20,7 +20,7 @@ static void LoadHTTPFSExtension(DuckDB &db) {
 		return;
 	}
 	ExtensionInfo extension_info;
-	ExtensionActiveLoad load_info(*db.instance, extension_info, "httpfs");
+	ExtensionActiveLoad load_info(*db.instance, extension_info, "httpfs", "");
 	ExtensionLoader loader(load_info);
 	HttpfsExtension extension;
 	extension.Load(loader);

--- a/test/unittest/short_read_test.cpp
+++ b/test/unittest/short_read_test.cpp
@@ -11,6 +11,9 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 
+#include <atomic>
+#include <thread>
+
 namespace duckdb {
 
 namespace {
@@ -33,9 +36,10 @@ static void RequireQueryOk(Connection &con, const string &query) {
 	REQUIRE_FALSE(result->HasError());
 }
 
-static void ConfigureHTTPTest(DuckDB &db, Connection &con, idx_t retries) {
+static void ConfigureHTTPTest(DuckDB &db, Connection &con, idx_t retries,
+                              const string &client_implementation = "curl") {
 	LoadHTTPFSExtension(db);
-	RequireQueryOk(con, "SET httpfs_client_implementation='curl'");
+	RequireQueryOk(con, "SET httpfs_client_implementation='" + client_implementation + "'");
 	RequireQueryOk(con, "SET httpfs_connection_caching=false");
 	RequireQueryOk(con, "SET http_retries=" + to_string(retries));
 	RequireQueryOk(con, "SET http_retry_wait_ms=1");
@@ -171,6 +175,52 @@ static void RunSuccessfulShortResponse() {
 	REQUIRE(CountRequests(observations, "GET", 206, expected_range) == 1);
 }
 
+static void RunParallelRangeHeaderRelease(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.object_data = string(8192, 'x');
+	config.advertise_ranges = false;
+	config.block_first_range_body_until_second_range = true;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureHTTPTest(db, con, 0, client_implementation);
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto first_handle = fs.OpenFile(server.HTTPPath(), FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	auto second_handle = fs.OpenFile(server.HTTPPath(), FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+
+	std::atomic<bool> start {false};
+	ReadOutcome first_outcome;
+	ReadOutcome second_outcome;
+	std::thread first_reader([&]() {
+		while (!start.load()) {
+			std::this_thread::yield();
+		}
+		first_outcome = TryReadHandle(con, *first_handle, 0, 1024);
+	});
+	std::thread second_reader([&]() {
+		while (!start.load()) {
+			std::this_thread::yield();
+		}
+		second_outcome = TryReadHandle(con, *second_handle, 1024, 1024);
+	});
+	start = true;
+	first_reader.join();
+	second_reader.join();
+
+	INFO(first_outcome.error);
+	INFO(second_outcome.error);
+	REQUIRE_FALSE(first_outcome.failed);
+	REQUIRE_FALSE(second_outcome.failed);
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(CountRequests(observations, "GET", 206, "bytes=0-1023") == 1);
+	REQUIRE(CountRequests(observations, "GET", 206, "bytes=1024-2047") == 1);
+	RequireQueryOk(con, "COMMIT");
+}
+
 } // namespace
 
 TEST_CASE("HTTP range reads reject truncated response bodies", "[httpfs][short-read]") {
@@ -182,6 +232,15 @@ TEST_CASE("HTTP range reads reject truncated response bodies", "[httpfs][short-r
 	}
 	SECTION("a cleanly terminated short response is rejected") {
 		RunSuccessfulShortResponse();
+	}
+}
+
+TEST_CASE("HTTP range readers resume after the first response headers", "[httpfs][range-probe]") {
+	SECTION("curl") {
+		RunParallelRangeHeaderRelease("curl");
+	}
+	SECTION("httplib") {
+		RunParallelRangeHeaderRelease("httplib");
 	}
 }
 


### PR DESCRIPTION
Title says it all

EDIT: due to bumping the DuckDB submodule we now test async CSV reads, which exposed an issue with full file downloads. Apparently, all async threads started reading the full file in parallel, and we ran out of memory in CI. I've had to fix that in this PR to get CI to succeed - we now synchronise the full file download: it's done only once.