### PR TITLE
S3 secret option normalization

### DIFF
--- a/src/create_secret_functions.cpp
+++ b/src/create_secret_functions.cpp
@@ -73,7 +73,7 @@ unique_ptr<BaseSecret> CreateS3SecretFunctions::CreateSecretFunctionInternal(Cli
 		} else if (lower_name == "endpoint") {
 			secret->secret_map["endpoint"] = named_param.second.ToString();
 		} else if (lower_name == "url_style") {
-			secret->secret_map["url_style"] = named_param.second.ToString();
+			secret->secret_map["url_style"] = StringUtil::Lower(named_param.second.ToString());
 		} else if (lower_name == "use_ssl") {
 			if (named_param.second.type() != LogicalType::BOOLEAN) {
 				throw InvalidInputException("Invalid type past to secret option: '%s', found '%s', expected: 'BOOLEAN'",

--- a/src/create_secret_functions.cpp
+++ b/src/create_secret_functions.cpp
@@ -100,7 +100,7 @@ unique_ptr<BaseSecret> CreateS3SecretFunctions::CreateSecretFunctionInternal(Cli
 			if (refresh) {
 				throw InvalidInputException("Can not set `refresh` and `refresh_info` at the same time");
 			}
-			refresh = named_param.second.GetValue<string>() == "auto";
+			refresh = StringUtil::Lower(named_param.second.GetValue<string>()) == "auto";
 			secret->secret_map["refresh"] = Value("auto");
 			child_list_t<Value> struct_fields;
 			for (const auto &named_param : input.options) {

--- a/test/sql/secrets/create_secret_binding.test
+++ b/test/sql/secrets/create_secret_binding.test
@@ -119,6 +119,22 @@ CREATE SECRET incorrect_type (
 ----
 Binder Error: Failed to cast option 'use_ssl' to type 'BOOLEAN': 'Could not convert string 'fliepflap' to BOOL'
 
+# Refresh mode values should be normalized before validation and not be used together
+statement error
+CREATE SECRET refresh_uppercase_conflict (
+    TYPE S3,
+    PROVIDER config,
+    KEY_ID '123',
+    SECRET 'secret',
+    REFRESH AUTO,
+    REFRESH_INFO MAP {
+        'KEY_ID': '456',
+        'SECRET': 'new_secret'
+    }
+)
+----
+Invalid Input Error: Can not set `refresh` and `refresh_info` at the same time
+
 # Incorrect param altogether
 statement error
 CREATE SECRET incorrect_type (

--- a/test/sql/secrets/create_secret_binding.test
+++ b/test/sql/secrets/create_secret_binding.test
@@ -30,6 +30,67 @@ FROM duckdb_secrets();
 statement ok
 DROP SECRET s1
 
+# Unquoted string options should behave the same as quoted string options
+statement ok
+CREATE SECRET s3_url_style_path (
+    TYPE S3,
+    PROVIDER config,
+    KEY_ID '123',
+    SECRET 'secret',
+    URL_STYLE PATH
+)
+
+statement ok
+CREATE SECRET s3_url_style_path_lower (
+    TYPE S3,
+    PROVIDER config,
+    KEY_ID '123',
+    SECRET 'secret',
+    URL_STYLE path
+)
+
+statement ok
+CREATE SECRET s3_url_style_path_quoted (
+    TYPE S3,
+    PROVIDER config,
+    KEY_ID '123',
+    SECRET 'secret',
+    URL_STYLE 'path'
+)
+
+statement ok
+CREATE SECRET s3_url_style_vhost (
+    TYPE S3,
+    PROVIDER config,
+    KEY_ID '123',
+    SECRET 'secret',
+    URL_STYLE VHOST
+)
+
+statement ok
+CREATE SECRET s3_url_style_virtual (
+    TYPE S3,
+    PROVIDER config,
+    KEY_ID '123',
+    SECRET 'secret',
+    URL_STYLE VIRTUAL
+)
+
+query II
+SELECT name, regexp_extract(secret_string, 'url_style=([^;]*)', 1)
+FROM duckdb_secrets(redact=false)
+WHERE name LIKE 's3_url_style_%'
+ORDER BY name;
+----
+s3_url_style_path	path
+s3_url_style_path_lower	path
+s3_url_style_path_quoted	path
+s3_url_style_vhost	vhost
+s3_url_style_virtual	virtual
+
+statement ok
+DROP SECRET s3_url_style_path; DROP SECRET s3_url_style_path_lower; DROP SECRET s3_url_style_path_quoted; DROP SECRET s3_url_style_vhost; DROP SECRET s3_url_style_virtual;
+
 # Create the secret again but in a different way to demonstrate casting and case insensitivity of param names
 statement ok
 CREATE SECRET s1 (


### PR DESCRIPTION
S3 secret option values were not normalized before being stored and later compared against lower-case values.

Closes #153 
Closes duckdblabs/duckdb-internal#6409
