### PR TITLE
Unify `enable_curl_server_cert_verification` and `enable_server_cert_verification`

### DIFF
--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -55,8 +55,6 @@ unique_ptr<HTTPParams> HTTPFSUtil::InitializeParameters(optional_ptr<FileOpener>
 	FileOpener::TryGetCurrentSetting(opener, "http_retry_wait_ms", result->retry_wait_ms, info);
 	FileOpener::TryGetCurrentSetting(opener, "http_retry_backoff", result->retry_backoff, info);
 	FileOpener::TryGetCurrentSetting(opener, "http_keep_alive", result->keep_alive, info);
-	FileOpener::TryGetCurrentSetting(opener, "enable_curl_server_cert_verification",
-	                                 result->enable_curl_server_cert_verification, info);
 	FileOpener::TryGetCurrentSetting(opener, "enable_server_cert_verification", result->enable_server_cert_verification,
 	                                 info);
 	FileOpener::TryGetCurrentSetting(opener, "ca_cert_file", result->ca_cert_file, info);
@@ -139,7 +137,6 @@ unique_ptr<HTTPParams> HTTPFSParams::Clone() const {
 	result->force_download = force_download;
 	result->auto_fallback_to_full_download = auto_fallback_to_full_download;
 	result->enable_server_cert_verification = enable_server_cert_verification;
-	result->enable_curl_server_cert_verification = enable_curl_server_cert_verification;
 	result->hf_max_per_page = hf_max_per_page;
 	result->ca_cert_file = ca_cert_file;
 	result->bearer_token = bearer_token;

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -172,7 +172,7 @@ public:
 		}
 
 		const bool verify_ssl =
-		    http_params.override_verify_ssl ? http_params.verify_ssl : http_params.enable_curl_server_cert_verification;
+		    http_params.override_verify_ssl ? http_params.verify_ssl : http_params.enable_server_cert_verification;
 		if (verify_ssl) {
 			curl_easy_setopt(*curl, CURLOPT_SSL_VERIFYPEER, 1L); // Verify the cert
 			curl_easy_setopt(*curl, CURLOPT_SSL_VERIFYHOST, 2L); // Verify that the cert matches the hostname

--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -72,9 +72,11 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          LogicalType::BOOLEAN, Value(false));
 	config.AddExtensionOption("enable_server_cert_verification", "Enable server side certificate verification.",
 	                          LogicalType::BOOLEAN, Value(true));
-	// the enable_curl_server_cert_verification setting is deprecated. It is unified with enable_server_cert_verification
+	// the enable_curl_server_cert_verification setting is deprecated. It is unified with
+	// enable_server_cert_verification
 	auto callback_enable_curl_server_cert_verification = [](ClientContext &context, SetScope scope, Value &parameter) {
-		DUCKDB_LOG_WARNING(context, "the enable_curl_server_cert_verification setting is deprecated. Use enable_server_cert_verification instead");
+		DUCKDB_LOG_WARNING(context, "the enable_curl_server_cert_verification setting is deprecated. Use "
+		                            "enable_server_cert_verification instead");
 		DBConfig::GetConfig(context).SetOption("enable_server_cert_verification", parameter);
 	};
 	config.AddExtensionOption("enable_curl_server_cert_verification",

--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -70,11 +70,16 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    LogicalType::BOOLEAN, Value(true));
 	config.AddExtensionOption("allow_asterisks_in_http_paths", "Allow '*' character in URLs users can query",
 	                          LogicalType::BOOLEAN, Value(false));
-	config.AddExtensionOption("enable_curl_server_cert_verification",
-	                          "Enable server side certificate verification for CURL backend.", LogicalType::BOOLEAN,
-	                          Value(true));
 	config.AddExtensionOption("enable_server_cert_verification", "Enable server side certificate verification.",
-	                          LogicalType::BOOLEAN, Value(false));
+	                          LogicalType::BOOLEAN, Value(true));
+	// the enable_curl_server_cert_verification setting is deprecated. It is unified with enable_server_cert_verification
+	auto callback_enable_curl_server_cert_verification = [](ClientContext &context, SetScope scope, Value &parameter) {
+		DUCKDB_LOG_WARNING(context, "the enable_curl_server_cert_verification setting is deprecated. Use enable_server_cert_verification instead");
+		DBConfig::GetConfig(context).SetOption("enable_server_cert_verification", parameter);
+	};
+	config.AddExtensionOption("enable_curl_server_cert_verification",
+	                          "Deprecated: alias for enable_server_cert_verification.", LogicalType::BOOLEAN,
+	                          Value(true), callback_enable_curl_server_cert_verification);
 	auto callback_ca_cert_file = [](ClientContext &context, SetScope scope, Value &parameter) {
 		if (parameter.IsNull()) {
 			throw InvalidInputException("NULL it's not a valid option for ca_cert_file");

--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -35,7 +35,7 @@ struct HTTPFSParams : public HTTPParams {
 
 	unique_ptr<HTTPParams> Clone() const;
 
-	static constexpr bool DEFAULT_ENABLE_SERVER_CERT_VERIFICATION = false;
+	static constexpr bool DEFAULT_ENABLE_SERVER_CERT_VERIFICATION = true;
 	static constexpr uint64_t DEFAULT_HF_MAX_PER_PAGE = 0;
 	static constexpr bool DEFAULT_FORCE_DOWNLOAD = false;
 	static constexpr bool AUTO_FALLBACK_TO_FULL_DOWNLOAD = true;
@@ -43,7 +43,6 @@ struct HTTPFSParams : public HTTPParams {
 	bool force_download = DEFAULT_FORCE_DOWNLOAD;
 	bool auto_fallback_to_full_download = AUTO_FALLBACK_TO_FULL_DOWNLOAD;
 	bool enable_server_cert_verification = DEFAULT_ENABLE_SERVER_CERT_VERIFICATION;
-	bool enable_curl_server_cert_verification = true;
 	idx_t hf_max_per_page = DEFAULT_HF_MAX_PER_PAGE;
 	string ca_cert_file;
 	string bearer_token;


### PR DESCRIPTION
Two settings controlled the same thing with opposite defaults depending on the backend: `httplib` used `enable_server_cert_verification` (default `false`) and `curl` used `enable_curl_server_cert_verification` (default `true`), so `enable_server_cert_verification` was a no-op under the default `curl` backend.

This PR unifies them into a single `enable_server_cert_verification` that controls TLS certificate verification for both backends, defaulting to `true`. `enable_curl_server_cert_verification` is kept as a deprecated alias that warns and forwards to `enable_server_cert_verification` for now and can be removed in later versions.