### PR TITLE
Fall back to path-style URLs for dotted S3 bucket names

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -961,7 +961,8 @@ ParsedS3Url S3FileSystem::S3UrlParse(string url, const S3AuthParams &params) {
 	// See https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
 	bool use_vhost = params.url_style.empty() || params.url_style == "vhost" || params.url_style == "virtual";
 	// A bucket name containing periods (.) is not addressable vhost-style over TLS. Fallback to path style url
-	bool use_path = params.url_style == "path" || (use_vhost && params.use_ssl && bucket.find('.') != std::string::npos);
+	bool use_path =
+	    params.url_style == "path" || (use_vhost && params.use_ssl && bucket.find('.') != std::string::npos);
 	if (use_path) {
 		path += "/" + bucket;
 	} else if (use_vhost) {

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -959,10 +959,13 @@ ParsedS3Url S3FileSystem::S3UrlParse(string url, const S3AuthParams &params) {
 
 	// Update host and path according to the url style
 	// See https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
-	if (params.url_style == "vhost" || params.url_style == "virtual" || params.url_style == "") {
-		host = bucket + "." + host;
-	} else if (params.url_style == "path") {
+	bool use_vhost = params.url_style.empty() || params.url_style == "vhost" || params.url_style == "virtual";
+	// A bucket name containing periods (.) is not addressable vhost-style over TLS. Fallback to path style url
+	bool use_path = params.url_style == "path" || (use_vhost && params.use_ssl && bucket.find('.') != std::string::npos);
+	if (use_path) {
 		path += "/" + bucket;
+	} else if (use_vhost) {
+		host = bucket + "." + host;
 	}
 
 	// Append key (including leading slash) to the path

--- a/test/sql/dotted_bucket_url.test
+++ b/test/sql/dotted_bucket_url.test
@@ -1,0 +1,35 @@
+# name: test/sql/dotted_bucket_url.test
+# description: Test getting metadata stats
+# group: [sql]
+
+require parquet
+
+require httpfs
+
+statement ok
+SET s3_access_key_id='';
+SET s3_secret_access_key='';
+SET s3_endpoint='s3.amazonaws.com';
+
+query I
+SELECT generation_energy_source FROM 's3://pudl.catalyst.coop/nightly/core_eia930__hourly_net_generation_by_energy_source.parquet' LIMIT 1;
+----
+battery_storage
+
+restart
+
+statement ok
+SET httpfs_client_implementation='httplib';
+
+query I
+SELECT generation_energy_source FROM 's3://pudl.catalyst.coop/nightly/core_eia930__hourly_net_generation_by_energy_source.parquet' LIMIT 1;
+----
+battery_storage
+
+statement ok
+SET enable_server_cert_verification = true;
+
+query I
+SELECT generation_energy_source FROM 's3://pudl.catalyst.coop/nightly/core_eia930__hourly_net_generation_by_energy_source.parquet' LIMIT 1;
+----
+battery_storage

--- a/test/sql/dotted_bucket_url.test
+++ b/test/sql/dotted_bucket_url.test
@@ -16,8 +16,6 @@ SELECT generation_energy_source FROM 's3://pudl.catalyst.coop/nightly/core_eia93
 ----
 battery_storage
 
-restart
-
 statement ok
 SET httpfs_client_implementation='httplib';
 


### PR DESCRIPTION
A bucket whose name contains dots is not addressable as a vhost over TLS and [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) acknowledges this. This PR adds a fall-back to path style for dotted S3 buckets.

This issue was reported here: https://github.com/duckdb/duckdb-httpfs/issues/334#issuecomment-5057505311. It is only reproducible with the `curl` client, which verifies certificates by default. On the contrary, `httplib`'s default value for certificate verification is false. Not sure why we have two different settings (`enable_server_cert_verification` and `enable_curl_server_cert_verification`) with different default values. I will look into it and potentially unify/deprecate one of them, but that's for another PR.