### PR TITLE
Add `HTTPRequestSession`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ set(HTTPFS_SOURCES
     hffs.cpp
     s3fs.cpp
     httpfs.cpp
+    http_request_session.cpp
     http_state.cpp
     hash_functions.cpp
     create_secret_functions.cpp

--- a/src/hffs.cpp
+++ b/src/hffs.cpp
@@ -45,10 +45,6 @@ static string ParseNextUrlFromLinkHeader(const string &link_header_content) {
 HFFileHandle::~HFFileHandle() {
 }
 
-unique_ptr<HTTPClient> HFFileHandle::CreateClient() {
-	return http_params.http_util.InitializeClient(http_params, parsed_url.endpoint);
-}
-
 string HuggingFaceFileSystem::ListHFRequest(ParsedHFUrl &url, HTTPFSParams &http_params, string &next_page_url,
                                             optional_ptr<HTTPState> state) {
 	HTTPHeaders header_map;

--- a/src/http_request_session.cpp
+++ b/src/http_request_session.cpp
@@ -1,0 +1,242 @@
+#include "http_request_session.hpp"
+
+#include "http_state.hpp"
+
+namespace duckdb {
+
+HTTPTransportSnapshot::HTTPTransportSnapshot(const HTTPFSParams &params)
+    : http_util(params.http_util), httpfs_util(params.httpfs_util), timeout(params.timeout),
+      timeout_usec(params.timeout_usec), retries(params.retries), retry_wait_ms(params.retry_wait_ms),
+      retry_backoff(params.retry_backoff), keep_alive(params.keep_alive), follow_location(params.follow_location),
+      override_verify_ssl(params.override_verify_ssl), verify_ssl(params.verify_ssl), http_proxy(params.http_proxy),
+      http_proxy_port(params.http_proxy.empty() ? 0 : params.http_proxy_port),
+      http_proxy_username(params.http_proxy_username), http_proxy_password(params.http_proxy_password),
+      enable_server_cert_verification(params.enable_server_cert_verification),
+      enable_curl_server_cert_verification(params.enable_curl_server_cert_verification),
+      ca_cert_file(params.ca_cert_file), bearer_token(params.bearer_token), client_reuse(params.client_reuse_mode) {
+}
+
+bool HTTPTransportSnapshot::ClientCompatibleWith(const HTTPTransportSnapshot &other) const {
+	return &http_util.get() == &other.http_util.get() && timeout == other.timeout &&
+	       timeout_usec == other.timeout_usec && keep_alive == other.keep_alive &&
+	       follow_location == other.follow_location && override_verify_ssl == other.override_verify_ssl &&
+	       verify_ssl == other.verify_ssl && http_proxy == other.http_proxy &&
+	       http_proxy_port == other.http_proxy_port && http_proxy_username == other.http_proxy_username &&
+	       http_proxy_password == other.http_proxy_password &&
+	       enable_server_cert_verification == other.enable_server_cert_verification &&
+	       enable_curl_server_cert_verification == other.enable_curl_server_cert_verification &&
+	       ca_cert_file == other.ca_cert_file && bearer_token == other.bearer_token &&
+	       client_reuse == other.client_reuse;
+}
+
+HTTPRequestSnapshot::HTTPRequestSnapshot(const HTTPFSParams &params, HTTPRequestSnapshotType type_p)
+    : type(type_p), transport(params), user_agent(params.user_agent), extra_headers(params.extra_headers),
+      state(params.state), logger(params.logger), force_download(params.force_download),
+      auto_fallback_to_full_download(params.auto_fallback_to_full_download),
+      unsafe_disable_etag_checks(params.unsafe_disable_etag_checks),
+      s3_version_id_pinning(params.s3_version_id_pinning), force_download_threshold(params.force_download_threshold),
+      hf_max_per_page(params.hf_max_per_page) {
+}
+
+HTTPRequestSnapshot::~HTTPRequestSnapshot() = default;
+
+bool HTTPRequestSnapshot::ClientCompatibleWith(const HTTPRequestSnapshot &other) const {
+	return type == other.type && transport.ClientCompatibleWith(other.transport);
+}
+
+unique_ptr<HTTPFSParams> HTTPRequestSnapshot::CreateRequestParams() const {
+	auto result = make_uniq<HTTPFSParams>(transport.http_util.get());
+	result->timeout = transport.timeout;
+	result->timeout_usec = transport.timeout_usec;
+	result->retries = transport.retries;
+	result->retry_wait_ms = transport.retry_wait_ms;
+	result->retry_backoff = transport.retry_backoff;
+	result->keep_alive = transport.keep_alive;
+	result->follow_location = transport.follow_location;
+	result->override_verify_ssl = transport.override_verify_ssl;
+	result->verify_ssl = transport.verify_ssl;
+	result->http_proxy = transport.http_proxy;
+	result->http_proxy_port = transport.http_proxy.empty() ? 0 : transport.http_proxy_port;
+	result->http_proxy_username = transport.http_proxy_username;
+	result->http_proxy_password = transport.http_proxy_password;
+	result->enable_server_cert_verification = transport.enable_server_cert_verification;
+	result->enable_curl_server_cert_verification = transport.enable_curl_server_cert_verification;
+	result->ca_cert_file = transport.ca_cert_file;
+	result->bearer_token = transport.bearer_token;
+	result->state = state;
+	result->logger = logger;
+	result->force_download = force_download;
+	result->auto_fallback_to_full_download = auto_fallback_to_full_download;
+	result->unsafe_disable_etag_checks = unsafe_disable_etag_checks;
+	result->s3_version_id_pinning = s3_version_id_pinning;
+	result->force_download_threshold = force_download_threshold;
+	result->client_reuse_mode = transport.client_reuse;
+	result->httpfs_util = transport.httpfs_util;
+	result->hf_max_per_page = hf_max_per_page;
+	result->user_agent = user_agent;
+	result->extra_headers = extra_headers;
+	result->pre_merged_headers = true;
+	return result;
+}
+
+void HTTPRequestSnapshot::AddConfiguredHeaders(HTTPHeaders &headers) const {
+	if (!user_agent.empty()) {
+		headers.Insert("User-Agent", user_agent);
+	}
+	for (const auto &header : extra_headers) {
+		headers[header.first] = header.second;
+	}
+}
+
+HTTPClientLease::HTTPClientLease(shared_ptr<HTTPRequestSession> session_p, reference<HTTPUtil> http_util_p,
+                                 HTTPClientReuseMode reuse_mode_p, idx_t generation_p, unique_ptr<HTTPClient> client_p)
+    : session(std::move(session_p)), http_util(http_util_p), reuse_mode(reuse_mode_p), generation(generation_p),
+      client(std::move(client_p)), reusable(true) {
+}
+
+HTTPClientLease::HTTPClientLease(HTTPClientLease &&other) noexcept
+    : session(std::move(other.session)), http_util(other.http_util), reuse_mode(other.reuse_mode),
+      generation(other.generation), client(std::move(other.client)), reusable(other.reusable) {
+	other.reusable = false;
+}
+
+HTTPClientLease &HTTPClientLease::operator=(HTTPClientLease &&other) noexcept {
+	if (this == &other) {
+		return *this;
+	}
+	Release();
+	session = std::move(other.session);
+	http_util = other.http_util;
+	reuse_mode = other.reuse_mode;
+	generation = other.generation;
+	client = std::move(other.client);
+	reusable = other.reusable;
+	other.reusable = false;
+	return *this;
+}
+
+HTTPClientLease::~HTTPClientLease() noexcept {
+	Release();
+}
+
+void HTTPClientLease::Release() noexcept {
+	if (!session) {
+		return;
+	}
+	auto session_ref = std::move(session);
+	session_ref->ReturnClient(std::move(client), http_util, reuse_mode, generation, reusable);
+}
+
+HTTPRequestSession::HTTPRequestSession(shared_ptr<const HTTPRequestSnapshot> snapshot_p)
+    : current_snapshot(std::move(snapshot_p)) {
+	D_ASSERT(current_snapshot);
+}
+
+HTTPRequestSession::~HTTPRequestSession() {
+	vector<IdleClient> clients;
+	{
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		clients = std::move(idle_clients);
+	}
+	CloseClients(std::move(clients));
+}
+
+CapturedHTTPRequestSnapshot HTTPRequestSession::Capture() const {
+	annotated_lock_guard<annotated_mutex> guard(lock);
+	return {current_snapshot, client_generation};
+}
+
+CapturedHTTPRequestSnapshot HTTPRequestSession::Publish(const CapturedHTTPRequestSnapshot &failed,
+                                                        shared_ptr<const HTTPRequestSnapshot> replacement) {
+	D_ASSERT(replacement);
+	vector<IdleClient> clients;
+	CapturedHTTPRequestSnapshot result;
+	{
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		if (current_snapshot != failed.snapshot || client_generation != failed.client_generation) {
+			return {current_snapshot, client_generation};
+		}
+		if (!current_snapshot->ClientCompatibleWith(*replacement)) {
+			client_generation++;
+			clients = std::move(idle_clients);
+		}
+		current_snapshot = std::move(replacement);
+		result = {current_snapshot, client_generation};
+	}
+	return result;
+}
+
+HTTPClientLease HTTPRequestSession::AcquireClient(const CapturedHTTPRequestSnapshot &captured,
+                                                  HTTPFSParams &request_params, const string &proto_host_port) {
+	auto reuse_mode = captured.snapshot->transport.client_reuse;
+	unique_ptr<HTTPClient> client;
+	if (reuse_mode == HTTPClientReuseMode::SESSION_LOCAL) {
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		if (captured.client_generation == client_generation) {
+			for (idx_t i = idle_clients.size(); i > 0; i--) {
+				auto &entry = idle_clients[i - 1];
+				if (&entry.http_util.get() == &captured.snapshot->transport.http_util.get() && entry.client &&
+				    entry.client->GetBaseUrl() == proto_host_port) {
+					client = std::move(entry.client);
+					idle_clients.erase_at(i - 1);
+					break;
+				}
+			}
+		}
+	}
+	if (!client && reuse_mode != HTTPClientReuseMode::NONE) {
+		client = captured.snapshot->transport.http_util.get().InitializeClient(request_params, proto_host_port);
+	}
+	return HTTPClientLease(shared_from_this(), captured.snapshot->transport.http_util, reuse_mode,
+	                       captured.client_generation, std::move(client));
+}
+
+void HTTPRequestSession::InvalidateClients() {
+	vector<IdleClient> clients;
+	{
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		client_generation++;
+		clients = std::move(idle_clients);
+	}
+}
+
+void HTTPRequestSession::ReturnClient(unique_ptr<HTTPClient> client, reference<HTTPUtil> http_util,
+                                      HTTPClientReuseMode reuse_mode, idx_t generation, bool reusable) noexcept {
+	if (!client) {
+		return;
+	}
+	if (!reusable) {
+		return;
+	}
+	if (reuse_mode == HTTPClientReuseMode::SESSION_LOCAL) {
+		bool generation_current = false;
+		try {
+			annotated_lock_guard<annotated_mutex> guard(lock);
+			generation_current = generation == client_generation;
+			if (generation_current) {
+				idle_clients.emplace_back(std::move(client), http_util);
+				return;
+			}
+		} catch (...) { // NOLINT
+			generation_current = true;
+		}
+		if (!generation_current) {
+			return;
+		}
+	}
+	try {
+		http_util.get().CloseClient(std::move(client));
+	} catch (...) { // NOLINT
+	}
+}
+
+void HTTPRequestSession::CloseClients(vector<IdleClient> clients) noexcept {
+	for (auto &entry : clients) {
+		try {
+			entry.http_util.get().CloseClient(std::move(entry.client));
+		} catch (...) { // NOLINT
+		}
+	}
+}
+
+} // namespace duckdb

--- a/src/http_request_session.cpp
+++ b/src/http_request_session.cpp
@@ -4,86 +4,28 @@
 
 namespace duckdb {
 
-HTTPTransportSnapshot::HTTPTransportSnapshot(const HTTPFSParams &params)
-    : http_util(params.http_util), httpfs_util(params.httpfs_util), timeout(params.timeout),
-      timeout_usec(params.timeout_usec), retries(params.retries), retry_wait_ms(params.retry_wait_ms),
-      retry_backoff(params.retry_backoff), keep_alive(params.keep_alive), follow_location(params.follow_location),
-      override_verify_ssl(params.override_verify_ssl), verify_ssl(params.verify_ssl), http_proxy(params.http_proxy),
-      http_proxy_port(params.http_proxy.empty() ? 0 : params.http_proxy_port),
-      http_proxy_username(params.http_proxy_username), http_proxy_password(params.http_proxy_password),
-      enable_server_cert_verification(params.enable_server_cert_verification),
-      enable_curl_server_cert_verification(params.enable_curl_server_cert_verification),
-      ca_cert_file(params.ca_cert_file), bearer_token(params.bearer_token), client_reuse(params.client_reuse_mode) {
-}
-
-bool HTTPTransportSnapshot::ClientCompatibleWith(const HTTPTransportSnapshot &other) const {
-	return &http_util.get() == &other.http_util.get() && timeout == other.timeout &&
-	       timeout_usec == other.timeout_usec && keep_alive == other.keep_alive &&
-	       follow_location == other.follow_location && override_verify_ssl == other.override_verify_ssl &&
-	       verify_ssl == other.verify_ssl && http_proxy == other.http_proxy &&
-	       http_proxy_port == other.http_proxy_port && http_proxy_username == other.http_proxy_username &&
-	       http_proxy_password == other.http_proxy_password &&
-	       enable_server_cert_verification == other.enable_server_cert_verification &&
-	       enable_curl_server_cert_verification == other.enable_curl_server_cert_verification &&
-	       ca_cert_file == other.ca_cert_file && bearer_token == other.bearer_token &&
-	       client_reuse == other.client_reuse;
-}
-
 HTTPRequestSnapshot::HTTPRequestSnapshot(const HTTPFSParams &params, HTTPRequestSnapshotType type_p)
-    : type(type_p), transport(params), user_agent(params.user_agent), extra_headers(params.extra_headers),
-      state(params.state), logger(params.logger), force_download(params.force_download),
-      auto_fallback_to_full_download(params.auto_fallback_to_full_download),
-      unsafe_disable_etag_checks(params.unsafe_disable_etag_checks),
-      s3_version_id_pinning(params.s3_version_id_pinning), force_download_threshold(params.force_download_threshold),
-      hf_max_per_page(params.hf_max_per_page) {
+    : type(type_p), params(params) {
 }
 
 HTTPRequestSnapshot::~HTTPRequestSnapshot() = default;
 
-bool HTTPRequestSnapshot::ClientCompatibleWith(const HTTPRequestSnapshot &other) const {
-	return type == other.type && transport.ClientCompatibleWith(other.transport);
+bool HTTPRequestSnapshot::CanReuseClientsWith(const HTTPRequestSnapshot &other) const {
+	return type == other.type && &params.http_util == &other.params.http_util &&
+	       params.client_reuse_mode == other.params.client_reuse_mode;
 }
 
 unique_ptr<HTTPFSParams> HTTPRequestSnapshot::CreateRequestParams() const {
-	auto result = make_uniq<HTTPFSParams>(transport.http_util.get());
-	result->timeout = transport.timeout;
-	result->timeout_usec = transport.timeout_usec;
-	result->retries = transport.retries;
-	result->retry_wait_ms = transport.retry_wait_ms;
-	result->retry_backoff = transport.retry_backoff;
-	result->keep_alive = transport.keep_alive;
-	result->follow_location = transport.follow_location;
-	result->override_verify_ssl = transport.override_verify_ssl;
-	result->verify_ssl = transport.verify_ssl;
-	result->http_proxy = transport.http_proxy;
-	result->http_proxy_port = transport.http_proxy.empty() ? 0 : transport.http_proxy_port;
-	result->http_proxy_username = transport.http_proxy_username;
-	result->http_proxy_password = transport.http_proxy_password;
-	result->enable_server_cert_verification = transport.enable_server_cert_verification;
-	result->enable_curl_server_cert_verification = transport.enable_curl_server_cert_verification;
-	result->ca_cert_file = transport.ca_cert_file;
-	result->bearer_token = transport.bearer_token;
-	result->state = state;
-	result->logger = logger;
-	result->force_download = force_download;
-	result->auto_fallback_to_full_download = auto_fallback_to_full_download;
-	result->unsafe_disable_etag_checks = unsafe_disable_etag_checks;
-	result->s3_version_id_pinning = s3_version_id_pinning;
-	result->force_download_threshold = force_download_threshold;
-	result->client_reuse_mode = transport.client_reuse;
-	result->httpfs_util = transport.httpfs_util;
-	result->hf_max_per_page = hf_max_per_page;
-	result->user_agent = user_agent;
-	result->extra_headers = extra_headers;
+	auto result = make_uniq<HTTPFSParams>(params);
 	result->pre_merged_headers = true;
 	return result;
 }
 
 void HTTPRequestSnapshot::AddConfiguredHeaders(HTTPHeaders &headers) const {
-	if (!user_agent.empty()) {
-		headers.Insert("User-Agent", user_agent);
+	if (!params.user_agent.empty()) {
+		headers.Insert("User-Agent", params.user_agent);
 	}
-	for (const auto &header : extra_headers) {
+	for (const auto &header : params.extra_headers) {
 		headers[header.first] = header.second;
 	}
 }
@@ -146,49 +88,54 @@ CapturedHTTPRequestSnapshot HTTPRequestSession::Capture() const {
 	return {current_snapshot, client_generation};
 }
 
-CapturedHTTPRequestSnapshot HTTPRequestSession::Publish(const CapturedHTTPRequestSnapshot &failed,
-                                                        shared_ptr<const HTTPRequestSnapshot> replacement) {
+HTTPRequestSnapshotPublication HTTPRequestSession::TryPublish(const shared_ptr<const HTTPRequestSnapshot> &expected,
+                                                              shared_ptr<const HTTPRequestSnapshot> replacement) {
 	D_ASSERT(replacement);
 	vector<IdleClient> clients;
-	CapturedHTTPRequestSnapshot result;
+	HTTPRequestSnapshotPublication result;
 	{
 		annotated_lock_guard<annotated_mutex> guard(lock);
-		if (current_snapshot != failed.snapshot || client_generation != failed.client_generation) {
-			return {current_snapshot, client_generation};
+		if (current_snapshot != expected) {
+			return {{current_snapshot, client_generation}, false};
 		}
-		if (!current_snapshot->ClientCompatibleWith(*replacement)) {
+		if (!current_snapshot->CanReuseClientsWith(*replacement)) {
 			client_generation++;
 			clients = std::move(idle_clients);
 		}
 		current_snapshot = std::move(replacement);
-		result = {current_snapshot, client_generation};
+		result = {{current_snapshot, client_generation}, true};
 	}
 	return result;
 }
 
 HTTPClientLease HTTPRequestSession::AcquireClient(const CapturedHTTPRequestSnapshot &captured,
                                                   HTTPFSParams &request_params, const string &proto_host_port) {
-	auto reuse_mode = captured.snapshot->transport.client_reuse;
+	auto &snapshot_params = captured.snapshot->Params();
+	auto reuse_mode = snapshot_params.client_reuse_mode;
 	unique_ptr<HTTPClient> client;
+	bool reused_client = false;
 	if (reuse_mode == HTTPClientReuseMode::SESSION_LOCAL) {
 		annotated_lock_guard<annotated_mutex> guard(lock);
 		if (captured.client_generation == client_generation) {
 			for (idx_t i = idle_clients.size(); i > 0; i--) {
 				auto &entry = idle_clients[i - 1];
-				if (&entry.http_util.get() == &captured.snapshot->transport.http_util.get() && entry.client &&
+				if (&entry.http_util.get() == &snapshot_params.http_util && entry.client &&
 				    entry.client->GetBaseUrl() == proto_host_port) {
 					client = std::move(entry.client);
 					idle_clients.erase_at(i - 1);
+					reused_client = true;
 					break;
 				}
 			}
 		}
 	}
-	if (!client && reuse_mode != HTTPClientReuseMode::NONE) {
-		client = captured.snapshot->transport.http_util.get().InitializeClient(request_params, proto_host_port);
+	if (reused_client) {
+		client->Initialize(request_params);
+	} else if (!client && reuse_mode != HTTPClientReuseMode::NONE) {
+		client = snapshot_params.http_util.InitializeClient(request_params, proto_host_port);
 	}
-	return HTTPClientLease(shared_from_this(), captured.snapshot->transport.http_util, reuse_mode,
-	                       captured.client_generation, std::move(client));
+	return HTTPClientLease(shared_from_this(), snapshot_params.http_util, reuse_mode, captured.client_generation,
+	                       std::move(client));
 }
 
 void HTTPRequestSession::InvalidateClients() {

--- a/src/http_state.cpp
+++ b/src/http_state.cpp
@@ -168,6 +168,11 @@ void HTTPState::WriteProfilingInformation(std::ostream &ss) {
 	ss << "└─────────────────────────────────────┘\n";
 }
 
+bool HTTPState::RunCredentialRefresh(const std::function<bool()> &callback) {
+	annotated_lock_guard<annotated_mutex> guard(credential_refresh_mutex);
+	return callback();
+}
+
 //! Get per-path state, create if it does not exist
 shared_ptr<HTTPFileState> HTTPState::GetFileState(const string &path) {
 	annotated_lock_guard<annotated_mutex> lock(file_states_mutex);

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -37,6 +37,8 @@ unique_ptr<HTTPParams> HTTPFSUtil::InitializeParameters(optional_ptr<FileOpener>
 	auto result = make_uniq<HTTPFSParams>(*this);
 	result->Initialize(opener);
 	result->state = HTTPState::TryGetState(opener);
+	result->client_reuse_mode = GetClientReuseMode();
+	result->httpfs_util = this;
 
 	// No point in continuing without an opener
 	if (!opener) {
@@ -149,61 +151,9 @@ unique_ptr<HTTPParams> HTTPFSParams::Clone() const {
 	result->user_agent = user_agent;
 	result->pre_merged_headers = pre_merged_headers;
 	result->force_download_threshold = force_download_threshold;
+	result->client_reuse_mode = client_reuse_mode;
+	result->httpfs_util = httpfs_util;
 	return std::move(result);
-}
-
-unique_ptr<HTTPClient> HTTPClientCache::GetClient() {
-	return GetClientWithGeneration().client;
-}
-
-HTTPClientCache::Entry HTTPClientCache::GetClientWithGeneration() {
-	lock_guard<mutex> lck(lock);
-	Entry result;
-	result.generation = generation;
-	if (clients.size() == 0) {
-		return result;
-	}
-
-	result.client = std::move(clients.back());
-	clients.pop_back();
-	return result;
-}
-
-void HTTPClientCache::StoreClient(unique_ptr<HTTPClient> client) {
-	lock_guard<mutex> lck(lock);
-	clients.push_back(std::move(client));
-}
-
-bool HTTPClientCache::StoreClient(Entry &entry) {
-	lock_guard<mutex> lck(lock);
-	if (!entry.client) {
-		return true;
-	}
-	if (entry.generation != generation) {
-		return false;
-	}
-	clients.push_back(std::move(entry.client));
-	return true;
-}
-
-void HTTPClientCache::Clear() {
-	lock_guard<mutex> lck(lock);
-	generation++;
-	clients.clear();
-}
-
-static void AddUserAgentIfAvailable(HTTPFSParams &http_params, HTTPHeaders &header_map) {
-	if (!http_params.user_agent.empty()) {
-		header_map.Insert("User-Agent", http_params.user_agent);
-	}
-}
-
-static void AddHandleHeaders(HTTPFSParams &http_params, HTTPHeaders &header_map) {
-	// Inject headers from the http param extra_headers into the request
-	for (auto &header : http_params.extra_headers) {
-		header_map[header.first] = header.second;
-	}
-	http_params.pre_merged_headers = true;
 }
 
 static string StripETagQuotes(const string &etag) {
@@ -211,6 +161,22 @@ static string StripETagQuotes(const string &etag) {
 		return etag.substr(1, etag.size() - 2);
 	}
 	return etag;
+}
+
+static unique_ptr<HTTPResponse> SendSessionRequest(HTTPRequestSession &session,
+                                                   const CapturedHTTPRequestSnapshot &captured,
+                                                   HTTPFSParams &request_params, BaseRequest &request) {
+	auto lease = session.AcquireClient(captured, request_params, request.proto_host_port);
+	try {
+		auto response = request_params.http_util.Request(request, lease.Client());
+		if (response && (response->HasRequestError() || static_cast<int>(response->status) >= 400)) {
+			lease.Invalidate();
+		}
+		return response;
+	} catch (...) {
+		lease.Invalidate();
+		throw;
+	}
 }
 
 unique_ptr<HTTPResponse> HTTPFileSystem::RunHeadRequest(string url, HTTPHeaders header_map, HTTPFSParams &http_params,
@@ -321,9 +287,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh,
 				    string responseEtag = response.GetHeaderValue("ETag");
 
 				    if (!responseEtag.empty() && StripETagQuotes(responseEtag) != StripETagQuotes(etag)) {
-					    if (global_metadata_cache) {
-						    global_metadata_cache->Erase(hfh.path);
-					    }
+					    EraseGlobalCacheEntry(hfh.path);
 					    throw HTTPException(
 					        response,
 					        "ETag on reading file \"%s\" was initially %s and now it returned %s, this likely means "
@@ -403,49 +367,24 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh,
 	return response;
 }
 
-unique_ptr<HTTPResponse> HTTPFileSystem::PostRequest(HTTPInput &input, string url, HTTPHeaders header_map,
-                                                     string &buffer_out, char *buffer_in, idx_t buffer_in_len,
-                                                     string params) {
-	AddUserAgentIfAvailable(input.http_params, header_map);
-	AddHandleHeaders(input.http_params, header_map);
-	return RunPostRequest(url, header_map, input.http_params, buffer_out, buffer_in, buffer_in_len,
-	                      [&](BaseRequest &request) { return input.http_params.http_util.Request(request); });
-}
-
-unique_ptr<HTTPResponse> HTTPFileSystem::PutRequest(HTTPInput &input, string url, HTTPHeaders header_map,
-                                                    char *buffer_in, idx_t buffer_in_len, string params) {
-	AddUserAgentIfAvailable(input.http_params, header_map);
-	AddHandleHeaders(input.http_params, header_map);
-
-	string content_type = "application/octet-stream";
-	return RunPutRequest(url, header_map, input.http_params, buffer_in, buffer_in_len, content_type,
-	                     [&](BaseRequest &request) { return input.http_params.http_util.Request(request); });
-}
-
 unique_ptr<HTTPResponse> HTTPFileSystem::HeadRequest(FileHandle &handle, string url, HTTPHeaders header_map) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
-	AddUserAgentIfAvailable(hfh.http_params, header_map);
-	AddHandleHeaders(hfh.http_params, header_map);
-
-	auto http_client = hfh.GetClient();
-	auto response = RunHeadRequest(url, header_map, hfh.http_params, [&](BaseRequest &request) {
-		return hfh.http_params.http_util.Request(request, http_client);
+	auto captured = hfh.request_session->Capture();
+	captured.snapshot->AddConfiguredHeaders(header_map);
+	auto request_params = captured.snapshot->CreateRequestParams();
+	return RunHeadRequest(url, header_map, *request_params, [&](BaseRequest &request) {
+		return SendSessionRequest(*hfh.request_session, captured, *request_params, request);
 	});
-	hfh.StoreClient(std::move(http_client));
-	return response;
 }
 
 unique_ptr<HTTPResponse> HTTPFileSystem::DeleteRequest(FileHandle &handle, string url, HTTPHeaders header_map) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
-	AddUserAgentIfAvailable(hfh.http_params, header_map);
-	AddHandleHeaders(hfh.http_params, header_map);
-
-	auto http_client = hfh.GetClient();
-	auto response = RunDeleteRequest(url, header_map, hfh.http_params, [&](BaseRequest &request) {
-		return hfh.http_params.http_util.Request(request, http_client);
+	auto captured = hfh.request_session->Capture();
+	captured.snapshot->AddConfiguredHeaders(header_map);
+	auto request_params = captured.snapshot->CreateRequestParams();
+	return RunDeleteRequest(url, header_map, *request_params, [&](BaseRequest &request) {
+		return SendSessionRequest(*hfh.request_session, captured, *request_params, request);
 	});
-	hfh.StoreClient(std::move(http_client));
-	return response;
 }
 
 HTTPException HTTPFileSystem::GetHTTPError(FileHandle &, const HTTPResponse &response, const string &url) {
@@ -462,40 +401,35 @@ HTTPException HTTPFileSystem::GetHTTPError(FileHandle &, const HTTPResponse &res
 unique_ptr<HTTPResponse> HTTPFileSystem::GetRequest(FileHandle &handle, string url, HTTPHeaders header_map,
                                                     CachedFileDownload &download) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
-	AddUserAgentIfAvailable(hfh.http_params, header_map);
-	AddHandleHeaders(hfh.http_params, header_map);
-
-	auto http_client = hfh.GetClient();
-	auto response = RunGetRequest(
-	    hfh, url, header_map, hfh.http_params, download,
+	auto captured = hfh.request_session->Capture();
+	captured.snapshot->AddConfiguredHeaders(header_map);
+	auto request_params = captured.snapshot->CreateRequestParams();
+	return RunGetRequest(
+	    hfh, url, header_map, *request_params, download,
 	    [&](const HTTPResponse &response) { return GetHTTPError(handle, response, url); },
-	    [&](BaseRequest &request) { return hfh.http_params.http_util.Request(request, http_client); });
-	hfh.StoreClient(std::move(http_client));
-	return response;
+	    [&](BaseRequest &request) {
+		    return SendSessionRequest(*hfh.request_session, captured, *request_params, request);
+	    });
 }
 
 unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, string url, HTTPHeaders header_map,
                                                          idx_t file_offset, char *buffer_out, idx_t buffer_out_len) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
-	AddUserAgentIfAvailable(hfh.http_params, header_map);
-	AddHandleHeaders(hfh.http_params, header_map);
-
-	auto http_client = hfh.GetClient();
-	auto response = RunGetRangeRequest(
-	    hfh, url, header_map, hfh.http_params, hfh.etag, hfh.auto_fallback_to_full_file_download, file_offset,
+	auto captured = hfh.request_session->Capture();
+	captured.snapshot->AddConfiguredHeaders(header_map);
+	auto request_params = captured.snapshot->CreateRequestParams();
+	return RunGetRangeRequest(
+	    hfh, url, header_map, *request_params, hfh.etag, hfh.auto_fallback_to_full_file_download, file_offset,
 	    buffer_out, buffer_out_len, [&](const HTTPResponse &response) { return GetHTTPError(handle, response, url); },
-	    [&](BaseRequest &request) { return hfh.http_params.http_util.Request(request, http_client); });
-	hfh.StoreClient(std::move(http_client));
-	return response;
-}
-
-HTTPInput::HTTPInput(unique_ptr<HTTPParams> params_p)
-    : params(std::move(params_p)), http_params(params->Cast<HTTPFSParams>()) {
+	    [&](BaseRequest &request) {
+		    return SendSessionRequest(*hfh.request_session, captured, *request_params, request);
+	    });
 }
 
 HTTPFileHandle::HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags,
-                               shared_ptr<HTTPInput> input_p)
-    : FileHandle(fs, file.path, flags), http_input(std::move(input_p)), http_params(http_input->http_params),
+                               unique_ptr<HTTPParams> params_p)
+    : FileHandle(fs, file.path, flags), request_session(make_shared_ptr<HTTPRequestSession>(
+                                            make_shared_ptr<HTTPRequestSnapshot>(params_p->Cast<HTTPFSParams>()))),
       flags(flags), length(0), last_modified(0), force_full_download(false), buffer_available(0), buffer_idx(0),
       file_offset(0), buffer_start(0), buffer_end(0) {
 	// check if the handle has extended properties that can be set directly in the handle
@@ -524,11 +458,6 @@ HTTPFileHandle::HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpe
 			initialized = true;
 		}
 	}
-}
-
-HTTPFileHandle::HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags,
-                               unique_ptr<HTTPParams> params_p)
-    : HTTPFileHandle(fs, file, flags, make_shared_ptr<HTTPInput>(std::move(params_p))) {
 }
 
 unique_ptr<HTTPFileHandle> HTTPFileSystem::CreateHandle(const OpenFileInfo &file, FileOpenFlags flags,
@@ -583,7 +512,7 @@ unique_ptr<FileHandle> HTTPFileSystem::OpenFileExtended(const OpenFileInfo &file
 }
 
 void HTTPFileHandle::AddStatistics(idx_t read_offset, idx_t read_length, idx_t read_duration) {
-	lock_guard<mutex> guard(throughput_lock);
+	annotated_lock_guard<annotated_mutex> guard(throughput_lock);
 	range_request_statistics.push_back({read_offset, read_length, read_duration});
 }
 
@@ -591,7 +520,7 @@ void HTTPFileHandle::RecordNetworkSample(double total_seconds, idx_t bytes, bool
 	if (!(total_seconds > 0)) {
 		return;
 	}
-	lock_guard<mutex> guard(throughput_lock);
+	annotated_lock_guard<annotated_mutex> guard(throughput_lock);
 	const idx_t n = tp_sample_count + 1;
 	const double alpha = MaxValue<double>(0.2, 1.0 / static_cast<double>(n));
 
@@ -609,7 +538,7 @@ void HTTPFileHandle::RecordNetworkSample(double total_seconds, idx_t bytes, bool
 }
 
 bool HTTPFileHandle::TryGetNetworkThroughput(NetworkThroughputEstimate &result) {
-	lock_guard<mutex> guard(throughput_lock);
+	annotated_lock_guard<annotated_mutex> guard(throughput_lock);
 	if (tp_sample_count == 0 || tp_latency_seconds <= 0 || tp_bandwidth_bps <= 0) {
 		return false;
 	}
@@ -620,19 +549,20 @@ bool HTTPFileHandle::TryGetNetworkThroughput(NetworkThroughputEstimate &result) 
 
 void HTTPFileHandle::AdaptReadBufferSize(idx_t next_read_offset) {
 	D_ASSERT(!SkipBuffer());
-	if (range_request_statistics.empty()) {
-		return; // No requests yet - nothing to do
-	}
-
-	const auto &last_read = range_request_statistics.back();
-	if (last_read.offset + last_read.length != next_read_offset) {
-		return; // Not reading sequentially
+	{
+		annotated_lock_guard<annotated_mutex> guard(throughput_lock);
+		if (range_request_statistics.empty()) {
+			return;
+		}
+		const auto &last_read = range_request_statistics.back();
+		if (last_read.offset + last_read.length != next_read_offset) {
+			return;
+		}
 	}
 
 	if (read_buffer.GetSize() >= MAXIMUM_READ_BUFFER_LEN) {
-		return; // Already at maximum size
+		return;
 	}
-
 	// Grow the buffer
 	// TODO: can use statistics to estimate per-byte and round-trip cost using least squares, and do something smarter
 	read_buffer = read_buffer.GetAllocator()->Allocate(read_buffer.GetSize() * 2);
@@ -659,7 +589,7 @@ bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders
 		if (res->HasRequestError()) {
 			// Special case: we can do a retry with a full file download
 			if (RespondedWithRangeRequestNotSupported(*res)) {
-				if (hfh.http_params.auto_fallback_to_full_download) {
+				if (hfh.request_session->Capture().snapshot->auto_fallback_to_full_download) {
 					return false;
 				}
 			}
@@ -815,7 +745,7 @@ void HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, id
 	const auto downloaded_length = cached_file->GetSize();
 	if (downloaded_length != head_reported_length) {
 		hfh.file_state->InvalidateCachedFile();
-		hfh.http_params.state->EraseFileState(hfh.path);
+		hfh.request_session->Capture().snapshot->state->EraseFileState(hfh.path);
 		throw HTTPException(Exception::ConstructMessage(
 		    "The size reported by HEAD for '%s' was %llu bytes, but the full GET downloaded %llu bytes. You can try "
 		    "to resolve this by enabling `SET force_download=true`",
@@ -890,11 +820,18 @@ idx_t HTTPFileSystem::SeekPosition(FileHandle &handle) {
 }
 
 optional_ptr<HTTPMetadataCache> HTTPFileSystem::GetGlobalCache() {
-	lock_guard<mutex> lock(global_cache_lock);
+	annotated_lock_guard<annotated_mutex> lock(global_cache_lock);
 	if (!global_metadata_cache) {
 		global_metadata_cache = make_uniq<HTTPMetadataCache>(false, true);
 	}
 	return global_metadata_cache.get();
+}
+
+void HTTPFileSystem::EraseGlobalCacheEntry(const string &path) {
+	annotated_lock_guard<annotated_mutex> lock(global_cache_lock);
+	if (global_metadata_cache) {
+		global_metadata_cache->Erase(path);
+	}
 }
 
 // Get either the local, global, or no cache depending on settings
@@ -1028,7 +965,7 @@ void HTTPFileHandle::LoadFileInfo() {
 				    range_res->status != HTTPStatusCode::Accepted_202 && range_res->status != HTTPStatusCode::OK_200) {
 					// It failed again, check whether we can fall back to full download
 					if (RespondedWithRangeRequestNotSupported(*range_res) &&
-					    http_params.auto_fallback_to_full_download) {
+					    request_session->Capture().snapshot->auto_fallback_to_full_download) {
 						force_full_download = true;
 					} else {
 						throw hfs.GetHTTPError(*this, *range_res, path);
@@ -1055,7 +992,7 @@ void HTTPFileHandle::LoadFileInfo() {
 	if (res->headers.HasHeader("ETag")) {
 		etag = res->headers.GetHeaderValue("ETag");
 	}
-	if (http_params.s3_version_id_pinning && res->headers.HasHeader("x-amz-version-id")) {
+	if (request_session->Capture().snapshot->s3_version_id_pinning && res->headers.HasHeader("x-amz-version-id")) {
 		version_id = res->headers.GetHeaderValue("x-amz-version-id");
 	}
 	if (res->headers.HasHeader("Accept-Ranges")) {
@@ -1116,11 +1053,15 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 		auto database = FileOpener::TryGetDatabase(opener);
 		buffer_allocator = database ? BufferAllocator::Get(*database) : Allocator::DefaultAllocator();
 	}
-	http_params.state = HTTPState::TryGetState(opener);
-	if (!http_params.state) {
-		http_params.state = make_shared_ptr<HTTPState>();
+	auto captured = request_session->Capture();
+	auto request_params = captured.snapshot->CreateRequestParams();
+	request_params->state = HTTPState::TryGetState(opener);
+	if (!request_params->state) {
+		request_params->state = make_shared_ptr<HTTPState>();
 	}
-	file_state = http_params.state->GetFileState(path);
+	request_session->Publish(captured, CreateRequestSnapshot(*request_params));
+	auto request_snapshot = request_session->Capture().snapshot;
+	file_state = request_snapshot->state->GetFileState(path);
 
 	if (opener) {
 		TryAddLogger(*opener);
@@ -1130,7 +1071,7 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 
 	bool should_write_cache = false;
 	if (flags.OpenForReading()) {
-		if (http_params.force_download) {
+		if (request_snapshot->force_download) {
 			length = hfs.FullDownload(*this, should_write_cache)->GetSize();
 			return;
 		}
@@ -1155,9 +1096,9 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 
 	if (flags.OpenForReading()) {
 
-		const auto has_cache_state = (http_params.state != nullptr) && (length == 0);
+		const auto has_cache_state = (request_snapshot->state != nullptr) && (length == 0);
 		const auto always_download = force_full_download;
-		const auto meets_threshold = (length < http_params.force_download_threshold) && (length != 0);
+		const auto meets_threshold = (length < request_snapshot->force_download_threshold) && (length != 0);
 
 		const auto should_full_download = has_cache_state || meets_threshold || always_download;
 
@@ -1180,58 +1121,24 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 	}
 }
 
-//! Whether clients are checked out from the shared connection pool instead of the per-handle cache.
-//! Only the curl util pools clients (one pool per database instance); every other configuration
-//! keeps per-handle reuse so it does not pay a fresh connection per request.
-static bool UseSharedConnectionPool(const HTTPParams &http_params) {
-#ifndef EMSCRIPTEN
-	auto &util = http_params.http_util;
-	if (util.GetName() == "HTTPFS-Curl") {
-		return static_cast<const HTTPFSCurlUtil &>(util).connection_caching_enabled;
-	}
-#endif
-	return false;
-}
-
-unique_ptr<HTTPClient> HTTPFileHandle::GetClient() {
-	if (!UseSharedConnectionPool(http_params)) {
-		// no shared pool for this configuration - reuse this handle's cached client
-		auto cached_client = client_cache.GetClient();
-		if (cached_client) {
-			return cached_client;
-		}
-	}
-	// with the shared pool enabled InitializeClient consults the pool, so that concurrent handles
-	// share connections instead of each hoarding a private pool
-	return CreateClient();
-}
-
-unique_ptr<HTTPClient> HTTPFileHandle::CreateClient() {
-	string path_out, proto_host_port;
-	HTTPUtil::DecomposeURL(path, path_out, proto_host_port);
-	return http_params.http_util.InitializeClient(http_params, proto_host_port);
-}
-
-void HTTPFileHandle::StoreClient(unique_ptr<HTTPClient> client) {
-	if (!UseSharedConnectionPool(http_params)) {
-		client_cache.StoreClient(std::move(client));
-		return;
-	}
-	// return the client to the shared connection pool so other handles can reuse it
-	http_params.http_util.CloseClient(std::move(client));
+shared_ptr<const HTTPRequestSnapshot> HTTPFileHandle::CreateRequestSnapshot(const HTTPFSParams &params) const {
+	return make_shared_ptr<HTTPRequestSnapshot>(params);
 }
 
 HTTPFileHandle::~HTTPFileHandle() {
 	DUCKDB_LOG_FILE_SYSTEM_CLOSE((*this));
-	auto client = client_cache.GetClient();
-	while (client) {
-		http_params.http_util.CloseClient(std::move(client));
-		client = client_cache.GetClient();
-	}
 }
 
 void HTTPFSUtil::ClearCachedConnections() {
 	// no-op by default
+}
+
+HTTPClientReuseMode HTTPFSUtil::GetClientReuseMode() const {
+#ifdef EMSCRIPTEN
+	return HTTPClientReuseMode::NONE;
+#else
+	return HTTPClientReuseMode::SESSION_LOCAL;
+#endif
 }
 
 string HTTPFSUtil::GetName() const {

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -121,39 +121,7 @@ unique_ptr<HTTPParams> HTTPFSUtil::InitializeParameters(optional_ptr<FileOpener>
 }
 
 unique_ptr<HTTPParams> HTTPFSParams::Clone() const {
-	auto result = make_uniq<HTTPFSParams>(http_util);
-	result->timeout = timeout;
-	result->timeout_usec = timeout_usec;
-	result->retries = retries;
-	result->retry_wait_ms = retry_wait_ms;
-	result->retry_backoff = retry_backoff;
-	result->keep_alive = keep_alive;
-	result->follow_location = follow_location;
-	result->override_verify_ssl = override_verify_ssl;
-	result->verify_ssl = verify_ssl;
-	result->http_proxy = http_proxy;
-	result->http_proxy_port = http_proxy.empty() ? 0 : http_proxy_port;
-	result->http_proxy_username = http_proxy_username;
-	result->http_proxy_password = http_proxy_password;
-	result->extra_headers = extra_headers;
-	result->logger = logger;
-
-	result->force_download = force_download;
-	result->auto_fallback_to_full_download = auto_fallback_to_full_download;
-	result->enable_server_cert_verification = enable_server_cert_verification;
-	result->enable_curl_server_cert_verification = enable_curl_server_cert_verification;
-	result->hf_max_per_page = hf_max_per_page;
-	result->ca_cert_file = ca_cert_file;
-	result->bearer_token = bearer_token;
-	result->unsafe_disable_etag_checks = unsafe_disable_etag_checks;
-	result->s3_version_id_pinning = s3_version_id_pinning;
-	result->state = state;
-	result->user_agent = user_agent;
-	result->pre_merged_headers = pre_merged_headers;
-	result->force_download_threshold = force_download_threshold;
-	result->client_reuse_mode = client_reuse_mode;
-	result->httpfs_util = httpfs_util;
-	return std::move(result);
+	return make_uniq<HTTPFSParams>(*this);
 }
 
 static string StripETagQuotes(const string &etag) {
@@ -589,7 +557,7 @@ bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders
 		if (res->HasRequestError()) {
 			// Special case: we can do a retry with a full file download
 			if (RespondedWithRangeRequestNotSupported(*res)) {
-				if (hfh.request_session->Capture().snapshot->auto_fallback_to_full_download) {
+				if (hfh.request_session->Capture().snapshot->Params().auto_fallback_to_full_download) {
 					return false;
 				}
 			}
@@ -745,7 +713,7 @@ void HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, id
 	const auto downloaded_length = cached_file->GetSize();
 	if (downloaded_length != head_reported_length) {
 		hfh.file_state->InvalidateCachedFile();
-		hfh.request_session->Capture().snapshot->state->EraseFileState(hfh.path);
+		hfh.request_session->Capture().snapshot->Params().state->EraseFileState(hfh.path);
 		throw HTTPException(Exception::ConstructMessage(
 		    "The size reported by HEAD for '%s' was %llu bytes, but the full GET downloaded %llu bytes. You can try "
 		    "to resolve this by enabling `SET force_download=true`",
@@ -965,7 +933,7 @@ void HTTPFileHandle::LoadFileInfo() {
 				    range_res->status != HTTPStatusCode::Accepted_202 && range_res->status != HTTPStatusCode::OK_200) {
 					// It failed again, check whether we can fall back to full download
 					if (RespondedWithRangeRequestNotSupported(*range_res) &&
-					    request_session->Capture().snapshot->auto_fallback_to_full_download) {
+					    request_session->Capture().snapshot->Params().auto_fallback_to_full_download) {
 						force_full_download = true;
 					} else {
 						throw hfs.GetHTTPError(*this, *range_res, path);
@@ -992,7 +960,8 @@ void HTTPFileHandle::LoadFileInfo() {
 	if (res->headers.HasHeader("ETag")) {
 		etag = res->headers.GetHeaderValue("ETag");
 	}
-	if (request_session->Capture().snapshot->s3_version_id_pinning && res->headers.HasHeader("x-amz-version-id")) {
+	if (request_session->Capture().snapshot->Params().s3_version_id_pinning &&
+	    res->headers.HasHeader("x-amz-version-id")) {
 		version_id = res->headers.GetHeaderValue("x-amz-version-id");
 	}
 	if (res->headers.HasHeader("Accept-Ranges")) {
@@ -1059,9 +1028,9 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 	if (!request_params->state) {
 		request_params->state = make_shared_ptr<HTTPState>();
 	}
-	request_session->Publish(captured, CreateRequestSnapshot(*request_params));
+	request_session->TryPublish(captured.snapshot, CreateRequestSnapshot(*request_params));
 	auto request_snapshot = request_session->Capture().snapshot;
-	file_state = request_snapshot->state->GetFileState(path);
+	file_state = request_snapshot->Params().state->GetFileState(path);
 
 	if (opener) {
 		TryAddLogger(*opener);
@@ -1071,7 +1040,7 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 
 	bool should_write_cache = false;
 	if (flags.OpenForReading()) {
-		if (request_snapshot->force_download) {
+		if (request_snapshot->Params().force_download) {
 			length = hfs.FullDownload(*this, should_write_cache)->GetSize();
 			return;
 		}
@@ -1096,9 +1065,9 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 
 	if (flags.OpenForReading()) {
 
-		const auto has_cache_state = (request_snapshot->state != nullptr) && (length == 0);
+		const auto has_cache_state = (request_snapshot->Params().state != nullptr) && (length == 0);
 		const auto always_download = force_full_download;
-		const auto meets_threshold = (length < request_snapshot->force_download_threshold) && (length != 0);
+		const auto meets_threshold = (length < request_snapshot->Params().force_download_threshold) && (length != 0);
 
 		const auto should_full_download = has_cache_state || meets_threshold || always_download;
 

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -137,7 +137,8 @@ static unique_ptr<HTTPResponse> SendSessionRequest(HTTPRequestSession &session,
 	auto lease = session.AcquireClient(captured, request_params, request.proto_host_port);
 	try {
 		auto response = request_params.http_util.Request(request, lease.Client());
-		if (response && (response->HasRequestError() || static_cast<int>(response->status) >= 400)) {
+		// A completed HTTP response leaves the transport reusable, regardless of its status.
+		if (response && response->HasRequestError()) {
 			lease.Invalidate();
 		}
 		return response;

--- a/src/httpfs_connection_caching.cpp
+++ b/src/httpfs_connection_caching.cpp
@@ -29,7 +29,7 @@ unique_ptr<HTTPClient> HTTPClientConnectionCache::Find(const string &base_url) {
 		auto &pool = pools[idx];
 		// block instead of skipping: a spurious miss dials a new connection (DNS + TLS),
 		// which is far more expensive than waiting for this short critical section
-		lock_guard<mutex> lock(pool.lock);
+		annotated_lock_guard<annotated_mutex> lock(pool.lock);
 		for (auto &entry : pool.entries) {
 			if (entry && entry->GetBaseUrl() == base_url) {
 				cache_pool_idx = idx;
@@ -49,7 +49,7 @@ void HTTPClientConnectionCache::Store(unique_ptr<HTTPClient> &&client) {
 	for (size_t i = 0; i < POOL_COUNT; i++) {
 		const size_t idx = (start + i) & (POOL_COUNT - 1);
 		auto &pool = pools[idx];
-		lock_guard<mutex> lock(pool.lock);
+		annotated_lock_guard<annotated_mutex> lock(pool.lock);
 		for (auto &entry : pool.entries) {
 			if (!entry) {
 				entry = std::move(client);
@@ -61,16 +61,24 @@ void HTTPClientConnectionCache::Store(unique_ptr<HTTPClient> &&client) {
 	// Pass 2: every pool is full — evict at random in the starting pool
 	RandomEngine engine;
 	auto &pool = pools[start];
-	lock_guard<mutex> lock(pool.lock);
-	const size_t slot = engine.NextRandomInteger() % pool.entries.size();
-	pool.entries[slot] = std::move(client);
+	unique_ptr<HTTPClient> evicted_client;
+	{
+		annotated_lock_guard<annotated_mutex> lock(pool.lock);
+		const size_t slot = engine.NextRandomInteger() % pool.entries.size();
+		evicted_client = std::move(pool.entries[slot]);
+		pool.entries[slot] = std::move(client);
+	}
 }
 
 void HTTPClientConnectionCache::Clear() {
+	vector<unique_ptr<HTTPClient>> cleared_clients;
+	cleared_clients.reserve(POOL_COUNT * POOL_SIZE);
 	for (auto &pool : pools) {
-		lock_guard<mutex> lock(pool.lock);
+		annotated_lock_guard<annotated_mutex> lock(pool.lock);
 		for (auto &entry : pool.entries) {
-			entry.reset();
+			if (entry) {
+				cleared_clients.push_back(std::move(entry));
+			}
 		}
 	}
 }
@@ -91,6 +99,10 @@ bool HTTPFSCurlUtil::EnableCaching(BaseRequest &request) {
 
 void HTTPFSCurlUtil::ClearCachedConnections() {
 	connection_cache.Clear();
+}
+
+HTTPClientReuseMode HTTPFSCurlUtil::GetClientReuseMode() const {
+	return connection_caching_enabled ? HTTPClientReuseMode::SHARED : HTTPClientReuseMode::SESSION_LOCAL;
 }
 
 void HTTPFSCurlUtil::CloseClient(unique_ptr<HTTPClient> &&client) {

--- a/src/httpfs_httplib_client.cpp
+++ b/src/httpfs_httplib_client.cpp
@@ -38,6 +38,8 @@ public:
 
 			if (!http_params.http_proxy_username.empty()) {
 				client->set_proxy_basic_auth(http_params.http_proxy_username, http_params.http_proxy_password);
+			} else {
+				client->set_proxy_basic_auth("", "");
 			}
 		} else {
 			client->set_proxy("", -1);

--- a/src/include/hffs.hpp
+++ b/src/include/hffs.hpp
@@ -63,8 +63,6 @@ public:
 	}
 	~HFFileHandle() override;
 
-	unique_ptr<HTTPClient> CreateClient() override;
-
 protected:
 	ParsedHFUrl parsed_url;
 };

--- a/src/include/http_metadata_cache.hpp
+++ b/src/include/http_metadata_cache.hpp
@@ -26,55 +26,31 @@ struct HTTPMetadataCacheEntry {
 // Simple cache with a max age for an entry to be valid
 class HTTPMetadataCache : public ClientContextState {
 public:
-	explicit HTTPMetadataCache(bool flush_on_query_end_p, bool shared_p)
-	    : flush_on_query_end(flush_on_query_end_p), shared(shared_p) {};
+	explicit HTTPMetadataCache(bool flush_on_query_end_p, bool) : flush_on_query_end(flush_on_query_end_p) {};
 
-	void Insert(const string &path, HTTPMetadataCacheEntry val) {
-		if (shared) {
-			lock_guard<mutex> parallel_lock(lock);
-			map[path] = val;
-		} else {
-			map[path] = val;
-		}
+	void Insert(const string &path, HTTPMetadataCacheEntry val) DUCKDB_EXCLUDES(lock) {
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		map[path] = std::move(val);
 	};
 
-	void Erase(string path) {
-		if (shared) {
-			lock_guard<mutex> parallel_lock(lock);
-			map.erase(path);
-		} else {
-			map.erase(path);
-		}
+	void Erase(string path) DUCKDB_EXCLUDES(lock) {
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		map.erase(path);
 	};
 
-	bool Find(string path, HTTPMetadataCacheEntry &ret_val) {
-		if (shared) {
-			lock_guard<mutex> parallel_lock(lock);
-			auto lookup = map.find(path);
-			if (lookup != map.end()) {
-				ret_val = lookup->second;
-				return true;
-			} else {
-				return false;
-			}
-		} else {
-			auto lookup = map.find(path);
-			if (lookup != map.end()) {
-				ret_val = lookup->second;
-				return true;
-			} else {
-				return false;
-			}
+	bool Find(string path, HTTPMetadataCacheEntry &ret_val) DUCKDB_EXCLUDES(lock) {
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		auto lookup = map.find(path);
+		if (lookup == map.end()) {
+			return false;
 		}
+		ret_val = lookup->second;
+		return true;
 	};
 
-	void Clear() {
-		if (shared) {
-			lock_guard<mutex> parallel_lock(lock);
-			map.clear();
-		} else {
-			map.clear();
-		}
+	void Clear() DUCKDB_EXCLUDES(lock) {
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		map.clear();
 	}
 
 	//! Called by the ClientContext when the current query ends
@@ -85,10 +61,9 @@ public:
 	}
 
 protected:
-	mutex lock;
-	unordered_map<string, HTTPMetadataCacheEntry> map;
+	annotated_mutex lock;
+	unordered_map<string, HTTPMetadataCacheEntry> map DUCKDB_GUARDED_BY(lock);
 	bool flush_on_query_end;
-	bool shared;
 };
 
 } // namespace duckdb

--- a/src/include/http_request_session.hpp
+++ b/src/include/http_request_session.hpp
@@ -12,33 +12,6 @@ class HTTPRequestSession;
 class HTTPState;
 class Logger;
 
-struct HTTPTransportSnapshot {
-	explicit HTTPTransportSnapshot(const HTTPFSParams &params);
-
-	reference<HTTPUtil> http_util;
-	optional_ptr<HTTPFSUtil> httpfs_util;
-	uint64_t timeout;
-	uint64_t timeout_usec;
-	uint64_t retries;
-	uint64_t retry_wait_ms;
-	float retry_backoff;
-	bool keep_alive;
-	bool follow_location;
-	bool override_verify_ssl;
-	bool verify_ssl;
-	string http_proxy;
-	idx_t http_proxy_port;
-	string http_proxy_username;
-	string http_proxy_password;
-	bool enable_server_cert_verification;
-	bool enable_curl_server_cert_verification;
-	string ca_cert_file;
-	string bearer_token;
-	HTTPClientReuseMode client_reuse;
-
-	bool ClientCompatibleWith(const HTTPTransportSnapshot &other) const;
-};
-
 enum class HTTPRequestSnapshotType : uint8_t { HTTP, S3 };
 
 struct HTTPRequestSnapshot {
@@ -49,21 +22,13 @@ struct HTTPRequestSnapshot {
 	virtual ~HTTPRequestSnapshot();
 
 	const HTTPRequestSnapshotType type;
-	HTTPTransportSnapshot transport;
-	string user_agent;
-	unordered_map<string, string> extra_headers;
-	shared_ptr<HTTPState> state;
-	shared_ptr<Logger> logger;
-	bool force_download;
-	bool auto_fallback_to_full_download;
-	bool unsafe_disable_etag_checks;
-	bool s3_version_id_pinning;
-	idx_t force_download_threshold;
-	idx_t hf_max_per_page;
 
-	virtual bool ClientCompatibleWith(const HTTPRequestSnapshot &other) const;
+	bool CanReuseClientsWith(const HTTPRequestSnapshot &other) const;
 	unique_ptr<HTTPFSParams> CreateRequestParams() const;
 	void AddConfiguredHeaders(HTTPHeaders &headers) const;
+	const HTTPFSParams &Params() const {
+		return params;
+	}
 
 	template <class TARGET>
 	TARGET &Cast() {
@@ -80,11 +45,19 @@ struct HTTPRequestSnapshot {
 		}
 		return reinterpret_cast<const TARGET &>(*this);
 	}
+
+private:
+	const HTTPFSParams params;
 };
 
 struct CapturedHTTPRequestSnapshot {
 	shared_ptr<const HTTPRequestSnapshot> snapshot;
 	idx_t client_generation;
+};
+
+struct HTTPRequestSnapshotPublication {
+	CapturedHTTPRequestSnapshot current;
+	bool published;
 };
 
 class HTTPClientLease {
@@ -125,8 +98,8 @@ public:
 	~HTTPRequestSession();
 
 	CapturedHTTPRequestSnapshot Capture() const DUCKDB_EXCLUDES(lock);
-	CapturedHTTPRequestSnapshot Publish(const CapturedHTTPRequestSnapshot &failed,
-	                                    shared_ptr<const HTTPRequestSnapshot> replacement) DUCKDB_EXCLUDES(lock);
+	HTTPRequestSnapshotPublication TryPublish(const shared_ptr<const HTTPRequestSnapshot> &expected,
+	                                          shared_ptr<const HTTPRequestSnapshot> replacement) DUCKDB_EXCLUDES(lock);
 	HTTPClientLease AcquireClient(const CapturedHTTPRequestSnapshot &captured, HTTPFSParams &request_params,
 	                              const string &proto_host_port) DUCKDB_EXCLUDES(lock);
 	void InvalidateClients() DUCKDB_EXCLUDES(lock);

--- a/src/include/http_request_session.hpp
+++ b/src/include/http_request_session.hpp
@@ -1,0 +1,154 @@
+#pragma once
+
+#include "duckdb/common/helper.hpp"
+#include "duckdb/common/http_util.hpp"
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/common/shared_ptr.hpp"
+#include "httpfs_client.hpp"
+
+namespace duckdb {
+
+class HTTPRequestSession;
+class HTTPState;
+class Logger;
+
+struct HTTPTransportSnapshot {
+	explicit HTTPTransportSnapshot(const HTTPFSParams &params);
+
+	reference<HTTPUtil> http_util;
+	optional_ptr<HTTPFSUtil> httpfs_util;
+	uint64_t timeout;
+	uint64_t timeout_usec;
+	uint64_t retries;
+	uint64_t retry_wait_ms;
+	float retry_backoff;
+	bool keep_alive;
+	bool follow_location;
+	bool override_verify_ssl;
+	bool verify_ssl;
+	string http_proxy;
+	idx_t http_proxy_port;
+	string http_proxy_username;
+	string http_proxy_password;
+	bool enable_server_cert_verification;
+	bool enable_curl_server_cert_verification;
+	string ca_cert_file;
+	string bearer_token;
+	HTTPClientReuseMode client_reuse;
+
+	bool ClientCompatibleWith(const HTTPTransportSnapshot &other) const;
+};
+
+enum class HTTPRequestSnapshotType : uint8_t { HTTP, S3 };
+
+struct HTTPRequestSnapshot {
+	static constexpr HTTPRequestSnapshotType TYPE = HTTPRequestSnapshotType::HTTP;
+
+	explicit HTTPRequestSnapshot(const HTTPFSParams &params,
+	                             HTTPRequestSnapshotType type_p = HTTPRequestSnapshotType::HTTP);
+	virtual ~HTTPRequestSnapshot();
+
+	const HTTPRequestSnapshotType type;
+	HTTPTransportSnapshot transport;
+	string user_agent;
+	unordered_map<string, string> extra_headers;
+	shared_ptr<HTTPState> state;
+	shared_ptr<Logger> logger;
+	bool force_download;
+	bool auto_fallback_to_full_download;
+	bool unsafe_disable_etag_checks;
+	bool s3_version_id_pinning;
+	idx_t force_download_threshold;
+	idx_t hf_max_per_page;
+
+	virtual bool ClientCompatibleWith(const HTTPRequestSnapshot &other) const;
+	unique_ptr<HTTPFSParams> CreateRequestParams() const;
+	void AddConfiguredHeaders(HTTPHeaders &headers) const;
+
+	template <class TARGET>
+	TARGET &Cast() {
+		if (type != TARGET::TYPE) {
+			throw InternalException("Failed to cast HTTP request snapshot - snapshot type mismatch");
+		}
+		return reinterpret_cast<TARGET &>(*this);
+	}
+
+	template <class TARGET>
+	const TARGET &Cast() const {
+		if (type != TARGET::TYPE) {
+			throw InternalException("Failed to cast HTTP request snapshot - snapshot type mismatch");
+		}
+		return reinterpret_cast<const TARGET &>(*this);
+	}
+};
+
+struct CapturedHTTPRequestSnapshot {
+	shared_ptr<const HTTPRequestSnapshot> snapshot;
+	idx_t client_generation;
+};
+
+class HTTPClientLease {
+	friend class HTTPRequestSession;
+
+public:
+	HTTPClientLease(HTTPClientLease &&other) noexcept;
+	HTTPClientLease &operator=(HTTPClientLease &&other) noexcept;
+	HTTPClientLease(const HTTPClientLease &) = delete;
+	HTTPClientLease &operator=(const HTTPClientLease &) = delete;
+	~HTTPClientLease() noexcept;
+
+	unique_ptr<HTTPClient> &Client() {
+		return client;
+	}
+	void Invalidate() {
+		reusable = false;
+	}
+
+private:
+	HTTPClientLease(shared_ptr<HTTPRequestSession> session_p, reference<HTTPUtil> http_util_p,
+	                HTTPClientReuseMode reuse_mode_p, idx_t generation_p, unique_ptr<HTTPClient> client_p);
+	void Release() noexcept;
+
+	shared_ptr<HTTPRequestSession> session;
+	reference<HTTPUtil> http_util;
+	HTTPClientReuseMode reuse_mode;
+	idx_t generation;
+	unique_ptr<HTTPClient> client;
+	bool reusable;
+};
+
+class HTTPRequestSession : public enable_shared_from_this<HTTPRequestSession> {
+	friend class HTTPClientLease;
+
+public:
+	explicit HTTPRequestSession(shared_ptr<const HTTPRequestSnapshot> snapshot_p);
+	~HTTPRequestSession();
+
+	CapturedHTTPRequestSnapshot Capture() const DUCKDB_EXCLUDES(lock);
+	CapturedHTTPRequestSnapshot Publish(const CapturedHTTPRequestSnapshot &failed,
+	                                    shared_ptr<const HTTPRequestSnapshot> replacement) DUCKDB_EXCLUDES(lock);
+	HTTPClientLease AcquireClient(const CapturedHTTPRequestSnapshot &captured, HTTPFSParams &request_params,
+	                              const string &proto_host_port) DUCKDB_EXCLUDES(lock);
+	void InvalidateClients() DUCKDB_EXCLUDES(lock);
+
+private:
+	struct IdleClient {
+		IdleClient(unique_ptr<HTTPClient> client_p, reference<HTTPUtil> http_util_p)
+		    : client(std::move(client_p)), http_util(http_util_p) {
+		}
+
+		unique_ptr<HTTPClient> client;
+		reference<HTTPUtil> http_util;
+	};
+
+	void ReturnClient(unique_ptr<HTTPClient> client, reference<HTTPUtil> http_util, HTTPClientReuseMode reuse_mode,
+	                  idx_t generation, bool reusable) noexcept DUCKDB_EXCLUDES(lock);
+	static void CloseClients(vector<IdleClient> clients) noexcept;
+
+	mutable annotated_mutex lock;
+	shared_ptr<const HTTPRequestSnapshot> current_snapshot DUCKDB_GUARDED_BY(lock);
+	idx_t client_generation DUCKDB_GUARDED_BY(lock) = 0;
+	vector<IdleClient> idle_clients DUCKDB_GUARDED_BY(lock);
+};
+
+} // namespace duckdb

--- a/src/include/http_state.hpp
+++ b/src/include/http_state.hpp
@@ -10,6 +10,7 @@
 #include "duckdb/main/client_context_state.hpp"
 
 #include <condition_variable>
+#include <functional>
 
 namespace duckdb {
 
@@ -238,13 +239,11 @@ public:
 		Reset();
 	}
 	void WriteProfilingInformation(std::ostream &ss) override;
-	mutex &CredentialRefreshLock() {
-		return credential_refresh_mutex;
-	}
+	bool RunCredentialRefresh(const std::function<bool()> &callback) DUCKDB_EXCLUDES(credential_refresh_mutex);
 
 private:
 	//! Serializes credential provider refreshes after auth failures.
-	mutex credential_refresh_mutex;
+	annotated_mutex credential_refresh_mutex;
 	//! Protects the per-path state map
 	annotated_mutex file_states_mutex;
 	//! Per-path state shared by all file handles in this query

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -9,6 +9,7 @@
 #include "duckdb/main/client_data.hpp"
 #include "http_metadata_cache.hpp"
 #include "httpfs_client.hpp"
+#include "http_request_session.hpp"
 
 #include <functional>
 
@@ -29,68 +30,16 @@ public:
 	}
 };
 
-class HTTPClientCache {
-public:
-	struct Entry {
-		unique_ptr<HTTPClient> client;
-		idx_t generation = 0;
-	};
-
-	//! Get a client from the client cache
-	unique_ptr<HTTPClient> GetClient();
-	//! Get a client together with the cache generation it came from
-	Entry GetClientWithGeneration();
-	//! Store a client in the cache for reuse
-	void StoreClient(unique_ptr<HTTPClient> client);
-	//! Store a generation-tagged client if the cache was not cleared while it was checked out
-	bool StoreClient(Entry &entry);
-	//! Clear the stored clients
-	void Clear();
-
-protected:
-	//! The cached clients
-	vector<unique_ptr<HTTPClient>> clients;
-	//! Incremented when the cache is cleared, invalidating checked-out clients
-	idx_t generation = 0;
-	//! Lock to fetch a client
-	mutex lock;
-};
-
-class HTTPInput {
-public:
-	HTTPInput(unique_ptr<HTTPParams> params_p);
-	virtual ~HTTPInput() = default;
-
-	unique_ptr<HTTPParams> params;
-	HTTPFSParams &http_params;
-
-	template <class TARGET>
-	TARGET &Cast() {
-		DynamicCastCheck<TARGET>(this);
-		return reinterpret_cast<TARGET &>(*this);
-	}
-	template <class TARGET>
-	const TARGET &Cast() const {
-		DynamicCastCheck<TARGET>(this);
-		return reinterpret_cast<const TARGET &>(*this);
-	}
-};
-
 class HTTPFileSystem;
 
 class HTTPFileHandle : public FileHandle {
 public:
 	HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags, unique_ptr<HTTPParams> params);
-	HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags, shared_ptr<HTTPInput> input);
 	~HTTPFileHandle() override;
 	// This two-phase construction allows subclasses more flexible setup.
 	virtual void Initialize(optional_ptr<FileOpener> opener);
 
-	// We keep an http client stored for connection reuse with keep-alive headers
-	HTTPClientCache client_cache;
-
-	shared_ptr<HTTPInput> http_input;
-	HTTPFSParams &http_params;
+	shared_ptr<HTTPRequestSession> request_session;
 
 	// File handle info
 	FileOpenFlags flags;
@@ -126,20 +75,14 @@ public:
 	constexpr static idx_t MAXIMUM_READ_BUFFER_LEN = 33554432;
 
 	// Adaptively resizes read_buffer based on range_request_statistics
-	void AddStatistics(idx_t read_offset, idx_t read_length, idx_t read_duration);
-	void AdaptReadBufferSize(idx_t next_read_offset);
+	void AddStatistics(idx_t read_offset, idx_t read_length, idx_t read_duration) DUCKDB_EXCLUDES(throughput_lock);
+	void AdaptReadBufferSize(idx_t next_read_offset) DUCKDB_EXCLUDES(throughput_lock);
 
 	// Record a completed range request into the network throughput estimate (latency + bandwidth)
-	void RecordNetworkSample(double total_seconds, idx_t bytes, bool sample_has_ttfb, double ttfb_seconds);
+	void RecordNetworkSample(double total_seconds, idx_t bytes, bool sample_has_ttfb, double ttfb_seconds)
+	    DUCKDB_EXCLUDES(throughput_lock);
 	// Expose the measured network throughput estimate to the (parquet) prefetch cost model.
-	bool TryGetNetworkThroughput(NetworkThroughputEstimate &result);
-
-	void AddHeaders(HTTPHeaders &map);
-
-	// Get a Client to run requests over
-	unique_ptr<HTTPClient> GetClient();
-	// Return the client for re-use
-	void StoreClient(unique_ptr<HTTPClient> client);
+	bool TryGetNetworkThroughput(NetworkThroughputEstimate &result) DUCKDB_EXCLUDES(throughput_lock);
 
 	// Whether to bypass the read buffer
 	bool SkipBuffer() const {
@@ -155,14 +98,14 @@ private:
 		idx_t length;
 		idx_t duration;
 	};
-	vector<RangeRequestStatistics> range_request_statistics;
+	vector<RangeRequestStatistics> range_request_statistics DUCKDB_GUARDED_BY(throughput_lock);
 
 	// throughput_lock guards the throughput estimate (fed by RecordNetworkSample) and range_request_statistics against
 	// concurrent prefetch reads.
-	mutex throughput_lock;
-	double tp_latency_seconds = 0;
-	double tp_bandwidth_bps = 0;
-	idx_t tp_sample_count = 0;
+	mutable annotated_mutex throughput_lock;
+	double tp_latency_seconds DUCKDB_GUARDED_BY(throughput_lock) = 0;
+	double tp_bandwidth_bps DUCKDB_GUARDED_BY(throughput_lock) = 0;
+	idx_t tp_sample_count DUCKDB_GUARDED_BY(throughput_lock) = 0;
 	// Minimum payload size for a request to contribute a bandwidth sample
 	constexpr static idx_t MIN_BANDWIDTH_SAMPLE_BYTES = 1 << 16; // 64 KiB
 
@@ -171,8 +114,7 @@ public:
 	}
 
 protected:
-	//! Create a new Client
-	virtual unique_ptr<HTTPClient> CreateClient();
+	virtual shared_ptr<const HTTPRequestSnapshot> CreateRequestSnapshot(const HTTPFSParams &params) const;
 	//! Perform a HEAD request to get the file info (if not yet loaded)
 	void LoadFileInfo();
 	//! TODO: make base function virtual?
@@ -242,11 +184,6 @@ public:
 	// Get Request without a range (i.e., downloads full file)
 	virtual unique_ptr<HTTPResponse> GetRequest(FileHandle &handle, string url, HTTPHeaders header_map,
 	                                            CachedFileDownload &download);
-	// Post Request that can handle variable sized responses without a content-length header (needed for s3 multipart)
-	virtual unique_ptr<HTTPResponse> PostRequest(HTTPInput &input, string url, HTTPHeaders header_map, string &result,
-	                                             char *buffer_in, idx_t buffer_in_len, string params = "");
-	virtual unique_ptr<HTTPResponse> PutRequest(HTTPInput &input, string url, HTTPHeaders header_map, char *buffer_in,
-	                                            idx_t buffer_in_len, string params = "");
 	virtual unique_ptr<HTTPResponse> DeleteRequest(FileHandle &handle, string url, HTTPHeaders header_map);
 	//! Fully download a file, or wait for an in-progress download of the same path
 	unique_ptr<CachedFileHandle> FullDownload(HTTPFileHandle &handle, bool &should_write_cache);
@@ -290,9 +227,11 @@ protected:
 	                                            HTTPSendCallback send_request);
 
 private:
+	void EraseGlobalCacheEntry(const string &path) DUCKDB_EXCLUDES(global_cache_lock);
+
 	// Global cache
-	mutex global_cache_lock;
-	unique_ptr<HTTPMetadataCache> global_metadata_cache;
+	mutable annotated_mutex global_cache_lock;
+	unique_ptr<HTTPMetadataCache> global_metadata_cache DUCKDB_GUARDED_BY(global_cache_lock);
 };
 
 } // namespace duckdb

--- a/src/include/httpfs_client.hpp
+++ b/src/include/httpfs_client.hpp
@@ -27,6 +27,9 @@ class HTTPLogger;
 class FileOpener;
 struct FileOpenerInfo;
 class HTTPState;
+class HTTPFSUtil;
+
+enum class HTTPClientReuseMode : uint8_t { SESSION_LOCAL, SHARED, NONE };
 
 struct HTTPFSParams : public HTTPParams {
 	HTTPFSParams(HTTPUtil &http_util) : HTTPParams(http_util) {
@@ -53,6 +56,8 @@ struct HTTPFSParams : public HTTPParams {
 	string user_agent = {""};
 	bool pre_merged_headers = false;
 	idx_t force_download_threshold = 0;
+	HTTPClientReuseMode client_reuse_mode = HTTPClientReuseMode::SESSION_LOCAL;
+	optional_ptr<HTTPFSUtil> httpfs_util;
 
 	// Additional fields needs to be appended at the end and need to be propagated to duckdb-wasm
 	// TODO: make this unnecessary
@@ -70,8 +75,9 @@ public:
 
 private:
 	struct Pool {
-		mutex lock {};
-		std::vector<unique_ptr<HTTPClient>> entries {std::vector<unique_ptr<HTTPClient>>(POOL_SIZE)};
+		annotated_mutex lock {};
+		std::vector<unique_ptr<HTTPClient>> entries DUCKDB_GUARDED_BY(lock) {
+		    std::vector<unique_ptr<HTTPClient>>(POOL_SIZE)};
 	};
 
 	std::array<Pool, POOL_COUNT> pools {};
@@ -85,6 +91,7 @@ public:
 
 	//! Clear any cached connections
 	virtual void ClearCachedConnections();
+	virtual HTTPClientReuseMode GetClientReuseMode() const;
 
 	static unordered_map<string, string> ParseGetParameters(const string &text);
 	static HTTPUtil &GetHTTPUtil(optional_ptr<FileOpener> opener);
@@ -99,6 +106,7 @@ public:
 	unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
 	void CloseClient(unique_ptr<HTTPClient> &&client) override;
 	void ClearCachedConnections() override;
+	HTTPClientReuseMode GetClientReuseMode() const override;
 	unique_ptr<HTTPResponse> SendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client) override;
 
 	static unordered_map<string, string> ParseGetParameters(const string &text);

--- a/src/include/s3_multi_part_upload.hpp
+++ b/src/include/s3_multi_part_upload.hpp
@@ -55,7 +55,7 @@ public:
 	void Finalize();
 
 	S3FileSystem &s3fs;
-	shared_ptr<HTTPInput> http_input;
+	shared_ptr<HTTPRequestSession> request_session;
 	string path;
 	const S3ConfigParams config_params;
 

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -133,15 +133,14 @@ struct S3RequestSnapshot : public HTTPRequestSnapshot {
 
 	S3RequestSnapshot(const HTTPFSParams &http_params, const S3AuthParams &auth_params_p, string refresh_path_p,
 	                  weak_ptr<ClientContext> client_context_p = {}, bool credential_refresh_enabled_p = true,
-	                  bool region_redirected_p = false);
-
-	bool ClientCompatibleWith(const HTTPRequestSnapshot &other) const override;
+	                  bool region_redirected_p = false, idx_t credential_generation_p = 0);
 
 	S3AuthParams auth_params;
 	string refresh_path;
 	weak_ptr<ClientContext> client_context;
 	bool credential_refresh_enabled;
 	bool region_redirected;
+	idx_t credential_generation;
 };
 
 class S3FileSystem;

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -128,28 +128,20 @@ struct S3RefreshableHTTPParams {
 	string bearer_token;
 };
 
-class S3HTTPInput : public HTTPInput {
-	friend class S3FileHandle;
-	friend class S3FileSystem;
+struct S3RequestSnapshot : public HTTPRequestSnapshot {
+	static constexpr HTTPRequestSnapshotType TYPE = HTTPRequestSnapshotType::S3;
 
-public:
-	S3HTTPInput(unique_ptr<HTTPParams> params, const S3AuthParams &auth_params_p,
-	            const S3ConfigParams &config_params_p);
-	~S3HTTPInput() override;
+	S3RequestSnapshot(const HTTPFSParams &http_params, const S3AuthParams &auth_params_p, string refresh_path_p,
+	                  weak_ptr<ClientContext> client_context_p = {}, bool credential_refresh_enabled_p = true,
+	                  bool region_redirected_p = false);
+
+	bool ClientCompatibleWith(const HTTPRequestSnapshot &other) const override;
 
 	S3AuthParams auth_params;
-	S3ConfigParams config_params;
-
-private:
-	//! Credential refresh helpers used by S3 write/multipart request retries.
-	mutex mu;
+	string refresh_path;
 	weak_ptr<ClientContext> client_context;
-	bool region_redirected = false;
-	bool credential_refresh_enabled = true;
-
-	bool TryRefreshAuthParams(const string &path, S3AuthParams request_auth_params,
-	                          S3RefreshableHTTPParams request_http_params);
-	void SetRegion(string region_p);
+	bool credential_refresh_enabled;
+	bool region_redirected;
 };
 
 class S3FileSystem;
@@ -164,8 +156,7 @@ public:
 	             const S3AuthParams &auth_params_p, const S3ConfigParams &config_params_p);
 	~S3FileHandle() override;
 
-	S3AuthParams &auth_params;
-	const S3ConfigParams &config_params;
+	const S3ConfigParams config_params;
 	shared_ptr<S3MultiPartUpload> multi_part_upload;
 
 	void Close() override;
@@ -173,18 +164,12 @@ public:
 	void FinalizeUpload();
 
 protected:
+	shared_ptr<const HTTPRequestSnapshot> CreateRequestSnapshot(const HTTPFSParams &params) const override;
 	void InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cache_entry) override;
 	HTTPMetadataCacheEntry GetCacheEntry() const override;
-	unique_ptr<HTTPClient> CreateClient() override;
 
 private:
-	//! Credential refresh helpers used by S3 read request retries.
-	bool TryRefreshAuthParams(S3AuthParams request_auth_params, S3RefreshableHTTPParams request_http_params);
 	void SetRegion(string region_p);
-
-	weak_ptr<ClientContext> client_context;
-	bool region_redirected = false;
-	bool credential_refresh_enabled = true;
 };
 
 class S3FileSystem : public HTTPFileSystem {
@@ -217,10 +202,10 @@ public:
 	                                    CachedFileDownload &download) override;
 	unique_ptr<HTTPResponse> GetRangeRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
 	                                         idx_t file_offset, char *buffer_out, idx_t buffer_out_len) override;
-	unique_ptr<HTTPResponse> PostRequest(HTTPInput &input, string s3_url, HTTPHeaders header_map, string &buffer_out,
-	                                     char *buffer_in, idx_t buffer_in_len, string http_params = "") override;
-	unique_ptr<HTTPResponse> PutRequest(HTTPInput &input, string s3_url, HTTPHeaders header_map, char *buffer_in,
-	                                    idx_t buffer_in_len, string http_params = "") override;
+	unique_ptr<HTTPResponse> PostRequest(HTTPRequestSession &session, string s3_url, string &buffer_out,
+	                                     char *buffer_in, idx_t buffer_in_len, string http_params = "");
+	unique_ptr<HTTPResponse> PutRequest(HTTPRequestSession &session, string s3_url, char *buffer_in,
+	                                    idx_t buffer_in_len, string http_params = "");
 	unique_ptr<HTTPResponse> DeleteRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map) override;
 	HTTPException GetHTTPError(FileHandle &, const HTTPResponse &response, const string &url) override;
 
@@ -261,21 +246,23 @@ protected:
 private:
 	//! Request retry wrappers that refresh credentials and rebuild signed S3 requests.
 	template <class REQUEST>
-	unique_ptr<HTTPResponse> RunS3InputRequestWithAuthRefresh(S3HTTPInput &s3_input, const string &s3_url,
-	                                                          const string &method, const string &query_string,
-	                                                          const string &payload_hash, const string &content_type,
-	                                                          REQUEST request);
+	unique_ptr<HTTPResponse> RunS3SessionRequestWithAuthRefresh(HTTPRequestSession &session, const string &s3_url,
+	                                                            const string &method, const string &query_string,
+	                                                            const string &payload_hash, const string &content_type,
+	                                                            const string &content_md5, REQUEST request);
 	template <class REQUEST>
 	unique_ptr<HTTPResponse> RunS3HandleRequestWithAuthRefresh(S3FileHandle &s3_handle, const string &s3_url,
 	                                                           const string &method, bool use_version_id,
 	                                                           REQUEST request);
+	unique_ptr<HTTPResponse> RunS3BulkDeleteRequest(HTTPRequestSession &session, const string &secret_lookup_url,
+	                                                const string &body, string &result);
 };
 
 // Helper class to do s3 ListObjectV2 api call https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
 struct AWSListObjectV2 {
-	static string Request(EncryptionUtil &encryption_util, const string &path, HTTPParams &http_params,
-	                      S3AuthParams &s3_auth_params, string &continuation_token, bool use_delimiter = false,
-	                      optional_idx max_keys = optional_idx(), optional_ptr<FileOpener> opener = nullptr);
+	static string Request(EncryptionUtil &encryption_util, HTTPRequestSession &session, const string &path,
+	                      const string &continuation_token, bool use_delimiter = false,
+	                      optional_idx max_keys = optional_idx());
 	static void ParseFileList(string &aws_response, vector<OpenFileInfo> &result);
 	static vector<string> ParseCommonPrefix(string &aws_response);
 	static string ParseContinuationToken(string &aws_response);

--- a/src/s3_multi_part_upload.cpp
+++ b/src/s3_multi_part_upload.cpp
@@ -7,7 +7,7 @@
 namespace duckdb {
 
 S3MultiPartUpload::S3MultiPartUpload(S3FileHandle &s3_file_handle)
-    : s3fs(s3_file_handle.file_system.Cast<S3FileSystem>()), http_input(s3_file_handle.http_input),
+    : s3fs(s3_file_handle.file_system.Cast<S3FileSystem>()), request_session(s3_file_handle.request_session),
       path(s3_file_handle.path), config_params(s3_file_handle.config_params), uploads_in_progress(0), parts_uploaded(0),
       upload_finalized(false) {
 }
@@ -58,7 +58,7 @@ string S3MultiPartUpload::InitializeMultipartUpload() {
 	// AWS response is around 300~ chars in docs so this should be enough to not need a resize
 	string result;
 	string query_param = "uploads=";
-	auto res = s3fs.PostRequest(*http_input, path, {}, result, nullptr, 0, query_param);
+	auto res = s3fs.PostRequest(*request_session, path, result, nullptr, 0, query_param);
 
 	if (res->status != HTTPStatusCode::OK_200) {
 		throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)", path, res->GetError(),
@@ -104,7 +104,7 @@ void S3MultiPartUpload::FinalizeMultipartUpload() {
 	string result;
 
 	string query_param = "uploadId=" + S3FileSystem::UrlEncode(multipart_upload_id, true);
-	auto res = s3fs.PostRequest(*http_input, path, {}, result, (char *)body.c_str(), body.length(), query_param);
+	auto res = s3fs.PostRequest(*request_session, path, result, (char *)body.c_str(), body.length(), query_param);
 	auto open_tag_pos = result.find("<CompleteMultipartUploadResult", 0);
 	if (open_tag_pos == string::npos) {
 		throw HTTPException(*res, "Unexpected response during S3 multipart upload finalization: %d\n\n%s",
@@ -132,7 +132,7 @@ void S3MultiPartUpload::UploadBufferImplementation(shared_ptr<S3WriteBuffer> wri
 
 	try {
 		// Transient S3 errors are retried inside PutRequest; a non-OK status here is already final.
-		res = s3fs.PutRequest(*http_input, path, {}, (char *)write_buffer->Ptr(), write_buffer->idx, query_param);
+		res = s3fs.PutRequest(*request_session, path, (char *)write_buffer->Ptr(), write_buffer->idx, query_param);
 
 		if (res->status != HTTPStatusCode::OK_200) {
 			throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)%s", path, res->GetError(),
@@ -246,8 +246,9 @@ void S3MultiPartUpload::FlushAllBuffers() {
 	if (!initialized_multipart_upload) {
 		// TODO (carlo): unclear how to handle kms_key_id, but given currently they are custom, leave the multiupload
 		// codepath in that case
-		auto &s3_input = http_input->Cast<S3HTTPInput>();
-		if (to_flush.size() == 1 && s3_input.auth_params.kms_key_id.empty()) {
+		auto captured = request_session->Capture();
+		auto &snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
+		if (to_flush.size() == 1 && snapshot.auth_params.kms_key_id.empty()) {
 			UploadSingleBuffer(to_flush[0]);
 			upload_finalized = true;
 			return;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -150,17 +150,38 @@ static bool IsGCSRequest(const string &url) {
 	return StringUtil::StartsWith(url, "gcs://") || StringUtil::StartsWith(url, "gs://");
 }
 
+// Defined later in this file.
+optional_idx TryFindTagContents(const string &response, const string &tag, idx_t cur_pos, string &result);
+
+static bool IsAuthRefreshErrorBody(const string &body) {
+	string code;
+	if (!TryFindTagContents(body, "Code", 0, code).IsValid()) {
+		return false;
+	}
+	return code == "ExpiredToken" || code == "InvalidToken" || code == "TokenRefreshRequired";
+}
+
 static bool IsAuthRefreshStatus(const ErrorData &error) {
 	auto &extra_info = error.ExtraInfo();
 	auto entry = extra_info.find("status_code");
 	if (entry == extra_info.end()) {
 		return false;
 	}
-	return entry->second == "401" || entry->second == "403";
+	if (entry->second == "401" || entry->second == "403") {
+		return true;
+	}
+	if (entry->second != "400") {
+		return false;
+	}
+	auto body_entry = extra_info.find("response_body");
+	return body_entry != extra_info.end() && IsAuthRefreshErrorBody(body_entry->second);
 }
 
 static bool IsAuthRefreshStatus(const HTTPResponse &response) {
-	return response.status == HTTPStatusCode::Unauthorized_401 || response.status == HTTPStatusCode::Forbidden_403;
+	if (response.status == HTTPStatusCode::Unauthorized_401 || response.status == HTTPStatusCode::Forbidden_403) {
+		return true;
+	}
+	return response.status == HTTPStatusCode::BadRequest_400 && IsAuthRefreshErrorBody(response.body);
 }
 
 static bool S3AuthParamsMatch(const S3AuthParams &left, const S3AuthParams &right) {
@@ -241,8 +262,7 @@ static bool IsS3CredentialRefreshEnabled(optional_ptr<FileOpener> opener) {
 }
 
 static bool ReloadS3AuthMaterial(optional_ptr<FileOpener> opener, const string &path, S3AuthParams &auth_params,
-                                 HTTPFSParams &http_params, const S3AuthParams &request_auth_params,
-                                 const S3RefreshableHTTPParams &request_http_params, bool preserve_region) {
+                                 HTTPFSParams &http_params, bool preserve_region) {
 	if (!opener) {
 		return false;
 	}
@@ -254,8 +274,8 @@ static bool ReloadS3AuthMaterial(optional_ptr<FileOpener> opener, const string &
 	}
 	auto reloaded_http_params = ReadRefreshableHTTPParams(opener, path);
 
-	if (S3AuthParamsMatch(reloaded_auth_params, request_auth_params) &&
-	    S3RefreshableHTTPParamsMatch(reloaded_http_params, request_http_params)) {
+	if (S3AuthParamsMatch(reloaded_auth_params, auth_params) &&
+	    S3RefreshableHTTPParamsMatch(reloaded_http_params, SnapshotRefreshableHTTPParams(http_params))) {
 		return false;
 	}
 
@@ -266,41 +286,31 @@ static bool ReloadS3AuthMaterial(optional_ptr<FileOpener> opener, const string &
 
 static bool TryRefreshS3AuthMaterial(optional_ptr<ClientContext> context, optional_ptr<FileOpener> opener,
                                      const string &path, S3AuthParams &auth_params, HTTPFSParams &http_params,
-                                     const S3AuthParams &request_auth_params,
-                                     const S3RefreshableHTTPParams &request_http_params,
                                      bool credential_refresh_enabled, bool preserve_region = false) {
 	if (!credential_refresh_enabled) {
 		return false;
 	}
-	if (!S3AuthParamsMatch(auth_params, request_auth_params) ||
-	    !S3RefreshableHTTPParamsMatch(SnapshotRefreshableHTTPParams(http_params), request_http_params)) {
-		return true;
-	}
 	if (!context) {
 		return false;
 	}
-	if (ReloadS3AuthMaterial(opener, path, auth_params, http_params, request_auth_params, request_http_params,
-	                         preserve_region)) {
+	if (ReloadS3AuthMaterial(opener, path, auth_params, http_params, preserve_region)) {
 		return true;
 	}
 
 	auto http_state = HTTPState::TryGetState(*context);
 	return http_state->RunCredentialRefresh([&]() {
-		if (ReloadS3AuthMaterial(opener, path, auth_params, http_params, request_auth_params, request_http_params,
-		                         preserve_region)) {
+		if (ReloadS3AuthMaterial(opener, path, auth_params, http_params, preserve_region)) {
 			return true;
 		}
 		if (!TryRefreshS3SecretForPath(*context, path)) {
 			return false;
 		}
-		return ReloadS3AuthMaterial(opener, path, auth_params, http_params, request_auth_params, request_http_params,
-		                            preserve_region);
+		return ReloadS3AuthMaterial(opener, path, auth_params, http_params, preserve_region);
 	});
 }
 
 struct S3RequestData {
 	S3AuthParams auth_params;
-	S3RefreshableHTTPParams refreshable_http_params;
 	unique_ptr<HTTPParams> http_params;
 	CapturedHTTPRequestSnapshot captured;
 	string source_url;
@@ -320,8 +330,6 @@ static S3RequestData CreateS3RequestData(EncryptionUtil &encryption_util, const 
 	result.auth_params = snapshot.auth_params;
 	result.http_params = snapshot.CreateRequestParams();
 	result.source_url = s3_url;
-	auto &httpfs_params = result.http_params->Cast<HTTPFSParams>();
-	result.refreshable_http_params = SnapshotRefreshableHTTPParams(httpfs_params);
 	auto parsed_s3_url = S3FileSystem::S3UrlParse(s3_url, result.auth_params);
 
 	result.http_url = parsed_s3_url.GetHTTPUrl(result.auth_params, query_string);
@@ -392,9 +400,6 @@ static optional_idx GetRegionRedirect(const ErrorData &error, const S3AuthParams
 	region_out = new_region->second;
 	return optional_idx(0);
 }
-
-// Defined later in this file.
-optional_idx TryFindTagContents(const string &response, const string &tag, idx_t cur_pos, string &result);
 
 // Core's status-based retry can't catch this: the discriminator is only in the S3 error body.
 bool IsS3RequestTimeout(const HTTPResponse &response) {
@@ -487,41 +492,72 @@ RunS3RequestWithAuthRefreshInternal(const string &s3_url, CREATE_DATA create_dat
 
 static bool TryRefreshS3Session(HTTPRequestSession &session, const S3RequestData &request_data) {
 	auto current = session.Capture();
-	if (current.snapshot != request_data.captured.snapshot) {
+	auto &failed_snapshot = request_data.captured.snapshot->Cast<S3RequestSnapshot>();
+	auto &current_snapshot = current.snapshot->Cast<S3RequestSnapshot>();
+	if (current_snapshot.credential_generation != failed_snapshot.credential_generation) {
 		return true;
 	}
-	auto &failed_snapshot = request_data.captured.snapshot->Cast<S3RequestSnapshot>();
-	if (!failed_snapshot.credential_refresh_enabled) {
+	if (!current_snapshot.credential_refresh_enabled) {
 		return false;
 	}
 
-	auto context = failed_snapshot.client_context.lock();
+	auto context = current_snapshot.client_context.lock();
 	if (!context) {
 		return false;
 	}
 	ClientContextFileOpener opener(*context);
-	auto auth_params = failed_snapshot.auth_params;
-	auto http_params = failed_snapshot.CreateRequestParams();
-	if (!TryRefreshS3AuthMaterial(context.get(), opener, failed_snapshot.refresh_path, auth_params, *http_params,
-	                              request_data.auth_params, request_data.refreshable_http_params,
-	                              failed_snapshot.credential_refresh_enabled, failed_snapshot.region_redirected)) {
-		return session.Capture().snapshot != request_data.captured.snapshot;
+	auto refreshed_auth_params = current_snapshot.auth_params;
+	auto refreshed_http_params = current_snapshot.CreateRequestParams();
+	if (!TryRefreshS3AuthMaterial(context.get(), opener, current_snapshot.refresh_path, refreshed_auth_params,
+	                              *refreshed_http_params, current_snapshot.credential_refresh_enabled,
+	                              current_snapshot.region_redirected)) {
+		return session.Capture().snapshot->Cast<S3RequestSnapshot>().credential_generation !=
+		       failed_snapshot.credential_generation;
 	}
-	auto replacement = make_shared_ptr<S3RequestSnapshot>(
-	    *http_params, auth_params, failed_snapshot.refresh_path, failed_snapshot.client_context,
-	    failed_snapshot.credential_refresh_enabled, failed_snapshot.region_redirected);
-	return session.Publish(request_data.captured, std::move(replacement)).snapshot != request_data.captured.snapshot;
+	auto refreshed_http_material = SnapshotRefreshableHTTPParams(*refreshed_http_params);
+	for (;;) {
+		current = session.Capture();
+		auto &latest = current.snapshot->Cast<S3RequestSnapshot>();
+		if (latest.credential_generation != failed_snapshot.credential_generation) {
+			return true;
+		}
+
+		auto merged_auth_params = refreshed_auth_params;
+		if (latest.region_redirected) {
+			merged_auth_params.SetRegion(latest.auth_params.region);
+		}
+		auto merged_http_params = latest.CreateRequestParams();
+		ApplyRefreshableHTTPParams(*merged_http_params, refreshed_http_material);
+		auto replacement = make_shared_ptr<S3RequestSnapshot>(
+		    *merged_http_params, merged_auth_params, latest.refresh_path, latest.client_context,
+		    latest.credential_refresh_enabled, latest.region_redirected, latest.credential_generation + 1);
+		auto publication = session.TryPublish(current.snapshot, std::move(replacement));
+		if (publication.published) {
+			return true;
+		}
+	}
 }
 
-static void SetS3SessionRegion(HTTPRequestSession &session, const S3RequestData &request_data, string correct_region) {
-	auto &failed_snapshot = request_data.captured.snapshot->Cast<S3RequestSnapshot>();
-	auto auth_params = failed_snapshot.auth_params;
-	auth_params.SetRegion(std::move(correct_region));
-	auto http_params = failed_snapshot.CreateRequestParams();
-	auto replacement = make_shared_ptr<S3RequestSnapshot>(*http_params, auth_params, failed_snapshot.refresh_path,
-	                                                      failed_snapshot.client_context,
-	                                                      failed_snapshot.credential_refresh_enabled, true);
-	session.Publish(request_data.captured, std::move(replacement));
+static bool SetS3SessionRegion(HTTPRequestSession &session, const string &correct_region, string &previous_region) {
+	for (;;) {
+		auto current = session.Capture();
+		auto &snapshot = current.snapshot->Cast<S3RequestSnapshot>();
+		if (snapshot.auth_params.region == correct_region) {
+			return false;
+		}
+
+		auto auth_params = snapshot.auth_params;
+		previous_region = auth_params.region;
+		auth_params.SetRegion(correct_region);
+		auto http_params = snapshot.CreateRequestParams();
+		auto replacement = make_shared_ptr<S3RequestSnapshot>(
+		    *http_params, auth_params, snapshot.refresh_path, snapshot.client_context,
+		    snapshot.credential_refresh_enabled, true, snapshot.credential_generation);
+		auto publication = session.TryPublish(current.snapshot, std::move(replacement));
+		if (publication.published) {
+			return true;
+		}
+	}
 }
 
 template <class REQUEST>
@@ -537,7 +573,8 @@ unique_ptr<HTTPResponse> S3FileSystem::RunS3SessionRequestWithAuthRefresh(
 	    IsTransientRetryEligibleMethod(method), request,
 	    [&](const S3RequestData &request_data) { return TryRefreshS3Session(session, request_data); },
 	    [&](const S3RequestData &request_data, string correct_region) {
-		    SetS3SessionRegion(session, request_data, std::move(correct_region));
+		    string previous_region;
+		    SetS3SessionRegion(session, correct_region, previous_region);
 	    });
 }
 
@@ -553,7 +590,15 @@ unique_ptr<HTTPResponse> S3FileSystem::RunS3HandleRequestWithAuthRefresh(S3FileH
 		    return TryRefreshS3Session(*s3_handle.request_session, request_data);
 	    },
 	    [&](const S3RequestData &request_data, string correct_region) {
-		    SetS3SessionRegion(*s3_handle.request_session, request_data, std::move(correct_region));
+		    string previous_region;
+		    if (SetS3SessionRegion(*s3_handle.request_session, correct_region, previous_region)) {
+			    auto &params = request_data.http_params->Cast<HTTPFSParams>();
+			    DUCKDB_LOG_WARNING(
+			        params.logger,
+			        "Read S3 file \"%s\" from incorrect region \"%s\" - retrying with updated region \"%s\".\n"
+			        "Consider setting the S3 region to this explicitly to avoid extra round-trips.",
+			        s3_url, previous_region, correct_region);
+		    }
 	    });
 }
 
@@ -739,20 +784,11 @@ unique_ptr<KeyValueSecret> CreateSecret(vector<string> &prefix_paths_p, string &
 
 S3RequestSnapshot::S3RequestSnapshot(const HTTPFSParams &http_params, const S3AuthParams &auth_params_p,
                                      string refresh_path_p, weak_ptr<ClientContext> client_context_p,
-                                     bool credential_refresh_enabled_p, bool region_redirected_p)
+                                     bool credential_refresh_enabled_p, bool region_redirected_p,
+                                     idx_t credential_generation_p)
     : HTTPRequestSnapshot(http_params, TYPE), auth_params(auth_params_p), refresh_path(std::move(refresh_path_p)),
       client_context(std::move(client_context_p)), credential_refresh_enabled(credential_refresh_enabled_p),
-      region_redirected(region_redirected_p) {
-}
-
-bool S3RequestSnapshot::ClientCompatibleWith(const HTTPRequestSnapshot &other) const {
-	if (other.type != TYPE || !HTTPRequestSnapshot::ClientCompatibleWith(other)) {
-		return false;
-	}
-	auto &s3_other = other.Cast<S3RequestSnapshot>();
-	return auth_params.endpoint == s3_other.auth_params.endpoint &&
-	       auth_params.use_ssl == s3_other.auth_params.use_ssl &&
-	       auth_params.url_style == s3_other.auth_params.url_style;
+      region_redirected(region_redirected_p), credential_generation(credential_generation_p) {
 }
 
 S3FileHandle::S3FileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags,
@@ -761,7 +797,8 @@ S3FileHandle::S3FileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFla
     : HTTPFileHandle(fs, file, flags, std::move(http_params_p)), config_params(config_params_p) {
 	auto captured = request_session->Capture();
 	auto request_params = captured.snapshot->CreateRequestParams();
-	request_session->Publish(captured, make_shared_ptr<S3RequestSnapshot>(*request_params, auth_params_p, file.path));
+	request_session->TryPublish(captured.snapshot,
+	                            make_shared_ptr<S3RequestSnapshot>(*request_params, auth_params_p, file.path));
 	auto_fallback_to_full_file_download = false;
 	if (flags.OpenForReading() && flags.OpenForWriting()) {
 		throw NotImplementedException("Cannot open an HTTP file for both reading and writing");
@@ -784,7 +821,7 @@ shared_ptr<const HTTPRequestSnapshot> S3FileHandle::CreateRequestSnapshot(const 
 	auto &s3_snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
 	return make_shared_ptr<S3RequestSnapshot>(params, s3_snapshot.auth_params, s3_snapshot.refresh_path,
 	                                          s3_snapshot.client_context, s3_snapshot.credential_refresh_enabled,
-	                                          s3_snapshot.region_redirected);
+	                                          s3_snapshot.region_redirected, s3_snapshot.credential_generation);
 }
 
 S3FileHandle::~S3FileHandle() {
@@ -800,11 +837,8 @@ S3FileHandle::~S3FileHandle() {
 }
 
 void S3FileHandle::SetRegion(string region_p) {
-	auto captured = request_session->Capture();
-	S3RequestData request_data;
-	request_data.captured = captured;
-	request_data.auth_params = captured.snapshot->Cast<S3RequestSnapshot>().auth_params;
-	SetS3SessionRegion(*request_session, request_data, std::move(region_p));
+	string previous_region;
+	SetS3SessionRegion(*request_session, region_p, previous_region);
 }
 
 S3ConfigParams S3ConfigParams::ReadFrom(optional_ptr<FileOpener> opener) {
@@ -1142,9 +1176,10 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 		if (context && refresh_enabled) {
 			weak_context = context->shared_from_this();
 		}
-		request_session->Publish(captured, make_shared_ptr<S3RequestSnapshot>(
-		                                       *request_params, snapshot.auth_params, snapshot.refresh_path,
-		                                       std::move(weak_context), refresh_enabled, snapshot.region_redirected));
+		request_session->TryPublish(captured.snapshot, make_shared_ptr<S3RequestSnapshot>(
+		                                                   *request_params, snapshot.auth_params, snapshot.refresh_path,
+		                                                   std::move(weak_context), refresh_enabled,
+		                                                   snapshot.region_redirected, snapshot.credential_generation));
 	}
 	HTTPFileHandle::Initialize(opener);
 
@@ -1388,7 +1423,6 @@ static S3RequestData CreateS3BulkDeleteRequestData(EncryptionUtil &encryption_ut
 	result.auth_params = snapshot.auth_params;
 	result.http_params = snapshot.CreateRequestParams();
 	result.source_url = secret_lookup_url;
-	result.refreshable_http_params = SnapshotRefreshableHTTPParams(result.http_params->Cast<HTTPFSParams>());
 
 	auto request_url = S3FileSystem::S3UrlParse(secret_lookup_url, result.auth_params);
 	auto request_path = GetS3BucketPath(request_url);
@@ -1421,7 +1455,8 @@ unique_ptr<HTTPResponse> S3FileSystem::RunS3BulkDeleteRequest(HTTPRequestSession
 	    },
 	    [&](const S3RequestData &request_data) { return TryRefreshS3Session(session, request_data); },
 	    [&](const S3RequestData &request_data, string correct_region) {
-		    SetS3SessionRegion(session, request_data, std::move(correct_region));
+		    string previous_region;
+		    SetS3SessionRegion(session, correct_region, previous_region);
 	    });
 }
 
@@ -1983,7 +2018,6 @@ string AWSListObjectV2::Request(EncryptionUtil &encryption_util, HTTPRequestSess
 		result.captured = captured;
 		result.auth_params = std::move(auth_params);
 		result.http_params = snapshot.CreateRequestParams();
-		result.refreshable_http_params = SnapshotRefreshableHTTPParams(result.http_params->Cast<HTTPFSParams>());
 		result.source_url = path;
 		auto request_path = parsed_url.path.substr(0, parsed_url.path.length() - parsed_url.key.length());
 		result.http_url =
@@ -2008,13 +2042,15 @@ string AWSListObjectV2::Request(EncryptionUtil &encryption_util, HTTPRequestSess
 	    },
 	    [&](const S3RequestData &request_data) { return TryRefreshS3Session(session, request_data); },
 	    [&](const S3RequestData &request_data, string correct_region) {
-		    auto &params = request_data.http_params->Cast<HTTPFSParams>();
-		    DUCKDB_LOG_WARNING(
-		        params.logger,
-		        "Ran S3 glob \"%s\" from incorrect region \"%s\" - retrying with updated region \"%s\".\n"
-		        "Consider setting the S3 region to this explicitly to avoid extra round-trips.",
-		        path, request_data.auth_params.region, correct_region);
-		    SetS3SessionRegion(session, request_data, std::move(correct_region));
+		    string previous_region;
+		    if (SetS3SessionRegion(session, correct_region, previous_region)) {
+			    auto &params = request_data.http_params->Cast<HTTPFSParams>();
+			    DUCKDB_LOG_WARNING(
+			        params.logger,
+			        "Ran S3 glob \"%s\" from incorrect region \"%s\" - retrying with updated region \"%s\".\n"
+			        "Consider setting the S3 region to this explicitly to avoid extra round-trips.",
+			        path, previous_region, correct_region);
+		    }
 	    });
 	if (response->HasRequestError()) {
 		throw IOException("%s error for HTTP GET to '%s'", response->GetRequestError(), path);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -614,11 +614,12 @@ static unique_ptr<HTTPResponse> SendS3SessionRequest(HTTPRequestSession &session
 	auto lease = session.AcquireClient(captured, params, request.proto_host_port);
 	try {
 		auto response = params.http_util.Request(request, lease.Client());
-		if (response && (IsS3RequestTimeout(*response) || response->HasRequestError() ||
-		                 static_cast<int>(response->status) >= 400)) {
+		auto request_timeout = response && IsS3RequestTimeout(*response);
+		// A completed S3 response leaves the transport reusable unless it reports a stalled connection.
+		if (response && (request_timeout || response->HasRequestError())) {
 			lease.Invalidate();
 		}
-		if (response && IsS3RequestTimeout(*response)) {
+		if (request_timeout) {
 			invalidate_connections();
 		}
 		return response;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -242,8 +242,7 @@ static bool IsS3CredentialRefreshEnabled(optional_ptr<FileOpener> opener) {
 
 static bool ReloadS3AuthMaterial(optional_ptr<FileOpener> opener, const string &path, S3AuthParams &auth_params,
                                  HTTPFSParams &http_params, const S3AuthParams &request_auth_params,
-                                 const S3RefreshableHTTPParams &request_http_params, HTTPClientCache *client_cache,
-                                 bool preserve_region) {
+                                 const S3RefreshableHTTPParams &request_http_params, bool preserve_region) {
 	if (!opener) {
 		return false;
 	}
@@ -262,9 +261,6 @@ static bool ReloadS3AuthMaterial(optional_ptr<FileOpener> opener, const string &
 
 	auth_params = std::move(reloaded_auth_params);
 	ApplyRefreshableHTTPParams(http_params, reloaded_http_params);
-	if (client_cache) {
-		client_cache->Clear();
-	}
 	return true;
 }
 
@@ -272,8 +268,7 @@ static bool TryRefreshS3AuthMaterial(optional_ptr<ClientContext> context, option
                                      const string &path, S3AuthParams &auth_params, HTTPFSParams &http_params,
                                      const S3AuthParams &request_auth_params,
                                      const S3RefreshableHTTPParams &request_http_params,
-                                     bool credential_refresh_enabled, HTTPClientCache *client_cache = nullptr,
-                                     bool preserve_region = false) {
+                                     bool credential_refresh_enabled, bool preserve_region = false) {
 	if (!credential_refresh_enabled) {
 		return false;
 	}
@@ -285,37 +280,29 @@ static bool TryRefreshS3AuthMaterial(optional_ptr<ClientContext> context, option
 		return false;
 	}
 	if (ReloadS3AuthMaterial(opener, path, auth_params, http_params, request_auth_params, request_http_params,
-	                         client_cache, preserve_region)) {
+	                         preserve_region)) {
 		return true;
 	}
 
 	auto http_state = HTTPState::TryGetState(*context);
-	lock_guard<mutex> refresh_lck(http_state->CredentialRefreshLock());
-	if (ReloadS3AuthMaterial(opener, path, auth_params, http_params, request_auth_params, request_http_params,
-	                         client_cache, preserve_region)) {
-		return true;
-	}
-	if (!TryRefreshS3SecretForPath(*context, path)) {
-		return false;
-	}
-	return ReloadS3AuthMaterial(opener, path, auth_params, http_params, request_auth_params, request_http_params,
-	                            client_cache, preserve_region);
-}
-
-static void AddS3HTTPHeaders(HTTPFSParams &http_params, HTTPHeaders &headers) {
-	if (!http_params.user_agent.empty()) {
-		headers.Insert("User-Agent", http_params.user_agent);
-	}
-	for (auto &header : http_params.extra_headers) {
-		headers[header.first] = header.second;
-	}
-	http_params.pre_merged_headers = true;
+	return http_state->RunCredentialRefresh([&]() {
+		if (ReloadS3AuthMaterial(opener, path, auth_params, http_params, request_auth_params, request_http_params,
+		                         preserve_region)) {
+			return true;
+		}
+		if (!TryRefreshS3SecretForPath(*context, path)) {
+			return false;
+		}
+		return ReloadS3AuthMaterial(opener, path, auth_params, http_params, request_auth_params, request_http_params,
+		                            preserve_region);
+	});
 }
 
 struct S3RequestData {
 	S3AuthParams auth_params;
 	S3RefreshableHTTPParams refreshable_http_params;
 	unique_ptr<HTTPParams> http_params;
+	CapturedHTTPRequestSnapshot captured;
 	string source_url;
 	string http_url;
 	HTTPHeaders headers;
@@ -323,20 +310,21 @@ struct S3RequestData {
 	bool auto_fallback_to_full_file_download = false;
 };
 
-static S3RequestData CreateS3RequestData(EncryptionUtil &encryption_util, const S3AuthParams &auth_params,
-                                         const HTTPFSParams &http_params, const string &s3_url, const string &method,
-                                         const string &query_string, const string &payload_hash = "",
-                                         const string &content_type = "", const string &content_md5 = "") {
+static S3RequestData CreateS3RequestData(EncryptionUtil &encryption_util, const CapturedHTTPRequestSnapshot &captured,
+                                         const string &s3_url, const string &method, const string &query_string,
+                                         const string &payload_hash = "", const string &content_type = "",
+                                         const string &content_md5 = "") {
+	auto &snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
 	S3RequestData result;
-	result.auth_params = auth_params;
-	result.http_params = http_params.Clone();
+	result.captured = captured;
+	result.auth_params = snapshot.auth_params;
+	result.http_params = snapshot.CreateRequestParams();
 	result.source_url = s3_url;
 	auto &httpfs_params = result.http_params->Cast<HTTPFSParams>();
 	result.refreshable_http_params = SnapshotRefreshableHTTPParams(httpfs_params);
 	auto parsed_s3_url = S3FileSystem::S3UrlParse(s3_url, result.auth_params);
 
 	result.http_url = parsed_s3_url.GetHTTPUrl(result.auth_params, query_string);
-
 	if (IsGCSRequest(s3_url) && !result.auth_params.oauth2_bearer_token.empty()) {
 		result.headers["Authorization"] = "Bearer " + result.auth_params.oauth2_bearer_token;
 		result.headers["Host"] = parsed_s3_url.host;
@@ -347,21 +335,18 @@ static S3RequestData CreateS3RequestData(EncryptionUtil &encryption_util, const 
 		result.headers = CreateS3Header(encryption_util, parsed_s3_url.path, query_string, parsed_s3_url.host, "s3",
 		                                method, result.auth_params, "", "", payload_hash, content_type, content_md5);
 	}
-	AddS3HTTPHeaders(httpfs_params, result.headers);
+	snapshot.AddConfiguredHeaders(result.headers);
 	return result;
 }
 
 static S3RequestData CreateS3HandleRequestData(EncryptionUtil &encryption_util, S3FileHandle &s3_handle,
                                                const string &s3_url, const string &method, bool use_version_id) {
-	S3AuthParams auth_params;
-	unique_ptr<HTTPParams> http_params;
+	auto captured = s3_handle.request_session->Capture();
 	string version_id;
 	string etag;
 	bool auto_fallback_to_full_file_download;
 	{
 		lock_guard<mutex> lck(s3_handle.mu);
-		auth_params = s3_handle.auth_params;
-		http_params = s3_handle.http_params.Clone();
 		version_id = s3_handle.version_id;
 		etag = s3_handle.etag;
 		auto_fallback_to_full_file_download = s3_handle.auto_fallback_to_full_file_download;
@@ -372,8 +357,7 @@ static S3RequestData CreateS3HandleRequestData(EncryptionUtil &encryption_util, 
 		query_string = "versionId=" + S3FileSystem::UrlEncode(version_id, true);
 	}
 
-	auto result = CreateS3RequestData(encryption_util, auth_params, http_params->Cast<HTTPFSParams>(), s3_url, method,
-	                                  query_string);
+	auto result = CreateS3RequestData(encryption_util, captured, s3_url, method, query_string);
 	result.etag = std::move(etag);
 	result.auto_fallback_to_full_file_download = auto_fallback_to_full_file_download;
 	return result;
@@ -461,21 +445,19 @@ RunS3RequestWithAuthRefreshInternal(const string &s3_url, CREATE_DATA create_dat
 		auto &http_params = request_data.http_params->template Cast<HTTPFSParams>();
 		try {
 			auto result = request(request_data);
-			if (result && !retried_auth_refresh && IsAuthRefreshStatus(*result) &&
-			    refresh_auth_params(request_data.auth_params, request_data.refreshable_http_params)) {
+			if (result && !retried_auth_refresh && IsAuthRefreshStatus(*result) && refresh_auth_params(request_data)) {
 				retried_auth_refresh = true;
 				continue;
 			}
 			string correct_region;
 			if (result && !retried_region &&
 			    GetRegionRedirect(*result, request_data.auth_params, correct_region).IsValid()) {
-				set_region(std::move(correct_region));
+				set_region(request_data, std::move(correct_region));
 				retried_region = true;
 				continue;
 			}
 			if (transient_retry_eligible && result && transient_retries < http_params.retries &&
 			    IsS3RequestTimeout(*result)) {
-				dynamic_cast<HTTPFSUtil &>(http_params.http_util).ClearCachedConnections();
 				SleepForS3RequestTimeoutRetry(http_params, transient_retries, transient_wait_ms);
 				transient_retries++;
 				continue;
@@ -483,19 +465,17 @@ RunS3RequestWithAuthRefreshInternal(const string &s3_url, CREATE_DATA create_dat
 			return result;
 		} catch (std::exception &ex) {
 			ErrorData error(ex);
-			if (!retried_auth_refresh && IsAuthRefreshStatus(error) &&
-			    refresh_auth_params(request_data.auth_params, request_data.refreshable_http_params)) {
+			if (!retried_auth_refresh && IsAuthRefreshStatus(error) && refresh_auth_params(request_data)) {
 				retried_auth_refresh = true;
 				continue;
 			}
 			string correct_region;
 			if (!retried_region && GetRegionRedirect(error, request_data.auth_params, correct_region).IsValid()) {
-				set_region(std::move(correct_region));
+				set_region(request_data, std::move(correct_region));
 				retried_region = true;
 				continue;
 			}
 			if (transient_retry_eligible && transient_retries < http_params.retries && IsS3RequestTimeout(error)) {
-				dynamic_cast<HTTPFSUtil &>(http_params.http_util).ClearCachedConnections();
 				SleepForS3RequestTimeoutRetry(http_params, transient_retries, transient_wait_ms);
 				transient_retries++;
 				continue;
@@ -505,25 +485,59 @@ RunS3RequestWithAuthRefreshInternal(const string &s3_url, CREATE_DATA create_dat
 	}
 }
 
+static bool TryRefreshS3Session(HTTPRequestSession &session, const S3RequestData &request_data) {
+	auto current = session.Capture();
+	if (current.snapshot != request_data.captured.snapshot) {
+		return true;
+	}
+	auto &failed_snapshot = request_data.captured.snapshot->Cast<S3RequestSnapshot>();
+	if (!failed_snapshot.credential_refresh_enabled) {
+		return false;
+	}
+
+	auto context = failed_snapshot.client_context.lock();
+	if (!context) {
+		return false;
+	}
+	ClientContextFileOpener opener(*context);
+	auto auth_params = failed_snapshot.auth_params;
+	auto http_params = failed_snapshot.CreateRequestParams();
+	if (!TryRefreshS3AuthMaterial(context.get(), opener, failed_snapshot.refresh_path, auth_params, *http_params,
+	                              request_data.auth_params, request_data.refreshable_http_params,
+	                              failed_snapshot.credential_refresh_enabled, failed_snapshot.region_redirected)) {
+		return session.Capture().snapshot != request_data.captured.snapshot;
+	}
+	auto replacement = make_shared_ptr<S3RequestSnapshot>(
+	    *http_params, auth_params, failed_snapshot.refresh_path, failed_snapshot.client_context,
+	    failed_snapshot.credential_refresh_enabled, failed_snapshot.region_redirected);
+	return session.Publish(request_data.captured, std::move(replacement)).snapshot != request_data.captured.snapshot;
+}
+
+static void SetS3SessionRegion(HTTPRequestSession &session, const S3RequestData &request_data, string correct_region) {
+	auto &failed_snapshot = request_data.captured.snapshot->Cast<S3RequestSnapshot>();
+	auto auth_params = failed_snapshot.auth_params;
+	auth_params.SetRegion(std::move(correct_region));
+	auto http_params = failed_snapshot.CreateRequestParams();
+	auto replacement = make_shared_ptr<S3RequestSnapshot>(*http_params, auth_params, failed_snapshot.refresh_path,
+	                                                      failed_snapshot.client_context,
+	                                                      failed_snapshot.credential_refresh_enabled, true);
+	session.Publish(request_data.captured, std::move(replacement));
+}
+
 template <class REQUEST>
-unique_ptr<HTTPResponse>
-S3FileSystem::RunS3InputRequestWithAuthRefresh(S3HTTPInput &s3_input, const string &s3_url, const string &method,
-                                               const string &query_string, const string &payload_hash,
-                                               const string &content_type, REQUEST request) {
+unique_ptr<HTTPResponse> S3FileSystem::RunS3SessionRequestWithAuthRefresh(
+    HTTPRequestSession &session, const string &s3_url, const string &method, const string &query_string,
+    const string &payload_hash, const string &content_type, const string &content_md5, REQUEST request) {
 	return RunS3RequestWithAuthRefreshInternal(
 	    s3_url,
 	    [&]() {
-		    lock_guard<mutex> lck(s3_input.mu);
-		    return CreateS3RequestData(GetEncryptionUtil(), s3_input.auth_params, s3_input.http_params, s3_url, method,
-		                               query_string, payload_hash, content_type);
+		    return CreateS3RequestData(GetEncryptionUtil(), session.Capture(), s3_url, method, query_string,
+		                               payload_hash, content_type, content_md5);
 	    },
 	    IsTransientRetryEligibleMethod(method), request,
-	    [&](const S3AuthParams &request_auth_params, const S3RefreshableHTTPParams &request_http_params) {
-		    return s3_input.TryRefreshAuthParams(s3_url, request_auth_params, request_http_params);
-	    },
-	    [&](string correct_region) {
-		    lock_guard<mutex> lck(s3_input.mu);
-		    s3_input.SetRegion(std::move(correct_region));
+	    [&](const S3RequestData &request_data) { return TryRefreshS3Session(session, request_data); },
+	    [&](const S3RequestData &request_data, string correct_region) {
+		    SetS3SessionRegion(session, request_data, std::move(correct_region));
 	    });
 }
 
@@ -535,23 +549,50 @@ unique_ptr<HTTPResponse> S3FileSystem::RunS3HandleRequestWithAuthRefresh(S3FileH
 	    s3_url,
 	    [&]() { return CreateS3HandleRequestData(GetEncryptionUtil(), s3_handle, s3_url, method, use_version_id); },
 	    IsTransientRetryEligibleMethod(method), request,
-	    [&](const S3AuthParams &request_auth_params, const S3RefreshableHTTPParams &request_http_params) {
-		    return s3_handle.TryRefreshAuthParams(request_auth_params, request_http_params);
+	    [&](const S3RequestData &request_data) {
+		    return TryRefreshS3Session(*s3_handle.request_session, request_data);
 	    },
-	    [&](string correct_region) { s3_handle.SetRegion(std::move(correct_region)); });
+	    [&](const S3RequestData &request_data, string correct_region) {
+		    SetS3SessionRegion(*s3_handle.request_session, request_data, std::move(correct_region));
+	    });
 }
 
-static unique_ptr<HTTPResponse> SendS3HandleRequestWithClientCache(S3FileHandle &s3_handle, HTTPFSParams &params,
-                                                                   BaseRequest &request) {
-	auto client_entry = s3_handle.client_cache.GetClientWithGeneration();
-	auto response = params.http_util.Request(request, client_entry.client);
-	if (response && IsS3RequestTimeout(*response)) {
-		client_entry.client.reset();
-		dynamic_cast<HTTPFSUtil &>(params.http_util).ClearCachedConnections();
-	} else if (!s3_handle.client_cache.StoreClient(client_entry)) {
-		params.http_util.CloseClient(std::move(client_entry.client));
+static unique_ptr<HTTPResponse> SendS3SessionRequest(HTTPRequestSession &session,
+                                                     const CapturedHTTPRequestSnapshot &captured, HTTPFSParams &params,
+                                                     BaseRequest &request) {
+	auto invalidate_connections = [&]() {
+		session.InvalidateClients();
+		if (params.httpfs_util) {
+			params.httpfs_util->ClearCachedConnections();
+		}
+	};
+	auto lease = session.AcquireClient(captured, params, request.proto_host_port);
+	try {
+		auto response = params.http_util.Request(request, lease.Client());
+		if (response && (IsS3RequestTimeout(*response) || response->HasRequestError() ||
+		                 static_cast<int>(response->status) >= 400)) {
+			lease.Invalidate();
+		}
+		if (response && IsS3RequestTimeout(*response)) {
+			invalidate_connections();
+		}
+		return response;
+	} catch (std::exception &ex) {
+		lease.Invalidate();
+		if (IsS3RequestTimeout(ErrorData(ex))) {
+			invalidate_connections();
+		}
+		throw;
+	} catch (...) {
+		lease.Invalidate();
+		throw;
 	}
-	return response;
+}
+
+static unique_ptr<HTTPResponse> SendS3HandleRequestWithClientCache(S3FileHandle &s3_handle,
+                                                                   const CapturedHTTPRequestSnapshot &captured,
+                                                                   HTTPFSParams &params, BaseRequest &request) {
+	return SendS3SessionRequest(*s3_handle.request_session, captured, params, request);
 }
 
 static HTTPException GetS3RequestError(const S3RequestData &request_data, const HTTPResponse &response) {
@@ -696,21 +737,31 @@ unique_ptr<KeyValueSecret> CreateSecret(vector<string> &prefix_paths_p, string &
 	return return_value;
 }
 
-S3HTTPInput::S3HTTPInput(unique_ptr<HTTPParams> params_p, const S3AuthParams &auth_params_p,
-                         const S3ConfigParams &config_params_p)
-    : HTTPInput(std::move(params_p)), auth_params(auth_params_p), config_params(config_params_p) {
+S3RequestSnapshot::S3RequestSnapshot(const HTTPFSParams &http_params, const S3AuthParams &auth_params_p,
+                                     string refresh_path_p, weak_ptr<ClientContext> client_context_p,
+                                     bool credential_refresh_enabled_p, bool region_redirected_p)
+    : HTTPRequestSnapshot(http_params, TYPE), auth_params(auth_params_p), refresh_path(std::move(refresh_path_p)),
+      client_context(std::move(client_context_p)), credential_refresh_enabled(credential_refresh_enabled_p),
+      region_redirected(region_redirected_p) {
 }
 
-S3HTTPInput::~S3HTTPInput() {
+bool S3RequestSnapshot::ClientCompatibleWith(const HTTPRequestSnapshot &other) const {
+	if (other.type != TYPE || !HTTPRequestSnapshot::ClientCompatibleWith(other)) {
+		return false;
+	}
+	auto &s3_other = other.Cast<S3RequestSnapshot>();
+	return auth_params.endpoint == s3_other.auth_params.endpoint &&
+	       auth_params.use_ssl == s3_other.auth_params.use_ssl &&
+	       auth_params.url_style == s3_other.auth_params.url_style;
 }
 
 S3FileHandle::S3FileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags,
                            unique_ptr<HTTPParams> http_params_p, const S3AuthParams &auth_params_p,
                            const S3ConfigParams &config_params_p)
-    : HTTPFileHandle(fs, file, flags,
-                     make_shared_ptr<S3HTTPInput>(std::move(http_params_p), auth_params_p, config_params_p)),
-      auth_params(http_input->Cast<S3HTTPInput>().auth_params),
-      config_params(http_input->Cast<S3HTTPInput>().config_params) {
+    : HTTPFileHandle(fs, file, flags, std::move(http_params_p)), config_params(config_params_p) {
+	auto captured = request_session->Capture();
+	auto request_params = captured.snapshot->CreateRequestParams();
+	request_session->Publish(captured, make_shared_ptr<S3RequestSnapshot>(*request_params, auth_params_p, file.path));
 	auto_fallback_to_full_file_download = false;
 	if (flags.OpenForReading() && flags.OpenForWriting()) {
 		throw NotImplementedException("Cannot open an HTTP file for both reading and writing");
@@ -728,6 +779,14 @@ S3FileHandle::S3FileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFla
 	}
 }
 
+shared_ptr<const HTTPRequestSnapshot> S3FileHandle::CreateRequestSnapshot(const HTTPFSParams &params) const {
+	auto captured = request_session->Capture();
+	auto &s3_snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
+	return make_shared_ptr<S3RequestSnapshot>(params, s3_snapshot.auth_params, s3_snapshot.refresh_path,
+	                                          s3_snapshot.client_context, s3_snapshot.credential_refresh_enabled,
+	                                          s3_snapshot.region_redirected);
+}
+
 S3FileHandle::~S3FileHandle() {
 	if (Exception::UncaughtException()) {
 		// We are in an exception, don't do anything
@@ -741,52 +800,11 @@ S3FileHandle::~S3FileHandle() {
 }
 
 void S3FileHandle::SetRegion(string region_p) {
-	lock_guard<mutex> lck(mu);
-	auth_params.SetRegion(std::move(region_p));
-	region_redirected = true;
-	client_cache.Clear();
-}
-
-bool S3FileHandle::TryRefreshAuthParams(S3AuthParams request_auth_params, S3RefreshableHTTPParams request_http_params) {
-	lock_guard<mutex> lck(mu);
-	auto refresh_enabled = credential_refresh_enabled;
-	auto context = client_context.lock();
-	if (!context) {
-		return TryRefreshS3AuthMaterial(nullptr, nullptr, path, auth_params, http_params, request_auth_params,
-		                                request_http_params, refresh_enabled, &client_cache, region_redirected);
-	}
-	ClientContextFileOpener opener(*context);
-	return TryRefreshS3AuthMaterial(context.get(), opener, path, auth_params, http_params, request_auth_params,
-	                                request_http_params, refresh_enabled, &client_cache, region_redirected);
-}
-
-void S3HTTPInput::SetRegion(string region_p) {
-	auth_params.SetRegion(std::move(region_p));
-	region_redirected = true;
-}
-
-bool S3HTTPInput::TryRefreshAuthParams(const string &path, S3AuthParams request_auth_params,
-                                       S3RefreshableHTTPParams request_http_params) {
-	lock_guard<mutex> lck(mu);
-	auto refresh_enabled = credential_refresh_enabled;
-	auto context = client_context.lock();
-	if (!context) {
-		return TryRefreshS3AuthMaterial(nullptr, nullptr, path, auth_params, http_params, request_auth_params,
-		                                request_http_params, refresh_enabled, nullptr, region_redirected);
-	}
-	ClientContextFileOpener opener(*context);
-	return TryRefreshS3AuthMaterial(context.get(), opener, path, auth_params, http_params, request_auth_params,
-	                                request_http_params, refresh_enabled, nullptr, region_redirected);
-}
-
-static bool TryRefreshS3AuthParams(optional_ptr<FileOpener> opener, const string &path, HTTPParams &http_params,
-                                   S3AuthParams &auth_params, const S3AuthParams &request_auth_params,
-                                   const S3RefreshableHTTPParams &request_http_params, bool preserve_region = false) {
-	auto &httpfs_params = http_params.Cast<HTTPFSParams>();
-	auto context = FileOpener::TryGetClientContext(opener);
-	return TryRefreshS3AuthMaterial(context, opener, path, auth_params, httpfs_params, request_auth_params,
-	                                request_http_params, IsS3CredentialRefreshEnabled(opener), nullptr,
-	                                preserve_region);
+	auto captured = request_session->Capture();
+	S3RequestData request_data;
+	request_data.captured = captured;
+	request_data.auth_params = captured.snapshot->Cast<S3RequestSnapshot>().auth_params;
+	SetS3SessionRegion(*request_session, request_data, std::move(region_p));
 }
 
 S3ConfigParams S3ConfigParams::ReadFrom(optional_ptr<FileOpener> opener) {
@@ -824,14 +842,6 @@ void S3FileHandle::FinalizeUpload() {
 	if (flags.OpenForWriting() && multi_part_upload) {
 		multi_part_upload->Finalize();
 	}
-}
-
-unique_ptr<HTTPClient> S3FileHandle::CreateClient() {
-	lock_guard<mutex> lck(mu);
-	auto auth_params = this->auth_params;
-	auto parsed_url = S3FileSystem::S3UrlParse(path, auth_params);
-	string proto_host_port = parsed_url.http_proto + parsed_url.host;
-	return http_params.http_util.InitializeClient(http_params, proto_host_port);
 }
 
 // Wrapper around the BufferManager::Allocate to that allows limiting the number of buffers that will be handed out
@@ -1009,30 +1019,32 @@ string ParsedS3Url::GetHTTPUrl(S3AuthParams &auth_params, const string &http_que
 	return full_url;
 }
 
-unique_ptr<HTTPResponse> S3FileSystem::PostRequest(HTTPInput &input, string url, HTTPHeaders header_map, string &result,
+unique_ptr<HTTPResponse> S3FileSystem::PostRequest(HTTPRequestSession &session, string url, string &result,
                                                    char *buffer_in, idx_t buffer_in_len, string http_params) {
-	auto &s3_input = input.Cast<S3HTTPInput>();
 	auto payload_hash = GetPayloadHash(buffer_in, buffer_in_len);
 	const string content_type = "application/octet-stream";
-	return RunS3InputRequestWithAuthRefresh(
-	    s3_input, url, "POST", http_params, payload_hash, content_type, [&](S3RequestData &request_data) {
+	return RunS3SessionRequestWithAuthRefresh(
+	    session, url, "POST", http_params, payload_hash, content_type, "", [&](S3RequestData &request_data) {
 		    result.clear();
 		    auto &params = request_data.http_params->Cast<HTTPFSParams>();
 		    return RunPostRequest(request_data.http_url, request_data.headers, params, result, buffer_in, buffer_in_len,
-		                          [&](BaseRequest &request) { return params.http_util.Request(request); });
+		                          [&](BaseRequest &request) {
+			                          return SendS3SessionRequest(session, request_data.captured, params, request);
+		                          });
 	    });
 }
 
-unique_ptr<HTTPResponse> S3FileSystem::PutRequest(HTTPInput &input, string url, HTTPHeaders header_map, char *buffer_in,
+unique_ptr<HTTPResponse> S3FileSystem::PutRequest(HTTPRequestSession &session, string url, char *buffer_in,
                                                   idx_t buffer_in_len, string http_params) {
-	auto &s3_input = input.Cast<S3HTTPInput>();
 	auto payload_hash = GetPayloadHash(buffer_in, buffer_in_len);
 	const string content_type = "application/octet-stream";
-	return RunS3InputRequestWithAuthRefresh(
-	    s3_input, url, "PUT", http_params, payload_hash, content_type, [&](S3RequestData &request_data) {
+	return RunS3SessionRequestWithAuthRefresh(
+	    session, url, "PUT", http_params, payload_hash, content_type, "", [&](S3RequestData &request_data) {
 		    auto &params = request_data.http_params->Cast<HTTPFSParams>();
 		    return RunPutRequest(request_data.http_url, request_data.headers, params, buffer_in, buffer_in_len,
-		                         content_type, [&](BaseRequest &request) { return params.http_util.Request(request); });
+		                         content_type, [&](BaseRequest &request) {
+			                         return SendS3SessionRequest(session, request_data.captured, params, request);
+		                         });
 	    });
 }
 
@@ -1041,7 +1053,7 @@ unique_ptr<HTTPResponse> S3FileSystem::HeadRequest(FileHandle &handle, string s3
 	return RunS3HandleRequestWithAuthRefresh(s3_handle, s3_url, "HEAD", false, [&](S3RequestData &request_data) {
 		auto &params = request_data.http_params->Cast<HTTPFSParams>();
 		return RunHeadRequest(request_data.http_url, request_data.headers, params, [&](BaseRequest &request) {
-			return SendS3HandleRequestWithClientCache(s3_handle, params, request);
+			return SendS3HandleRequestWithClientCache(s3_handle, request_data.captured, params, request);
 		});
 	});
 }
@@ -1054,7 +1066,9 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_
 		return RunGetRequest(
 		    s3_handle, request_data.http_url, request_data.headers, params, download,
 		    [&](const HTTPResponse &response) { return GetS3RequestError(request_data, response); },
-		    [&](BaseRequest &request) { return SendS3HandleRequestWithClientCache(s3_handle, params, request); });
+		    [&](BaseRequest &request) {
+			    return SendS3HandleRequestWithClientCache(s3_handle, request_data.captured, params, request);
+		    });
 	});
 }
 
@@ -1067,7 +1081,9 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, strin
 		    s3_handle, request_data.http_url, request_data.headers, params, request_data.etag,
 		    request_data.auto_fallback_to_full_file_download, file_offset, buffer_out, buffer_out_len,
 		    [&](const HTTPResponse &response) { return GetS3RequestError(request_data, response); },
-		    [&](BaseRequest &request) { return SendS3HandleRequestWithClientCache(s3_handle, params, request); });
+		    [&](BaseRequest &request) {
+			    return SendS3HandleRequestWithClientCache(s3_handle, request_data.captured, params, request);
+		    });
 	});
 }
 
@@ -1076,7 +1092,7 @@ unique_ptr<HTTPResponse> S3FileSystem::DeleteRequest(FileHandle &handle, string 
 	return RunS3HandleRequestWithAuthRefresh(s3_handle, s3_url, "DELETE", false, [&](S3RequestData &request_data) {
 		auto &params = request_data.http_params->Cast<HTTPFSParams>();
 		return RunDeleteRequest(request_data.http_url, request_data.headers, params, [&](BaseRequest &request) {
-			return SendS3HandleRequestWithClientCache(s3_handle, params, request);
+			return SendS3HandleRequestWithClientCache(s3_handle, request_data.captured, params, request);
 		});
 	});
 }
@@ -1107,8 +1123,10 @@ void S3FileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cache_
 
 HTTPMetadataCacheEntry S3FileHandle::GetCacheEntry() const {
 	auto result = HTTPFileHandle::GetCacheEntry();
-	if (!auth_params.region.empty()) {
-		result.properties["s3_region"] = auth_params.region;
+	auto captured = request_session->Capture();
+	auto &snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
+	if (!snapshot.auth_params.region.empty()) {
+		result.properties["s3_region"] = snapshot.auth_params.region;
 	}
 	return result;
 }
@@ -1116,73 +1134,19 @@ HTTPMetadataCacheEntry S3FileHandle::GetCacheEntry() const {
 void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 	auto context = FileOpener::TryGetClientContext(opener);
 	auto refresh_enabled = IsS3CredentialRefreshEnabled(opener);
-	auto &s3_input = http_input->Cast<S3HTTPInput>();
 	{
-		lock_guard<mutex> lck(mu);
-		credential_refresh_enabled = refresh_enabled;
+		auto captured = request_session->Capture();
+		auto &snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
+		auto request_params = snapshot.CreateRequestParams();
+		weak_ptr<ClientContext> weak_context;
 		if (context && refresh_enabled) {
-			client_context = context->shared_from_this();
-		} else {
-			client_context.reset();
+			weak_context = context->shared_from_this();
 		}
+		request_session->Publish(captured, make_shared_ptr<S3RequestSnapshot>(
+		                                       *request_params, snapshot.auth_params, snapshot.refresh_path,
+		                                       std::move(weak_context), refresh_enabled, snapshot.region_redirected));
 	}
-	{
-		lock_guard<mutex> input_lck(s3_input.mu);
-		s3_input.credential_refresh_enabled = refresh_enabled;
-		if (context && refresh_enabled) {
-			s3_input.client_context = context->shared_from_this();
-		} else {
-			s3_input.client_context.reset();
-		}
-	}
-	try {
-		HTTPFileHandle::Initialize(opener);
-	} catch (std::exception &ex) {
-		ErrorData error(ex);
-		bool refreshed_secret = false;
-		if (error.Type() == ExceptionType::IO || error.Type() == ExceptionType::HTTP) {
-			refreshed_secret = TryRefreshAuthParams(auth_params, SnapshotRefreshableHTTPParams(http_params));
-		}
-		string correct_region;
-		if (!refreshed_secret) {
-			auto &extra_info = error.ExtraInfo();
-			auto entry = extra_info.find("status_code");
-			if (entry != extra_info.end()) {
-				if (entry->second == "301" || entry->second == "400") {
-					auto new_region = extra_info.find("header_x-amz-bucket-region");
-					if (new_region != extra_info.end()) {
-						correct_region = new_region->second;
-					}
-				}
-				if (entry->second == "403") {
-					// 403: FORBIDDEN
-					string extra_text;
-					if (IsGCSRequest(path)) {
-						extra_text = S3FileSystem::GetGCSAuthError(auth_params);
-					} else {
-						extra_text = S3FileSystem::GetS3AuthError(auth_params);
-					}
-					throw Exception(extra_info, error.Type(), error.RawMessage() + extra_text);
-				}
-			}
-			if (correct_region.empty()) {
-				throw;
-			}
-		}
-		if (!refreshed_secret) {
-			FileOpenerInfo info = {path};
-			auth_params = S3AuthParams::ReadFrom(opener, info);
-		}
-		if (!correct_region.empty()) {
-			DUCKDB_LOG_WARNING(
-			    logger,
-			    "Read S3 file \"%s\" from incorrect region \"%s\" - retrying with updated region \"%s\".\n"
-			    "Consider setting the S3 region to this explicitly to avoid extra round-trips.",
-			    path, auth_params.region, correct_region);
-			SetRegion(std::move(correct_region));
-		}
-		HTTPFileHandle::Initialize(opener);
-	}
+	HTTPFileHandle::Initialize(opener);
 
 	if (flags.OpenForWriting()) {
 		auto aws_minimum_part_size = 5242880; // 5 MiB https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
@@ -1379,6 +1343,88 @@ static string GetS3BucketPath(const ParsedS3Url &parsed_url) {
 	return bucket_path.empty() ? "/" : bucket_path;
 }
 
+static shared_ptr<HTTPRequestSession> CreateS3OperationSession(optional_ptr<FileOpener> opener, const string &path,
+                                                               const S3AuthParams &auth_params) {
+	FileOpenerInfo info = {path};
+	auto &http_util = HTTPFSUtil::GetHTTPUtil(opener);
+	auto http_params = http_util.InitializeParameters(opener, info);
+	weak_ptr<ClientContext> weak_context;
+	auto context = FileOpener::TryGetClientContext(opener);
+	auto refresh_enabled = IsS3CredentialRefreshEnabled(opener);
+	if (context && refresh_enabled) {
+		weak_context = context->shared_from_this();
+	}
+	return make_shared_ptr<HTTPRequestSession>(make_shared_ptr<S3RequestSnapshot>(
+	    http_params->Cast<HTTPFSParams>(), auth_params, path, std::move(weak_context), refresh_enabled));
+}
+
+static string CreateS3DeleteBody(const vector<string> &keys, idx_t begin, idx_t end) {
+	std::stringstream body;
+	body << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+	body << "<Delete xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">";
+	for (idx_t i = begin; i < end; i++) {
+		body << "<Object><Key>" << keys[i] << "</Key></Object>";
+	}
+	body << "<Quiet>true</Quiet></Delete>";
+	return body.str();
+}
+
+static string GetS3DeleteContentMD5(const string &body) {
+	MD5Context md5_context;
+	md5_context.Add(body);
+	data_t md5_hash[MD5Context::MD5_HASH_LENGTH_BINARY];
+	md5_context.Finish(md5_hash);
+	string_t md5_blob(const_char_ptr_cast(md5_hash), MD5Context::MD5_HASH_LENGTH_BINARY);
+	return Blob::ToBase64(md5_blob);
+}
+
+static S3RequestData CreateS3BulkDeleteRequestData(EncryptionUtil &encryption_util,
+                                                   const CapturedHTTPRequestSnapshot &captured,
+                                                   const string &secret_lookup_url, const string &payload_hash,
+                                                   const string &content_md5) {
+	auto &snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
+	S3RequestData result;
+	result.captured = captured;
+	result.auth_params = snapshot.auth_params;
+	result.http_params = snapshot.CreateRequestParams();
+	result.source_url = secret_lookup_url;
+	result.refreshable_http_params = SnapshotRefreshableHTTPParams(result.http_params->Cast<HTTPFSParams>());
+
+	auto request_url = S3FileSystem::S3UrlParse(secret_lookup_url, result.auth_params);
+	auto request_path = GetS3BucketPath(request_url);
+	result.headers = CreateS3Header(encryption_util, request_path, "delete=", request_url.host, "s3", "POST",
+	                                result.auth_params, "", "", payload_hash, "application/xml", content_md5);
+	snapshot.AddConfiguredHeaders(result.headers);
+	result.http_url = request_url.http_proto + request_url.host + S3FileSystem::UrlEncode(request_path) + "?delete";
+	return result;
+}
+
+unique_ptr<HTTPResponse> S3FileSystem::RunS3BulkDeleteRequest(HTTPRequestSession &session,
+                                                              const string &secret_lookup_url, const string &body,
+                                                              string &result) {
+	auto payload_hash = GetPayloadHash(const_cast<char *>(body.data()), body.length());
+	auto content_md5 = GetS3DeleteContentMD5(body);
+	return RunS3RequestWithAuthRefreshInternal(
+	    secret_lookup_url,
+	    [&]() {
+		    return CreateS3BulkDeleteRequestData(GetEncryptionUtil(), session.Capture(), secret_lookup_url,
+		                                         payload_hash, content_md5);
+	    },
+	    false,
+	    [&](S3RequestData &request_data) {
+		    result.clear();
+		    auto &params = request_data.http_params->Cast<HTTPFSParams>();
+		    return RunPostRequest(request_data.http_url, request_data.headers, params, result,
+		                          const_cast<char *>(body.data()), body.length(), [&](BaseRequest &request) {
+			                          return SendS3SessionRequest(session, request_data.captured, params, request);
+		                          });
+	    },
+	    [&](const S3RequestData &request_data) { return TryRefreshS3Session(session, request_data); },
+	    [&](const S3RequestData &request_data, string correct_region) {
+		    SetS3SessionRegion(session, request_data, std::move(correct_region));
+	    });
+}
+
 void S3FileSystem::RemoveFiles(const vector<string> &paths, optional_ptr<FileOpener> opener) {
 	if (paths.empty()) {
 		return;
@@ -1416,66 +1462,13 @@ void S3FileSystem::RemoveFiles(const vector<string> &paths, optional_ptr<FileOpe
 		const vector<string> &keys = batch.keys;
 		const vector<string> &secret_lookup_paths = batch.secret_lookup_paths;
 		auto &url_info = batch.url_info;
+		auto delete_session = CreateS3OperationSession(opener, secret_lookup_paths.front(), url_info.auth_params);
 
 		for (idx_t batch_start = 0; batch_start < keys.size(); batch_start += MAX_KEYS_PER_REQUEST) {
 			idx_t batch_end = MinValue<idx_t>(batch_start + MAX_KEYS_PER_REQUEST, keys.size());
-
-			std::stringstream xml_body;
-			xml_body << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
-			xml_body << "<Delete xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">";
-
-			for (idx_t i = batch_start; i < batch_end; i++) {
-				xml_body << "<Object><Key>" << keys[i] << "</Key></Object>";
-			}
-
-			xml_body << "<Quiet>true</Quiet>";
-			xml_body << "</Delete>";
-
-			string body = xml_body.str();
-
-			MD5Context md5_context;
-			md5_context.Add(body);
-			data_t md5_hash[MD5Context::MD5_HASH_LENGTH_BINARY];
-			md5_context.Finish(md5_hash);
-
-			string_t md5_blob(const_char_ptr_cast(md5_hash), MD5Context::MD5_HASH_LENGTH_BINARY);
-			string content_md5 = Blob::ToBase64(md5_blob);
-
-			const string http_query_param_for_sig = "delete=";
-			const string http_query_param_for_url = "delete";
-			auto payload_hash = GetPayloadHash(const_cast<char *>(body.data()), body.length());
-			string secret_lookup_url = secret_lookup_paths[batch_start];
+			auto body = CreateS3DeleteBody(keys, batch_start, batch_end);
 			string result;
-			unique_ptr<HTTPResponse> res;
-			bool retried_auth_refresh = false;
-
-			while (true) {
-				auto request_auth_params = url_info.auth_params;
-				FileOpenerInfo info = {secret_lookup_url};
-				auto &http_util = HTTPFSUtil::GetHTTPUtil(opener);
-				auto http_params = http_util.InitializeParameters(opener, info);
-				auto request_http_params = SnapshotRefreshableHTTPParams(http_params->Cast<HTTPFSParams>());
-				auto request_url = S3UrlParse(secret_lookup_url, url_info.auth_params);
-				auto request_path = GetS3BucketPath(request_url);
-				auto headers =
-				    CreateS3Header(GetEncryptionUtil(), request_path, http_query_param_for_sig, request_url.host, "s3",
-				                   "POST", url_info.auth_params, "", "", payload_hash, "application/xml", content_md5);
-
-				string http_url = request_url.http_proto + request_url.host + S3FileSystem::UrlEncode(request_path) +
-				                  "?" + http_query_param_for_url;
-				S3HTTPInput http_input(std::move(http_params), url_info.auth_params, S3ConfigParams::ReadFrom(opener));
-
-				result.clear();
-				res = HTTPFileSystem::PostRequest(http_input, http_url, headers, result,
-				                                  const_cast<char *>(body.data()), body.length());
-				if (!retried_auth_refresh && res && IsAuthRefreshStatus(*res) &&
-				    TryRefreshS3AuthParams(opener, secret_lookup_url, http_input.http_params, url_info.auth_params,
-				                           request_auth_params, request_http_params)) {
-					retried_auth_refresh = true;
-					continue;
-				}
-				break;
-			}
+			auto res = RunS3BulkDeleteRequest(*delete_session, secret_lookup_paths[batch_start], body, result);
 
 			if (res->status != HTTPStatusCode::OK_200) {
 				throw IOException("Failed to remove files: HTTP %d (%s)\n%s", static_cast<int>(res->status),
@@ -1593,7 +1586,7 @@ private:
 	string glob_pattern;
 	optional_ptr<FileOpener> opener;
 	mutable bool finished = false;
-	mutable S3AuthParams s3_auth_params;
+	shared_ptr<HTTPRequestSession> request_session;
 	string shared_path;
 	ParsedS3Url parsed_s3_url;
 	mutable string main_continuation_token;
@@ -1612,7 +1605,7 @@ S3GlobResult::S3GlobResult(S3FileSystem &fs_p, const string &glob_pattern_p, opt
 	FileOpenerInfo info = {glob_pattern};
 
 	// Trim any query parameters from the string
-	s3_auth_params = S3AuthParams::ReadFrom(opener, info);
+	auto s3_auth_params = S3AuthParams::ReadFrom(opener, info);
 
 	// In url compatibility mode, we ignore globs allowing users to query files with the glob chars
 	if (s3_auth_params.s3_url_compatibility_mode) {
@@ -1635,6 +1628,7 @@ S3GlobResult::S3GlobResult(S3FileSystem &fs_p, const string &glob_pattern_p, opt
 	shared_path = parsed_glob_url.substr(0, first_wildcard_pos);
 
 	fs.ReadQueryParams(parsed_s3_url.query_param, s3_auth_params);
+	request_session = CreateS3OperationSession(opener, glob_pattern, s3_auth_params);
 }
 
 bool S3GlobResult::ExpandNextPath() const {
@@ -1642,9 +1636,6 @@ bool S3GlobResult::ExpandNextPath() const {
 		return false;
 	}
 
-	FileOpenerInfo info = {glob_pattern};
-	auto &http_util = HTTPFSUtil::GetHTTPUtil(opener);
-	auto http_params = http_util.InitializeParameters(opener, info);
 	const vector<string> pattern_splits = StringUtil::Split(parsed_s3_url.key, "/");
 
 	vector<OpenFileInfo> s3_keys;
@@ -1658,9 +1649,8 @@ bool S3GlobResult::ExpandNextPath() const {
 		    Match(key_splits.begin(), key_splits.end(), pattern_splits.begin(), pattern_splits.end(), false);
 		if (is_match) {
 			prefix_path = S3FileSystem::UrlDecode(prefix_path);
-			auto prefix_res =
-			    AWSListObjectV2::Request(fs.GetEncryptionUtil(), prefix_path, *http_params, s3_auth_params,
-			                             common_prefix_continuation_token, true, optional_idx(), opener);
+			auto prefix_res = AWSListObjectV2::Request(fs.GetEncryptionUtil(), *request_session, prefix_path,
+			                                           common_prefix_continuation_token, true);
 
 			AWSListObjectV2::ParseFileList(prefix_res, s3_keys);
 			auto more_prefixes = AWSListObjectV2::ParseCommonPrefix(prefix_res);
@@ -1699,9 +1689,8 @@ bool S3GlobResult::ExpandNextPath() const {
 		bool perform_listing = (glob_type != GlobType::HIERARCHICAL);
 
 		// First perform listing once (default will get back up to 1000 elements)
-		string response_str =
-		    AWSListObjectV2::Request(fs.GetEncryptionUtil(), shared_path, *http_params, s3_auth_params,
-		                             main_continuation_token, !perform_listing, optional_idx(), opener);
+		string response_str = AWSListObjectV2::Request(fs.GetEncryptionUtil(), *request_session, shared_path,
+		                                               main_continuation_token, !perform_listing);
 
 		string next_continuation_token = AWSListObjectV2::ParseContinuationToken(response_str);
 
@@ -1731,9 +1720,8 @@ bool S3GlobResult::ExpandNextPath() const {
 				// 1. clear keys
 				s3_keys_tmp.clear();
 				// 2. do request again, now passing true
-				response_str =
-				    AWSListObjectV2::Request(fs.GetEncryptionUtil(), shared_path, *http_params, s3_auth_params,
-				                             main_continuation_token, true, optional_idx(), opener);
+				response_str = AWSListObjectV2::Request(fs.GetEncryptionUtil(), *request_session, shared_path,
+				                                        main_continuation_token, true);
 
 				// 3. now set next_continuation_token
 				next_continuation_token = AWSListObjectV2::ParseContinuationToken(response_str);
@@ -1773,8 +1761,10 @@ bool S3GlobResult::ExpandNextPath() const {
 				result_full_url += '?' + parsed_s3_url.query_param;
 			}
 			s3_key.path = std::move(result_full_url);
-			if (!s3_auth_params.region.empty()) {
-				s3_key.extended_info->options["s3_region"] = s3_auth_params.region;
+			auto captured = request_session->Capture();
+			auto &snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
+			if (!snapshot.auth_params.region.empty()) {
+				s3_key.extended_info->options["s3_region"] = snapshot.auth_params.region;
 			}
 			expanded_files.push_back(std::move(s3_key));
 		}
@@ -1947,11 +1937,8 @@ HTTPException S3FileSystem::GetS3Error(const S3AuthParams &s3_auth_params, const
 
 HTTPException S3FileSystem::GetHTTPError(FileHandle &handle, const HTTPResponse &response, const string &url) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
-	S3AuthParams auth_params;
-	{
-		lock_guard<mutex> lck(s3_handle.mu);
-		auth_params = s3_handle.auth_params;
-	}
+	auto captured = s3_handle.request_session->Capture();
+	auto auth_params = captured.snapshot->Cast<S3RequestSnapshot>().auth_params;
 
 	// Use GCS-specific error for GCS URLs
 	if (IsGCSRequest(url) && response.status == HTTPStatusCode::Forbidden_403) {
@@ -1964,135 +1951,82 @@ HTTPException S3FileSystem::GetHTTPError(FileHandle &handle, const HTTPResponse 
 	return GetS3Error(auth_params, response, url);
 }
 
-string AWSListObjectV2::Request(EncryptionUtil &encryption_util, const string &path, HTTPParams &http_params,
-                                S3AuthParams &s3_auth_params, string &continuation_token, bool use_delimiter,
-                                optional_idx max_keys, optional_ptr<FileOpener> opener) {
-	auto &httpfs_params = http_params.Cast<HTTPFSParams>();
-	const idx_t MAX_RETRIES = 2 + httpfs_params.retries;
-	bool retried_auth_refresh = false;
-	bool retried_region = false;
-	idx_t transient_retries = 0;
-	double transient_wait_ms = 0;
-	for (idx_t it = 0; it <= MAX_RETRIES; it++) {
-		auto request_auth_params = s3_auth_params;
-		auto request_http_params = SnapshotRefreshableHTTPParams(http_params.Cast<HTTPFSParams>());
-		auto parsed_url = S3FileSystem::S3UrlParse(path, s3_auth_params);
+string AWSListObjectV2::Request(EncryptionUtil &encryption_util, HTTPRequestSession &session, const string &path,
+                                const string &continuation_token, bool use_delimiter, optional_idx max_keys) {
+	auto create_request_data = [&]() {
+		auto captured = session.Capture();
+		auto &snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
+		auto auth_params = snapshot.auth_params;
+		auto parsed_url = S3FileSystem::S3UrlParse(path, auth_params);
 
-		// Construct the ListObjectsV2 call
-		string req_path = parsed_url.path.substr(0, parsed_url.path.length() - parsed_url.key.length());
-
-		map<string, string> req_params;
-		// NOTE: req_params needs to be sorted before passing to sigv4 code
+		map<string, string> request_params;
 		if (!continuation_token.empty()) {
-			req_params["continuation-token"] = S3FileSystem::UrlEncode(continuation_token, true);
+			request_params["continuation-token"] = S3FileSystem::UrlEncode(continuation_token, true);
 		}
-
 		if (use_delimiter) {
-			req_params["delimiter"] = "%2F";
+			request_params["delimiter"] = "%2F";
 		}
-
-		req_params["encoding-type"] = "url";
-		req_params["list-type"] = "2";
+		request_params["encoding-type"] = "url";
+		request_params["list-type"] = "2";
 		if (max_keys.IsValid()) {
-			req_params["max-keys"] = to_string(max_keys.GetIndex());
+			request_params["max-keys"] = to_string(max_keys.GetIndex());
 		}
-		req_params["prefix"] = S3FileSystem::UrlEncode(parsed_url.key, true);
+		request_params["prefix"] = S3FileSystem::UrlEncode(parsed_url.key, true);
 
-		string encoded_params = "";
-		for (const auto &p : req_params) {
-			encoded_params += p.first + "=" + p.second + "&";
+		string encoded_params;
+		for (const auto &param : request_params) {
+			encoded_params += param.first + "=" + param.second + "&";
 		}
-		if (!encoded_params.empty()) {
-			// Remove last '&'
-			encoded_params.pop_back();
-		}
-		auto header_map = CreateS3Header(encryption_util, req_path, encoded_params, parsed_url.host, "s3", "GET",
-		                                 s3_auth_params, "", "", "", "");
+		encoded_params.pop_back();
 
-		// Get requests use fresh connection
-		string full_host = parsed_url.http_proto + parsed_url.host;
-		string listobjectv2_url = req_path + "?" + encoded_params;
-		string actual_path = full_host;
-		if (StringUtil::StartsWith(listobjectv2_url, full_host)) {
-			actual_path = listobjectv2_url;
-		} else if (listobjectv2_url[0] == '/') {
-			actual_path += listobjectv2_url;
+		S3RequestData result;
+		result.captured = captured;
+		result.auth_params = std::move(auth_params);
+		result.http_params = snapshot.CreateRequestParams();
+		result.refreshable_http_params = SnapshotRefreshableHTTPParams(result.http_params->Cast<HTTPFSParams>());
+		result.source_url = path;
+		auto request_path = parsed_url.path.substr(0, parsed_url.path.length() - parsed_url.key.length());
+		result.http_url =
+		    parsed_url.http_proto + parsed_url.host + S3FileSystem::UrlEncode(request_path) + "?" + encoded_params;
+		if (IsGCSRequest(path) && !result.auth_params.oauth2_bearer_token.empty()) {
+			result.headers["Authorization"] = "Bearer " + result.auth_params.oauth2_bearer_token;
+			result.headers["Host"] = parsed_url.host;
 		} else {
-			actual_path += "/" + listobjectv2_url;
+			result.headers = CreateS3Header(encryption_util, request_path, encoded_params, parsed_url.host, "s3", "GET",
+			                                result.auth_params);
 		}
-		// Buffer the response in HTTPResponse instead of streaming it through callbacks. The retry classifier needs the
-		// complete S3 error body to distinguish RequestTimeout (HTTP 400), and callbacks otherwise retain per-attempt
-		// state across HTTPUtil's internal retry loop.
-		GetRequestInfo get_request(actual_path, header_map, http_params, nullptr, nullptr);
-		auto result = http_params.http_util.Request(get_request);
-		if (result->HasRequestError()) {
-			throw IOException("%s error for HTTP GET to '%s'", result->GetRequestError(), listobjectv2_url);
-		}
-		ErrorData error;
-		if (static_cast<int>(result->status) >= 400) {
-			string trimmed_path = path;
-			StringUtil::RTrim(trimmed_path, "/");
-			error = ErrorData(S3FileSystem::GetS3Error(s3_auth_params, *result, trimmed_path));
-		}
-		// check
-		string updated_bucket_region;
-		if (result->status == HTTPStatusCode::MovedPermanently_301) {
-			string moved_error;
-			if (!retried_region && result->HasHeader("x-amz-bucket-region")) {
-				auto response_region = result->GetHeaderValue("x-amz-bucket-region");
-				if (response_region == s3_auth_params.region) {
-					moved_error = "suggested region \"" + response_region +
-					              "\" is the same as the region we used to make the request";
-				} else {
-					updated_bucket_region = response_region;
-				}
-			} else {
-				moved_error = "HTTP response did not contain header_x-amz-bucket-region";
-			}
-			if (!moved_error.empty()) {
-				throw HTTPException(*result, "HTTP 301 response when running glob \"%s\" but %s", path, moved_error);
-			}
-		}
-		if (error.HasError()) {
-			if (transient_retries < httpfs_params.retries && IsS3RequestTimeout(*result)) {
-				SleepForS3RequestTimeoutRetry(httpfs_params, transient_retries, transient_wait_ms);
-				transient_retries++;
-				continue;
-			}
-			if (!retried_auth_refresh && IsAuthRefreshStatus(error) &&
-			    TryRefreshS3AuthParams(opener, path, http_params, s3_auth_params, request_auth_params,
-			                           request_http_params, retried_region)) {
-				retried_auth_refresh = true;
-				continue;
-			}
-			if (!retried_region && result->HasHeader("x-amz-bucket-region")) {
-				auto response_region = result->GetHeaderValue("x-amz-bucket-region");
-				if (response_region != s3_auth_params.region) {
-					updated_bucket_region = response_region;
-				}
-			}
-			if (updated_bucket_region.empty()) {
-				// no updated region found
-				error.Throw();
-			}
-		}
-		if (!updated_bucket_region.empty()) {
-			DUCKDB_LOG_WARNING(
-			    http_params.logger,
-			    "Ran S3 glob \"%s\" from incorrect region \"%s\" - retrying with updated region \"%s\".\n"
-			    "Consider setting the S3 region to this explicitly to avoid extra round-trips.",
-			    path, s3_auth_params.region, updated_bucket_region);
+		snapshot.AddConfiguredHeaders(result.headers);
+		return result;
+	};
 
-			// bucket region was updated - update and re-run the request against the correct endpoint
-			s3_auth_params.SetRegion(std::move(updated_bucket_region));
-			retried_region = true;
-			continue;
-		}
-		return std::move(result->body);
+	auto response = RunS3RequestWithAuthRefreshInternal(
+	    path, create_request_data, true,
+	    [&](S3RequestData &request_data) {
+		    auto &params = request_data.http_params->Cast<HTTPFSParams>();
+		    GetRequestInfo get_request(request_data.http_url, request_data.headers, params, nullptr, nullptr);
+		    return SendS3SessionRequest(session, request_data.captured, params, get_request);
+	    },
+	    [&](const S3RequestData &request_data) { return TryRefreshS3Session(session, request_data); },
+	    [&](const S3RequestData &request_data, string correct_region) {
+		    auto &params = request_data.http_params->Cast<HTTPFSParams>();
+		    DUCKDB_LOG_WARNING(
+		        params.logger,
+		        "Ran S3 glob \"%s\" from incorrect region \"%s\" - retrying with updated region \"%s\".\n"
+		        "Consider setting the S3 region to this explicitly to avoid extra round-trips.",
+		        path, request_data.auth_params.region, correct_region);
+		    SetS3SessionRegion(session, request_data, std::move(correct_region));
+	    });
+	if (response->HasRequestError()) {
+		throw IOException("%s error for HTTP GET to '%s'", response->GetRequestError(), path);
 	}
-	throw InvalidInputException(
-	    "Exceeded retry count in AWSListObjectV2::Request while retrying transient errors, region redirects, or "
-	    "credential refresh");
+	if (static_cast<int>(response->status) >= 400) {
+		auto captured = session.Capture();
+		auto &snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
+		string trimmed_path = path;
+		StringUtil::RTrim(trimmed_path, "/");
+		throw S3FileSystem::GetS3Error(snapshot.auth_params, *response, trimmed_path);
+	}
+	return std::move(response->body);
 }
 
 void AWSListObjectV2::ParseFileList(string &aws_response, vector<OpenFileInfo> &result) {

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -7,7 +7,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../src/include)
 add_executable(
   unittest_httpfs EXCLUDE_FROM_ALL
   main.cpp mock_s3_server.cpp httpfs_refresh_test.cpp s3_list_retry_test.cpp
-  short_read_test.cpp)
+  short_read_test.cpp http_request_session_test.cpp)
 set_target_properties(unittest_httpfs PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                                  ${CMAKE_BINARY_DIR}/test)
 

--- a/test/unittest/http_request_session_test.cpp
+++ b/test/unittest/http_request_session_test.cpp
@@ -11,8 +11,10 @@ namespace {
 
 struct ClientLifecycle {
 	idx_t initialized = 0;
+	idx_t client_initializations = 0;
 	idx_t closed = 0;
 	idx_t destroyed = 0;
+	shared_ptr<HTTPState> last_state;
 };
 
 class TrackingHTTPClient : public HTTPClient {
@@ -25,7 +27,12 @@ public:
 		lifecycle.destroyed++;
 	}
 
-	void Initialize(HTTPParams &) override {
+	void Initialize(HTTPParams &params) override {
+		lifecycle.client_initializations++;
+		lifecycle.last_state = params.Cast<HTTPFSParams>().state;
+		if (on_initialize) {
+			on_initialize();
+		}
 	}
 	unique_ptr<HTTPResponse> Get(GetRequestInfo &) override {
 		return Success();
@@ -46,6 +53,8 @@ public:
 		return Success();
 	}
 
+	std::function<void()> on_initialize;
+
 private:
 	static unique_ptr<HTTPResponse> Success() {
 		return make_uniq<HTTPResponse>(HTTPStatusCode::OK_200);
@@ -59,12 +68,15 @@ public:
 	explicit TrackingHTTPUtil(ClientLifecycle &lifecycle_p) : lifecycle(lifecycle_p) {
 	}
 
-	unique_ptr<HTTPClient> InitializeClient(HTTPParams &, const string &proto_host_port) override {
+	unique_ptr<HTTPClient> InitializeClient(HTTPParams &params, const string &proto_host_port) override {
 		lifecycle.initialized++;
 		if (on_initialize) {
 			on_initialize();
 		}
-		return make_uniq<TrackingHTTPClient>(proto_host_port, lifecycle);
+		auto result = make_uniq<TrackingHTTPClient>(proto_host_port, lifecycle);
+		result->on_initialize = on_client_initialize;
+		result->Initialize(params);
+		return result;
 	}
 
 	void CloseClient(unique_ptr<HTTPClient> &&client) override {
@@ -82,6 +94,7 @@ public:
 	ClientLifecycle &lifecycle;
 	HTTPClientReuseMode reuse_mode = HTTPClientReuseMode::SESSION_LOCAL;
 	std::function<void()> on_initialize;
+	std::function<void()> on_client_initialize;
 	std::function<void()> on_close;
 };
 
@@ -107,7 +120,9 @@ TEST_CASE("HTTP request snapshots are immutable and checked", "[httpfs][request-
 
 	params.extra_headers["X-Test"] = "second";
 	auto replacement = make_shared_ptr<HTTPRequestSnapshot>(params);
-	auto current = session->Publish(initial, replacement);
+	auto publication = session->TryPublish(initial.snapshot, replacement);
+	REQUIRE(publication.published);
+	auto current = publication.current;
 
 	HTTPHeaders initial_headers;
 	initial.snapshot->AddConfiguredHeaders(initial_headers);
@@ -121,20 +136,23 @@ TEST_CASE("HTTP request snapshots are immutable and checked", "[httpfs][request-
 	REQUIRE(current_headers.GetHeaderValue("X-Test") == "second");
 
 	auto stale_replacement = make_shared_ptr<HTTPRequestSnapshot>(CreateParams(http_util));
-	auto still_current = session->Publish(initial, stale_replacement);
-	REQUIRE(still_current.snapshot == current.snapshot);
+	auto stale_publication = session->TryPublish(initial.snapshot, stale_replacement);
+	REQUIRE_FALSE(stale_publication.published);
+	REQUIRE(stale_publication.current.snapshot == current.snapshot);
 
 	session->InvalidateClients();
 	auto stale_generation_replacement = make_shared_ptr<HTTPRequestSnapshot>(CreateParams(http_util));
-	auto newer_generation = session->Publish(current, stale_generation_replacement);
-	REQUIRE(newer_generation.snapshot == current.snapshot);
-	REQUIRE(newer_generation.client_generation > current.client_generation);
-	REQUIRE(current.snapshot->type == HTTPRequestSnapshotType::HTTP);
+	auto newer_generation = session->TryPublish(current.snapshot, stale_generation_replacement);
+	REQUIRE(newer_generation.published);
+	REQUIRE(newer_generation.current.snapshot == stale_generation_replacement);
+	REQUIRE(newer_generation.current.client_generation > current.client_generation);
+	REQUIRE(newer_generation.current.snapshot->type == HTTPRequestSnapshotType::HTTP);
 }
 
 TEST_CASE("HTTP client leases obey snapshot generations", "[httpfs][request-session]") {
 	ClientLifecycle lifecycle;
 	TrackingHTTPUtil http_util(lifecycle);
+	TrackingHTTPUtil other_http_util(lifecycle);
 	auto params = CreateParams(http_util);
 	auto session = make_shared_ptr<HTTPRequestSession>(make_shared_ptr<HTTPRequestSnapshot>(params));
 	auto session_ptr = session.get();
@@ -176,10 +194,9 @@ TEST_CASE("HTTP client leases obey snapshot generations", "[httpfs][request-sess
 		auto lease = session->AcquireClient(captured, *request_params, "http://localhost");
 		REQUIRE(lease.Client());
 
-		auto incompatible_params = CreateParams(http_util);
-		incompatible_params.http_proxy = "proxy.invalid";
+		auto incompatible_params = CreateParams(other_http_util);
 		auto replacement = make_shared_ptr<HTTPRequestSnapshot>(incompatible_params);
-		session->Publish(captured, replacement);
+		REQUIRE(session->TryPublish(captured.snapshot, replacement).published);
 	}
 	REQUIRE(lifecycle.initialized == 2);
 	REQUIRE(lifecycle.closed == 0);
@@ -198,6 +215,122 @@ TEST_CASE("HTTP client leases obey snapshot generations", "[httpfs][request-sess
 	session.reset();
 	REQUIRE(lifecycle.closed == 1);
 	REQUIRE(lifecycle.destroyed == 3);
+}
+
+TEST_CASE("HTTP request sessions reinitialize reused clients", "[httpfs][request-session]") {
+	ClientLifecycle lifecycle;
+	TrackingHTTPUtil http_util(lifecycle);
+	auto params = CreateParams(http_util);
+	params.state = make_shared_ptr<HTTPState>();
+	auto initial_state = params.state;
+	auto session = make_shared_ptr<HTTPRequestSession>(make_shared_ptr<HTTPRequestSnapshot>(params));
+	auto session_ptr = session.get();
+	http_util.on_client_initialize = [session_ptr]() {
+		auto captured = session_ptr->Capture();
+		REQUIRE(captured.snapshot);
+	};
+
+	{
+		auto captured = session->Capture();
+		auto request_params = captured.snapshot->CreateRequestParams();
+		auto lease = session->AcquireClient(captured, *request_params, "http://localhost");
+		REQUIRE(lease.Client());
+	}
+	REQUIRE(lifecycle.initialized == 1);
+	REQUIRE(lifecycle.client_initializations == 1);
+	REQUIRE(lifecycle.last_state == initial_state);
+
+	auto replacement_params = params;
+	replacement_params.state = make_shared_ptr<HTTPState>();
+	auto replacement_state = replacement_params.state;
+	auto captured = session->Capture();
+	auto publication = session->TryPublish(captured.snapshot, make_shared_ptr<HTTPRequestSnapshot>(replacement_params));
+	REQUIRE(publication.published);
+	REQUIRE(publication.current.client_generation == captured.client_generation);
+
+	{
+		auto current = session->Capture();
+		auto request_params = current.snapshot->CreateRequestParams();
+		auto lease = session->AcquireClient(current, *request_params, "http://localhost");
+		REQUIRE(lease.Client());
+	}
+	REQUIRE(lifecycle.initialized == 1);
+	REQUIRE(lifecycle.client_initializations == 2);
+	REQUIRE(lifecycle.last_state == replacement_state);
+}
+
+TEST_CASE("HTTP request sessions discard clients that fail reinitialization", "[httpfs][request-session]") {
+	ClientLifecycle lifecycle;
+	TrackingHTTPUtil http_util(lifecycle);
+	auto params = CreateParams(http_util);
+	auto session = make_shared_ptr<HTTPRequestSession>(make_shared_ptr<HTTPRequestSnapshot>(params));
+	idx_t initialization_count = 0;
+	http_util.on_client_initialize = [&]() {
+		initialization_count++;
+		if (initialization_count == 2) {
+			throw IOException("reinitialization failed");
+		}
+	};
+
+	{
+		auto captured = session->Capture();
+		auto request_params = captured.snapshot->CreateRequestParams();
+		auto lease = session->AcquireClient(captured, *request_params, "http://localhost");
+		REQUIRE(lease.Client());
+	}
+
+	auto captured = session->Capture();
+	auto request_params = captured.snapshot->CreateRequestParams();
+	REQUIRE_THROWS(session->AcquireClient(captured, *request_params, "http://localhost"));
+	REQUIRE(lifecycle.initialized == 1);
+	REQUIRE(lifecycle.client_initializations == 2);
+	REQUIRE(lifecycle.destroyed == 1);
+
+	captured = session->Capture();
+	request_params = captured.snapshot->CreateRequestParams();
+	{
+		auto lease = session->AcquireClient(captured, *request_params, "http://localhost");
+		REQUIRE(lease.Client());
+	}
+	REQUIRE(lifecycle.initialized == 2);
+	REQUIRE(lifecycle.destroyed == 1);
+}
+
+TEST_CASE("HTTP request snapshots copy HTTPFS parameters through one source", "[httpfs][request-session]") {
+	ClientLifecycle lifecycle;
+	TrackingHTTPUtil http_util(lifecycle);
+	auto params = CreateParams(http_util);
+	params.timeout = 17;
+	params.timeout_usec = 23;
+	params.retries = 5;
+	params.http_proxy = "proxy.test";
+	params.http_proxy_port = 8123;
+	params.http_proxy_username = "user";
+	params.http_proxy_password = "password";
+	params.user_agent = "snapshot-agent";
+	params.extra_headers["X-Snapshot"] = "present";
+	params.force_download = true;
+	params.force_download_threshold = 42;
+	params.hf_max_per_page = 99;
+	params.state = make_shared_ptr<HTTPState>();
+
+	HTTPRequestSnapshot snapshot(params);
+	auto request_params = snapshot.CreateRequestParams();
+	REQUIRE(&request_params->http_util == &http_util);
+	REQUIRE(request_params->timeout == 17);
+	REQUIRE(request_params->timeout_usec == 23);
+	REQUIRE(request_params->retries == 5);
+	REQUIRE(request_params->http_proxy == "proxy.test");
+	REQUIRE(request_params->http_proxy_port == 8123);
+	REQUIRE(request_params->http_proxy_username == "user");
+	REQUIRE(request_params->http_proxy_password == "password");
+	REQUIRE(request_params->user_agent == "snapshot-agent");
+	REQUIRE(request_params->extra_headers == params.extra_headers);
+	REQUIRE(request_params->force_download);
+	REQUIRE(request_params->force_download_threshold == 42);
+	REQUIRE(request_params->hf_max_per_page == 99);
+	REQUIRE(request_params->state == params.state);
+	REQUIRE(request_params->pre_merged_headers);
 }
 
 TEST_CASE("HTTP client leases preserve backend reuse policy", "[httpfs][request-session]") {

--- a/test/unittest/http_request_session_test.cpp
+++ b/test/unittest/http_request_session_test.cpp
@@ -1,0 +1,241 @@
+#include "catch.hpp"
+
+#include "http_request_session.hpp"
+#include "s3fs.hpp"
+
+#include <functional>
+
+namespace duckdb {
+
+namespace {
+
+struct ClientLifecycle {
+	idx_t initialized = 0;
+	idx_t closed = 0;
+	idx_t destroyed = 0;
+};
+
+class TrackingHTTPClient : public HTTPClient {
+public:
+	TrackingHTTPClient(const string &base_url, ClientLifecycle &lifecycle_p)
+	    : HTTPClient(base_url), lifecycle(lifecycle_p) {
+	}
+
+	~TrackingHTTPClient() override {
+		lifecycle.destroyed++;
+	}
+
+	void Initialize(HTTPParams &) override {
+	}
+	unique_ptr<HTTPResponse> Get(GetRequestInfo &) override {
+		return Success();
+	}
+	unique_ptr<HTTPResponse> Put(PutRequestInfo &) override {
+		return Success();
+	}
+	unique_ptr<HTTPResponse> Head(HeadRequestInfo &) override {
+		return Success();
+	}
+	unique_ptr<HTTPResponse> Delete(DeleteRequestInfo &) override {
+		return Success();
+	}
+	unique_ptr<HTTPResponse> Post(PostRequestInfo &) override {
+		return Success();
+	}
+	unique_ptr<HTTPResponse> Options(OptionsRequestInfo &) override {
+		return Success();
+	}
+
+private:
+	static unique_ptr<HTTPResponse> Success() {
+		return make_uniq<HTTPResponse>(HTTPStatusCode::OK_200);
+	}
+
+	ClientLifecycle &lifecycle;
+};
+
+class TrackingHTTPUtil : public HTTPFSUtil {
+public:
+	explicit TrackingHTTPUtil(ClientLifecycle &lifecycle_p) : lifecycle(lifecycle_p) {
+	}
+
+	unique_ptr<HTTPClient> InitializeClient(HTTPParams &, const string &proto_host_port) override {
+		lifecycle.initialized++;
+		if (on_initialize) {
+			on_initialize();
+		}
+		return make_uniq<TrackingHTTPClient>(proto_host_port, lifecycle);
+	}
+
+	void CloseClient(unique_ptr<HTTPClient> &&client) override {
+		lifecycle.closed++;
+		if (on_close) {
+			on_close();
+		}
+		client.reset();
+	}
+
+	HTTPClientReuseMode GetClientReuseMode() const override {
+		return reuse_mode;
+	}
+
+	ClientLifecycle &lifecycle;
+	HTTPClientReuseMode reuse_mode = HTTPClientReuseMode::SESSION_LOCAL;
+	std::function<void()> on_initialize;
+	std::function<void()> on_close;
+};
+
+static HTTPFSParams CreateParams(TrackingHTTPUtil &http_util) {
+	HTTPFSParams result(http_util);
+	result.client_reuse_mode = http_util.GetClientReuseMode();
+	result.httpfs_util = http_util;
+	return result;
+}
+
+} // namespace
+
+TEST_CASE("HTTP request snapshots are immutable and checked", "[httpfs][request-session]") {
+	ClientLifecycle lifecycle;
+	TrackingHTTPUtil http_util(lifecycle);
+	auto params = CreateParams(http_util);
+	params.user_agent = "httpfs-session-test";
+	params.extra_headers["X-Test"] = "first";
+
+	auto initial_snapshot = make_shared_ptr<HTTPRequestSnapshot>(params);
+	auto session = make_shared_ptr<HTTPRequestSession>(initial_snapshot);
+	auto initial = session->Capture();
+
+	params.extra_headers["X-Test"] = "second";
+	auto replacement = make_shared_ptr<HTTPRequestSnapshot>(params);
+	auto current = session->Publish(initial, replacement);
+
+	HTTPHeaders initial_headers;
+	initial.snapshot->AddConfiguredHeaders(initial_headers);
+	REQUIRE(initial_headers.GetHeaderValue("User-Agent") == "httpfs-session-test");
+	REQUIRE(initial_headers.GetHeaderValue("X-Test") == "first");
+
+	HTTPHeaders current_headers;
+	current.snapshot->AddConfiguredHeaders(current_headers);
+	current.snapshot->AddConfiguredHeaders(current_headers);
+	REQUIRE(current_headers.GetHeaderValue("User-Agent") == "httpfs-session-test");
+	REQUIRE(current_headers.GetHeaderValue("X-Test") == "second");
+
+	auto stale_replacement = make_shared_ptr<HTTPRequestSnapshot>(CreateParams(http_util));
+	auto still_current = session->Publish(initial, stale_replacement);
+	REQUIRE(still_current.snapshot == current.snapshot);
+
+	session->InvalidateClients();
+	auto stale_generation_replacement = make_shared_ptr<HTTPRequestSnapshot>(CreateParams(http_util));
+	auto newer_generation = session->Publish(current, stale_generation_replacement);
+	REQUIRE(newer_generation.snapshot == current.snapshot);
+	REQUIRE(newer_generation.client_generation > current.client_generation);
+	REQUIRE(current.snapshot->type == HTTPRequestSnapshotType::HTTP);
+}
+
+TEST_CASE("HTTP client leases obey snapshot generations", "[httpfs][request-session]") {
+	ClientLifecycle lifecycle;
+	TrackingHTTPUtil http_util(lifecycle);
+	auto params = CreateParams(http_util);
+	auto session = make_shared_ptr<HTTPRequestSession>(make_shared_ptr<HTTPRequestSnapshot>(params));
+	auto session_ptr = session.get();
+
+	http_util.on_initialize = [session_ptr]() {
+		auto captured = session_ptr->Capture();
+		REQUIRE(captured.snapshot);
+	};
+	http_util.on_close = [session_ptr]() {
+		auto captured = session_ptr->Capture();
+		REQUIRE(captured.snapshot);
+	};
+
+	{
+		auto captured = session->Capture();
+		auto request_params = captured.snapshot->CreateRequestParams();
+		REQUIRE(&request_params->http_util == &http_util);
+		auto lease = session->AcquireClient(captured, *request_params, "http://localhost");
+		REQUIRE(lease.Client());
+	}
+	REQUIRE(lifecycle.initialized == 1);
+	REQUIRE(lifecycle.closed == 0);
+	REQUIRE(lifecycle.destroyed == 0);
+
+	{
+		auto captured = session->Capture();
+		auto request_params = captured.snapshot->CreateRequestParams();
+		auto lease = session->AcquireClient(captured, *request_params, "http://localhost");
+		REQUIRE(lease.Client());
+		REQUIRE(lifecycle.initialized == 1);
+		lease.Invalidate();
+	}
+	REQUIRE(lifecycle.closed == 0);
+	REQUIRE(lifecycle.destroyed == 1);
+
+	{
+		auto captured = session->Capture();
+		auto request_params = captured.snapshot->CreateRequestParams();
+		auto lease = session->AcquireClient(captured, *request_params, "http://localhost");
+		REQUIRE(lease.Client());
+
+		auto incompatible_params = CreateParams(http_util);
+		incompatible_params.http_proxy = "proxy.invalid";
+		auto replacement = make_shared_ptr<HTTPRequestSnapshot>(incompatible_params);
+		session->Publish(captured, replacement);
+	}
+	REQUIRE(lifecycle.initialized == 2);
+	REQUIRE(lifecycle.closed == 0);
+	REQUIRE(lifecycle.destroyed == 2);
+
+	{
+		auto captured = session->Capture();
+		auto request_params = captured.snapshot->CreateRequestParams();
+		auto lease = session->AcquireClient(captured, *request_params, "http://localhost");
+		REQUIRE(lease.Client());
+	}
+	REQUIRE(lifecycle.initialized == 3);
+	REQUIRE(lifecycle.closed == 0);
+	REQUIRE(lifecycle.destroyed == 2);
+
+	session.reset();
+	REQUIRE(lifecycle.closed == 1);
+	REQUIRE(lifecycle.destroyed == 3);
+}
+
+TEST_CASE("HTTP client leases preserve backend reuse policy", "[httpfs][request-session]") {
+	SECTION("shared clients return through the HTTP util") {
+		ClientLifecycle lifecycle;
+		TrackingHTTPUtil http_util(lifecycle);
+		http_util.reuse_mode = HTTPClientReuseMode::SHARED;
+		auto params = CreateParams(http_util);
+		auto session = make_shared_ptr<HTTPRequestSession>(make_shared_ptr<HTTPRequestSnapshot>(params));
+
+		auto captured = session->Capture();
+		auto request_params = captured.snapshot->CreateRequestParams();
+		{
+			auto lease = session->AcquireClient(captured, *request_params, "http://localhost");
+			REQUIRE(lease.Client());
+		}
+		REQUIRE(lifecycle.initialized == 1);
+		REQUIRE(lifecycle.closed == 1);
+		REQUIRE(lifecycle.destroyed == 1);
+	}
+
+	SECTION("client-free implementations do not initialize or close clients") {
+		ClientLifecycle lifecycle;
+		TrackingHTTPUtil http_util(lifecycle);
+		http_util.reuse_mode = HTTPClientReuseMode::NONE;
+		auto params = CreateParams(http_util);
+		auto session = make_shared_ptr<HTTPRequestSession>(make_shared_ptr<HTTPRequestSnapshot>(params));
+
+		auto captured = session->Capture();
+		auto request_params = captured.snapshot->CreateRequestParams();
+		{
+			auto lease = session->AcquireClient(captured, *request_params, "http://localhost");
+			REQUIRE_FALSE(lease.Client());
+		}
+		REQUIRE(lifecycle.initialized == 0);
+		REQUIRE(lifecycle.closed == 0);
+		REQUIRE(lifecycle.destroyed == 0);
+	}
+}
+
+} // namespace duckdb

--- a/test/unittest/httpfs_refresh_test.cpp
+++ b/test/unittest/httpfs_refresh_test.cpp
@@ -571,6 +571,105 @@ static void RunListGlobRefreshDisabledScenario() {
 	AssertNoRefresh(test_id);
 }
 
+static void RunS3HeaderScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.stale_key_id = "NEVER_STALE";
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	LoadHTTPFSExtension(db);
+	RequireQueryOk(con, StringUtil::Format("SET httpfs_client_implementation='%s'", client_implementation));
+	RequireQueryOk(con, "SET httpfs_connection_caching=false");
+	RequireQueryOk(con, StringUtil::Format(R"(
+CREATE SECRET s3_headers (
+	TYPE S3,
+	SCOPE '%s',
+	KEY_ID 'FRESH_KEY',
+	SECRET 'FRESH_SECRET',
+	REGION 'us-east-1',
+	ENDPOINT '%s',
+	USE_SSL false,
+	URL_STYLE 'path',
+	EXTRA_HTTP_HEADERS MAP {'X-HTTPFS-Session': 'present'}
+))",
+	                                       S3_PATH, server.Endpoint()));
+
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	{
+		auto handle = fs.OpenFile(S3_PATH, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+		REQUIRE(handle);
+	}
+	RequireQueryOk(con, "COMMIT");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE_FALSE(observations.empty());
+	for (const auto &observation : observations) {
+		REQUIRE(observation.user_agent_count == 1);
+		REQUIRE_FALSE(observation.user_agent.empty());
+		REQUIRE(observation.session_header_count == 1);
+		REQUIRE(observation.session_header == "present");
+	}
+}
+
+static void RunS3RegionRedirectScenario(const string &client_implementation, bool list_request) {
+	MockS3ServerConfig config;
+	config.stale_key_id = "NEVER_STALE";
+	config.required_region = "us-east-1";
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	LoadHTTPFSExtension(db);
+	RequireQueryOk(con, StringUtil::Format("SET httpfs_client_implementation='%s'", client_implementation));
+	RequireQueryOk(con, "SET httpfs_connection_caching=false");
+	RequireQueryOk(con, StringUtil::Format(R"(
+CREATE SECRET s3_region_redirect (
+	TYPE S3,
+	SCOPE 's3://refresh-bucket/',
+	KEY_ID 'FRESH_KEY',
+	SECRET 'FRESH_SECRET',
+	REGION 'eu-west-1',
+	ENDPOINT '%s',
+	USE_SSL false,
+	URL_STYLE 'path'
+))",
+	                                       server.Endpoint()));
+
+	if (list_request) {
+		auto result = con.Query("SELECT file FROM glob('s3://refresh-bucket/*.bin')");
+		REQUIRE(result);
+		INFO((result->HasError() ? result->GetError() : string()));
+		REQUIRE_FALSE(result->HasError());
+		REQUIRE(result->RowCount() == 1);
+	} else {
+		RequireQueryOk(con, "BEGIN TRANSACTION");
+		auto &fs = FileSystem::GetFileSystem(*con.context);
+		{
+			auto handle = fs.OpenFile(S3_PATH, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+			REQUIRE(handle);
+		}
+		RequireQueryOk(con, "COMMIT");
+	}
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	bool saw_redirect = false;
+	bool saw_success = false;
+	for (const auto &observation : observations) {
+		if (observation.status == 301 && observation.region == "eu-west-1") {
+			saw_redirect = true;
+		}
+		if (observation.status == 200 && observation.region == "us-east-1") {
+			saw_success = true;
+		}
+	}
+	REQUIRE(saw_redirect);
+	REQUIRE(saw_success);
+}
+
 static void RunMultipleStaleHandlesSingleRefreshScenario() {
 	MockS3ServerConfig config;
 	config.bucket = BUCKET;
@@ -1027,6 +1126,30 @@ TEST_CASE("HTTPFS initializes and clones parameters without a configured proxy",
 	auto &cloned_params = clone->Cast<HTTPFSParams>();
 	REQUIRE(cloned_params.http_proxy.empty());
 	REQUIRE(cloned_params.http_proxy_port == 0);
+}
+
+TEST_CASE("HTTP request sessions merge configured headers once", "[httpfs][request-session][headers]") {
+	SECTION("httplib") {
+		RunS3HeaderScenario("httplib");
+	}
+	SECTION("curl") {
+		RunS3HeaderScenario("curl");
+	}
+}
+
+TEST_CASE("S3 request sessions publish region redirects", "[httpfs][request-session][s3][region]") {
+	SECTION("httplib HEAD") {
+		RunS3RegionRedirectScenario("httplib", false);
+	}
+	SECTION("curl HEAD") {
+		RunS3RegionRedirectScenario("curl", false);
+	}
+	SECTION("httplib LIST") {
+		RunS3RegionRedirectScenario("httplib", true);
+	}
+	SECTION("curl LIST") {
+		RunS3RegionRedirectScenario("curl", true);
+	}
 }
 
 } // namespace duckdb

--- a/test/unittest/httpfs_refresh_test.cpp
+++ b/test/unittest/httpfs_refresh_test.cpp
@@ -276,6 +276,18 @@ static idx_t CountObservations(const vector<MockS3RequestObservation> &observati
 	return result;
 }
 
+static vector<int> ObservationPorts(const vector<MockS3RequestObservation> &observations, const string &method,
+                                    const string &key_id, int status, const string &range = string()) {
+	vector<int> result;
+	for (auto &observation : observations) {
+		if (observation.method == method && observation.key_id == key_id && observation.status == status &&
+		    observation.range == range) {
+			result.push_back(observation.remote_port);
+		}
+	}
+	return result;
+}
+
 template <class OPERATION>
 static vector<MockS3RequestObservation>
 RunRefreshScenario(MockS3RefreshTarget refresh_target, const string &client_implementation, bool connection_caching,
@@ -1026,8 +1038,8 @@ static void RunMultipartInitNotRetriedScenario(const string &client_implementati
 	REQUIRE(CountObservationsTarget(observations, "POST", 400, "uploads") == 1);
 }
 
-// With curl connection caching, the retry must run on a fresh connection instead of the stalled cached one.
-static void RunCachedConnectionRetryScenario() {
+// A RequestTimeout retry must run on a fresh connection instead of the stalled one.
+static void RunFreshConnectionRetryScenario(const string &client_implementation, bool connection_caching) {
 	MockS3ServerConfig config;
 	config.bucket = BUCKET;
 	config.object_key = OBJECT_KEY;
@@ -1038,7 +1050,7 @@ static void RunCachedConnectionRetryScenario() {
 
 	DuckDB db(nullptr);
 	Connection con(db);
-	ConfigureRefreshTest(db, con, server, "curl", true);
+	ConfigureRefreshTest(db, con, server, client_implementation, connection_caching);
 
 	RequireQueryOk(con, "SET http_retries=3");
 	RequireQueryOk(con, "SET http_retry_wait_ms=1");
@@ -1177,6 +1189,12 @@ static void RunHeadNotRetriedScenario(const string &client_implementation) {
 	INFO(MockS3DescribeObservations(observations));
 	REQUIRE(CountObservations(observations, "HEAD", STALE_KEY_ID, 400) == 1);
 	REQUIRE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 206, "bytes=0-1"));
+	auto error_ports = ObservationPorts(observations, "HEAD", STALE_KEY_ID, 400);
+	auto success_ports = ObservationPorts(observations, "GET", STALE_KEY_ID, 206, "bytes=0-1");
+	REQUIRE(error_ports.size() == 1);
+	REQUIRE(success_ports.size() == 1);
+	REQUIRE(error_ports[0] != 0);
+	REQUIRE(error_ports[0] == success_ports[0]);
 }
 
 // Like multipart-init, a multipart-complete POST must not be replayed even on RequestTimeout.
@@ -1243,8 +1261,14 @@ TEST_CASE("HTTPFS retries transient S3 RequestTimeout across request types", "[h
 	SECTION("curl") {
 		RunAllTransientRetryScenarios("curl");
 	}
-	SECTION("curl with connection caching retries on a fresh connection") {
-		RunCachedConnectionRetryScenario();
+	SECTION("httplib retries RequestTimeout on a fresh connection") {
+		RunFreshConnectionRetryScenario("httplib", false);
+	}
+	SECTION("session-local curl retries RequestTimeout on a fresh connection") {
+		RunFreshConnectionRetryScenario("curl", false);
+	}
+	SECTION("shared curl retries RequestTimeout on a fresh connection") {
+		RunFreshConnectionRetryScenario("curl", true);
 	}
 }
 

--- a/test/unittest/httpfs_refresh_test.cpp
+++ b/test/unittest/httpfs_refresh_test.cpp
@@ -5,9 +5,11 @@
 #include "create_secret_functions.hpp"
 #include "httpfs_client.hpp"
 #include "httpfs_extension.hpp"
+#include "s3fs.hpp"
 
 #include "duckdb.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
@@ -15,6 +17,7 @@
 
 #include <array>
 #include <atomic>
+#include <functional>
 #include <mutex>
 #include <new>
 #include <unordered_map>
@@ -39,8 +42,9 @@ struct ProviderStats {
 };
 
 struct ProviderRegistry {
-	std::mutex lock;
-	std::unordered_map<string, ProviderStats> stats;
+	annotated_mutex lock;
+	std::unordered_map<string, ProviderStats> stats DUCKDB_GUARDED_BY(lock);
+	std::unordered_map<string, std::function<void()>> refresh_hooks DUCKDB_GUARDED_BY(lock);
 };
 
 static ProviderRegistry &GetProviderRegistry() {
@@ -61,25 +65,60 @@ static void RecordProviderCall(const string &test_id, const string &key_id) {
 		return;
 	}
 	auto &registry = GetProviderRegistry();
-	std::lock_guard<std::mutex> lock(registry.lock);
-	auto &stats = registry.stats[test_id];
-	stats.key_ids.push_back(key_id);
-	if (key_id == STALE_KEY_ID) {
-		stats.initial_creations++;
-	} else if (key_id == FRESH_KEY_ID) {
-		stats.refresh_creations++;
+	std::function<void()> refresh_hook;
+	{
+		annotated_lock_guard<annotated_mutex> lock(registry.lock);
+		auto &stats = registry.stats[test_id];
+		stats.key_ids.push_back(key_id);
+		if (key_id == STALE_KEY_ID) {
+			stats.initial_creations++;
+		} else if (key_id == FRESH_KEY_ID) {
+			stats.refresh_creations++;
+			auto entry = registry.refresh_hooks.find(test_id);
+			if (entry != registry.refresh_hooks.end()) {
+				refresh_hook = entry->second;
+			}
+		}
+	}
+	if (refresh_hook) {
+		refresh_hook();
 	}
 }
 
 static ProviderStats GetProviderStats(const string &test_id) {
 	auto &registry = GetProviderRegistry();
-	std::lock_guard<std::mutex> lock(registry.lock);
+	annotated_lock_guard<annotated_mutex> lock(registry.lock);
 	auto entry = registry.stats.find(test_id);
 	if (entry == registry.stats.end()) {
 		return ProviderStats();
 	}
 	return entry->second;
 }
+
+static void SetProviderRefreshHook(const string &test_id, std::function<void()> refresh_hook) {
+	auto &registry = GetProviderRegistry();
+	annotated_lock_guard<annotated_mutex> lock(registry.lock);
+	registry.refresh_hooks[test_id] = std::move(refresh_hook);
+}
+
+static void ClearProviderRefreshHook(const string &test_id) {
+	auto &registry = GetProviderRegistry();
+	annotated_lock_guard<annotated_mutex> lock(registry.lock);
+	registry.refresh_hooks.erase(test_id);
+}
+
+class ProviderRefreshHook {
+public:
+	ProviderRefreshHook(string test_id_p, std::function<void()> refresh_hook) : test_id(std::move(test_id_p)) {
+		SetProviderRefreshHook(test_id, std::move(refresh_hook));
+	}
+	~ProviderRefreshHook() {
+		ClearProviderRefreshHook(test_id);
+	}
+
+private:
+	string test_id;
+};
 
 struct TestS3SecretFunctions : public CreateS3SecretFunctions {
 	static void SetTestNamedParams(CreateSecretFunction &function, string type) {
@@ -238,13 +277,15 @@ static idx_t CountObservations(const vector<MockS3RequestObservation> &observati
 }
 
 template <class OPERATION>
-static vector<MockS3RequestObservation> RunRefreshScenario(MockS3RefreshTarget refresh_target,
-                                                           const string &client_implementation, bool connection_caching,
-                                                           OPERATION operation) {
+static vector<MockS3RequestObservation>
+RunRefreshScenario(MockS3RefreshTarget refresh_target, const string &client_implementation, bool connection_caching,
+                   OPERATION operation, int stale_auth_status = 403, string stale_auth_error_code = "AccessDenied") {
 	MockS3ServerConfig config;
 	config.bucket = BUCKET;
 	config.object_key = OBJECT_KEY;
 	config.stale_key_id = STALE_KEY_ID;
+	config.stale_auth_status = stale_auth_status;
+	config.stale_auth_error_code = std::move(stale_auth_error_code);
 	config.refresh_target = refresh_target;
 	auto object_data = config.object_data;
 	MockS3Server server(std::move(config));
@@ -437,6 +478,68 @@ static void RunListGlobRefreshScenario(const string &client_implementation, bool
 	REQUIRE(MockS3HasObservation(observations, "GET", FRESH_KEY_ID, 200, string(), "list-type=2"));
 }
 
+static void RunTokenFullGetRefreshScenario(const string &client_implementation, const string &error_code) {
+	auto observations = RunRefreshScenario(
+	    MockS3RefreshTarget::FULL_GET, client_implementation, false,
+	    [](Connection &con, const string &) {
+		    RequireQueryOk(con, "SET force_download=true");
+		    auto &fs = FileSystem::GetFileSystem(*con.context);
+		    auto handle = fs.OpenFile(S3_PATH, FileFlags::FILE_FLAGS_READ);
+		    REQUIRE(handle);
+	    },
+	    400, error_code);
+	REQUIRE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 400));
+	REQUIRE(MockS3HasObservation(observations, "GET", FRESH_KEY_ID, 200));
+}
+
+static void RunTokenListRefreshScenario(const string &client_implementation, const string &error_code) {
+	auto observations = RunRefreshScenario(
+	    MockS3RefreshTarget::LIST_OBJECTS_GET, client_implementation, false,
+	    [](Connection &con, const string &) {
+		    auto result = con.Query("SELECT file FROM glob('s3://refresh-bucket/object*.bin')");
+		    REQUIRE(result);
+		    INFO((result->HasError() ? result->GetError() : string()));
+		    REQUIRE_FALSE(result->HasError());
+		    REQUIRE(result->RowCount() == 1);
+	    },
+	    400, error_code);
+	REQUIRE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 400, string(), "list-type=2"));
+	REQUIRE(MockS3HasObservation(observations, "GET", FRESH_KEY_ID, 200, string(), "list-type=2"));
+}
+
+static void RunNonAuth400NoRefreshScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	config.stale_auth_status = 400;
+	config.stale_auth_error_code = "InvalidRequest";
+	config.refresh_target = MockS3RefreshTarget::FULL_GET;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto test_id = ConfigureRefreshTest(db, con, server, client_implementation, false);
+	RequireQueryOk(con, "SET force_download=true");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	string error;
+	try {
+		auto &fs = FileSystem::GetFileSystem(*con.context);
+		fs.OpenFile(S3_PATH, FileFlags::FILE_FLAGS_READ);
+	} catch (std::exception &ex) {
+		error = ex.what();
+	}
+	INFO(error);
+	REQUIRE(error.find("InvalidRequest") != string::npos);
+	RequireQueryOk(con, "ROLLBACK");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 400));
+	REQUIRE_FALSE(HasRequestWithKey(observations, FRESH_KEY_ID));
+	AssertNoRefresh(test_id);
+}
+
 static void RunAllRequestRefreshScenarios(const string &client_implementation, bool connection_caching) {
 	RunHeadRefreshScenario(client_implementation, connection_caching);
 	RunFullGetRefreshScenario(client_implementation, connection_caching);
@@ -625,6 +728,7 @@ static void RunS3RegionRedirectScenario(const string &client_implementation, boo
 	LoadHTTPFSExtension(db);
 	RequireQueryOk(con, StringUtil::Format("SET httpfs_client_implementation='%s'", client_implementation));
 	RequireQueryOk(con, "SET httpfs_connection_caching=false");
+	RequireQueryOk(con, "SET enable_logging=true");
 	RequireQueryOk(con, StringUtil::Format(R"(
 CREATE SECRET s3_region_redirect (
 	TYPE S3,
@@ -668,6 +772,12 @@ CREATE SECRET s3_region_redirect (
 	}
 	REQUIRE(saw_redirect);
 	REQUIRE(saw_success);
+
+	auto logs = con.Query("SELECT count(*) FROM duckdb_logs WHERE message LIKE '%incorrect region%'");
+	REQUIRE(logs);
+	INFO((logs->HasError() ? logs->GetError() : string()));
+	REQUIRE_FALSE(logs->HasError());
+	REQUIRE(logs->GetValue(0, 0).GetValue<int64_t>() == 1);
 }
 
 static void RunMultipleStaleHandlesSingleRefreshScenario() {
@@ -704,6 +814,84 @@ static void RunMultipleStaleHandlesSingleRefreshScenario() {
 	INFO(MockS3DescribeObservations(observations));
 	REQUIRE(CountObservations(observations, "GET", STALE_KEY_ID, 403) >= handles.size());
 	REQUIRE(CountObservations(observations, "GET", FRESH_KEY_ID, 206) == handles.size());
+	AssertSingleRefresh(test_id);
+}
+
+static void PublishTestS3Region(const shared_ptr<HTTPRequestSession> &session, const string &region) {
+	for (;;) {
+		auto captured = session->Capture();
+		auto &snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
+		if (snapshot.auth_params.region == region) {
+			return;
+		}
+		auto auth_params = snapshot.auth_params;
+		auth_params.SetRegion(region);
+		auto http_params = snapshot.CreateRequestParams();
+		auto replacement = make_shared_ptr<S3RequestSnapshot>(
+		    *http_params, auth_params, snapshot.refresh_path, snapshot.client_context,
+		    snapshot.credential_refresh_enabled, true, snapshot.credential_generation);
+		if (session->TryPublish(captured.snapshot, std::move(replacement)).published) {
+			return;
+		}
+	}
+}
+
+static void RunRefreshPublicationScenario(const string &client_implementation, bool invalidate_clients,
+                                          bool publish_region) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	config.refresh_target = MockS3RefreshTarget::RANGE_GET;
+	auto object_data = config.object_data;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto test_id = ConfigureRefreshTest(db, con, server, client_implementation, false);
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(S3_PATH, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	REQUIRE(handle);
+	auto session = handle->Cast<S3FileHandle>().request_session;
+	ProviderRefreshHook refresh_hook(test_id, [session, invalidate_clients, publish_region]() {
+		if (invalidate_clients) {
+			session->InvalidateClients();
+		}
+		if (publish_region) {
+			PublishTestS3Region(session, "eu-west-1");
+		}
+	});
+
+	const idx_t offset = 7;
+	const idx_t read_size = 9;
+	string buffer(read_size, '\0');
+	handle->Read(QueryContext(*con.context), &buffer[0], read_size, offset);
+	REQUIRE(buffer == object_data.substr(offset, read_size));
+	RequireQueryOk(con, "COMMIT");
+
+	auto &snapshot = session->Capture().snapshot->Cast<S3RequestSnapshot>();
+	REQUIRE(snapshot.auth_params.access_key_id == FRESH_KEY_ID);
+	REQUIRE(snapshot.credential_generation == 1);
+	if (publish_region) {
+		REQUIRE(snapshot.auth_params.region == "eu-west-1");
+		REQUIRE(snapshot.region_redirected);
+	}
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 403, "bytes=7-15"));
+	REQUIRE(MockS3HasObservation(observations, "GET", FRESH_KEY_ID, 206, "bytes=7-15"));
+	if (publish_region) {
+		bool saw_merged_request = false;
+		for (const auto &observation : observations) {
+			if (observation.method == "GET" && observation.key_id == FRESH_KEY_ID &&
+			    observation.region == "eu-west-1" && observation.status == 206) {
+				saw_merged_request = true;
+			}
+		}
+		REQUIRE(saw_merged_request);
+	}
 	AssertSingleRefresh(test_id);
 }
 
@@ -1072,6 +1260,23 @@ TEST_CASE("HTTPFS refreshes S3 credentials across request methods", "[httpfs][s3
 	}
 }
 
+TEST_CASE("HTTPFS refreshes S3 credentials for token-specific HTTP 400 errors", "[httpfs][s3][refresh]") {
+	for (const string client_implementation : {"httplib", "curl"}) {
+		DYNAMIC_SECTION(client_implementation << " refreshes ExpiredToken during file open") {
+			RunTokenFullGetRefreshScenario(client_implementation, "ExpiredToken");
+		}
+		DYNAMIC_SECTION(client_implementation << " refreshes InvalidToken during LIST") {
+			RunTokenListRefreshScenario(client_implementation, "InvalidToken");
+		}
+		DYNAMIC_SECTION(client_implementation << " refreshes TokenRefreshRequired during LIST") {
+			RunTokenListRefreshScenario(client_implementation, "TokenRefreshRequired");
+		}
+		DYNAMIC_SECTION(client_implementation << " does not refresh a generic HTTP 400") {
+			RunNonAuth400NoRefreshScenario(client_implementation);
+		}
+	}
+}
+
 TEST_CASE("HTTPFS can disable S3 credential refresh", "[httpfs][s3][refresh]") {
 	SECTION("range reads fail without refresh") {
 		RunRangeRefreshDisabledScenario();
@@ -1101,6 +1306,24 @@ TEST_CASE("HTTPFS streams full GETs without Content-Length", "[httpfs][s3][strea
 
 TEST_CASE("HTTPFS reuses one S3 credential refresh across stale handles", "[httpfs][s3][refresh]") {
 	RunMultipleStaleHandlesSingleRefreshScenario();
+}
+
+TEST_CASE("S3 credential publication is independent from client invalidation", "[httpfs][s3][refresh]") {
+	SECTION("httplib") {
+		RunRefreshPublicationScenario("httplib", true, false);
+	}
+	SECTION("curl") {
+		RunRefreshPublicationScenario("curl", true, false);
+	}
+}
+
+TEST_CASE("S3 credential refresh composes with a concurrent region publication", "[httpfs][s3][refresh]") {
+	SECTION("httplib") {
+		RunRefreshPublicationScenario("httplib", false, true);
+	}
+	SECTION("curl") {
+		RunRefreshPublicationScenario("curl", false, true);
+	}
 }
 
 TEST_CASE("HTTPFS bulk delete follows a refreshed S3 endpoint", "[httpfs][s3][refresh]") {

--- a/test/unittest/mock_s3_server.cpp
+++ b/test/unittest/mock_s3_server.cpp
@@ -230,9 +230,10 @@ struct MockS3Server::Impl {
 		Record(request, response.status);
 	}
 
-	void SendForbidden(const httplib::Request &request, httplib::Response &response) const {
-		response.status = 403;
-		response.set_content("<Error><Code>AccessDenied</Code><Message>stale credentials</Message></Error>",
+	void SendAuthFailure(const httplib::Request &request, httplib::Response &response) const {
+		response.status = config.stale_auth_status;
+		response.set_content(StringUtil::Format("<Error><Code>%s</Code><Message>stale credentials</Message></Error>",
+		                                        config.stale_auth_error_code),
 		                     "application/xml");
 		Record(request, response.status);
 	}
@@ -339,7 +340,7 @@ struct MockS3Server::Impl {
 				return httplib::Server::HandlerResponse::Handled;
 			}
 			if (ShouldRejectStaleCredentials(request)) {
-				SendForbidden(request, response);
+				SendAuthFailure(request, response);
 				return httplib::Server::HandlerResponse::Handled;
 			}
 			if (remaining_head_failures.load() > 0) {
@@ -355,7 +356,7 @@ struct MockS3Server::Impl {
 
 		server.Get(path, [this](const httplib::Request &request, httplib::Response &response) {
 			if (ShouldRejectStaleCredentials(request)) {
-				SendForbidden(request, response);
+				SendAuthFailure(request, response);
 				return;
 			}
 			if (remaining_get_failures.load() > 0) {
@@ -488,7 +489,7 @@ struct MockS3Server::Impl {
 				return;
 			}
 			if (ShouldRejectStaleCredentials(request)) {
-				SendForbidden(request, response);
+				SendAuthFailure(request, response);
 				return;
 			}
 			if (config.transient_503_lists > 0 && transient_503_lists_sent.fetch_add(1) < config.transient_503_lists) {
@@ -506,7 +507,7 @@ struct MockS3Server::Impl {
 
 		server.Put(path, [this](const httplib::Request &request, httplib::Response &response) {
 			if (ShouldRejectStaleCredentials(request)) {
-				SendForbidden(request, response);
+				SendAuthFailure(request, response);
 				return;
 			}
 			if (remaining_put_failures.load() > 0) {
@@ -519,7 +520,7 @@ struct MockS3Server::Impl {
 
 		server.Post(path, [this](const httplib::Request &request, httplib::Response &response) {
 			if (ShouldRejectStaleCredentials(request)) {
-				SendForbidden(request, response);
+				SendAuthFailure(request, response);
 				return;
 			}
 			if (request.target.find("uploads") != string::npos && remaining_post_failures.load() > 0) {
@@ -537,7 +538,7 @@ struct MockS3Server::Impl {
 
 		auto bulk_delete = [this](const httplib::Request &request, httplib::Response &response) {
 			if (ShouldRejectStaleCredentials(request)) {
-				SendForbidden(request, response);
+				SendAuthFailure(request, response);
 				return;
 			}
 			SendBulkDeleteSuccess(request, response);
@@ -547,7 +548,7 @@ struct MockS3Server::Impl {
 
 		server.Delete(path, [this](const httplib::Request &request, httplib::Response &response) {
 			if (ShouldRejectStaleCredentials(request)) {
-				SendForbidden(request, response);
+				SendAuthFailure(request, response);
 				return;
 			}
 			if (remaining_delete_failures.load() > 0) {

--- a/test/unittest/mock_s3_server.cpp
+++ b/test/unittest/mock_s3_server.cpp
@@ -30,6 +30,27 @@ static string ExtractCredentialKey(const string &authorization) {
 	return authorization.substr(credential_pos, end_pos - credential_pos);
 }
 
+static string ExtractCredentialRegion(const string &authorization) {
+	auto credential_pos = authorization.find("Credential=");
+	if (credential_pos == string::npos) {
+		return string();
+	}
+	credential_pos += strlen("Credential=");
+	auto key_end = authorization.find('/', credential_pos);
+	if (key_end == string::npos) {
+		return string();
+	}
+	auto date_end = authorization.find('/', key_end + 1);
+	if (date_end == string::npos) {
+		return string();
+	}
+	auto region_end = authorization.find('/', date_end + 1);
+	if (region_end == string::npos) {
+		return string();
+	}
+	return authorization.substr(date_end + 1, region_end - date_end - 1);
+}
+
 static bool ParseRange(const string &range, idx_t object_size, idx_t &start, idx_t &end) {
 	static constexpr const char *PREFIX = "bytes=";
 	if (range.rfind(PREFIX, 0) != 0) {
@@ -63,6 +84,16 @@ static string GetHeader(const httplib::Request &request, const string &header) {
 		return string();
 	}
 	return request.get_header_value(header);
+}
+
+static idx_t CountHeader(const httplib::Request &request, const string &header) {
+	idx_t result = 0;
+	for (const auto &entry : request.headers) {
+		if (StringUtil::CIEquals(entry.first, header)) {
+			result++;
+		}
+	}
+	return result;
 }
 
 } // namespace
@@ -156,6 +187,11 @@ struct MockS3Server::Impl {
 		       MatchesRefreshTarget(request);
 	}
 
+	bool ShouldRedirectRegion(const httplib::Request &request) const {
+		return !config.required_region.empty() &&
+		       ExtractCredentialRegion(GetHeader(request, "Authorization")) != config.required_region;
+	}
+
 	void Record(const httplib::Request &request, int status) const {
 		MockS3RequestObservation observation;
 		observation.method = request.method;
@@ -163,6 +199,11 @@ struct MockS3Server::Impl {
 		observation.target = request.target;
 		observation.range = GetHeader(request, "Range");
 		observation.key_id = ExtractCredentialKey(GetHeader(request, "Authorization"));
+		observation.region = ExtractCredentialRegion(GetHeader(request, "Authorization"));
+		observation.user_agent = GetHeader(request, "User-Agent");
+		observation.session_header = GetHeader(request, "X-HTTPFS-Session");
+		observation.user_agent_count = CountHeader(request, "User-Agent");
+		observation.session_header_count = CountHeader(request, "X-HTTPFS-Session");
 		observation.status = status;
 		observation.remote_port = request.remote_port;
 
@@ -193,6 +234,13 @@ struct MockS3Server::Impl {
 		response.status = 403;
 		response.set_content("<Error><Code>AccessDenied</Code><Message>stale credentials</Message></Error>",
 		                     "application/xml");
+		Record(request, response.status);
+	}
+
+	void SendRegionRedirect(const httplib::Request &request, httplib::Response &response) const {
+		response.status = 301;
+		response.set_header("x-amz-bucket-region", config.required_region);
+		response.set_content("<Error><Code>PermanentRedirect</Code></Error>", "application/xml");
 		Record(request, response.status);
 	}
 
@@ -285,6 +333,10 @@ struct MockS3Server::Impl {
 		server.set_pre_routing_handler([this, path](const httplib::Request &request, httplib::Response &response) {
 			if (request.method != "HEAD" || request.path != path) {
 				return httplib::Server::HandlerResponse::Unhandled;
+			}
+			if (ShouldRedirectRegion(request)) {
+				SendRegionRedirect(request, response);
+				return httplib::Server::HandlerResponse::Handled;
 			}
 			if (ShouldRejectStaleCredentials(request)) {
 				SendForbidden(request, response);
@@ -383,18 +435,18 @@ struct MockS3Server::Impl {
 			response.set_header("Accept-Ranges", "bytes");
 			response.set_header("ETag", config.etag);
 			if (config.block_first_range_body_until_second_range && range_request_index == 1) {
-				const auto range_length = range_end - range_start + 1;
+				auto wait_for_second_request = make_shared_ptr<std::atomic<bool>>(true);
 				response.set_content_provider(
-				    range_length, "application/octet-stream",
-				    [this, range_start](size_t offset, size_t length, httplib::DataSink &sink) {
-					    if (offset == 0) {
+				    config.object_data.size(), "application/octet-stream",
+				    [this, wait_for_second_request](size_t offset, size_t length, httplib::DataSink &sink) {
+					    if (wait_for_second_request->exchange(false)) {
 						    std::unique_lock<std::mutex> lock(range_request_lock);
 						    if (!range_request_started.wait_for(lock, std::chrono::seconds(5),
 						                                        [this]() { return range_requests_seen >= 2; })) {
 							    return false;
 						    }
 					    }
-					    return sink.write(config.object_data.data() + range_start + offset, length);
+					    return sink.write(config.object_data.data() + offset, length);
 				    });
 				Record(request, response.status);
 				return;
@@ -429,6 +481,10 @@ struct MockS3Server::Impl {
 			if (request.target.find("list-type=2") == string::npos) {
 				response.status = 404;
 				Record(request, response.status);
+				return;
+			}
+			if (ShouldRedirectRegion(request)) {
+				SendRegionRedirect(request, response);
 				return;
 			}
 			if (ShouldRejectStaleCredentials(request)) {
@@ -606,8 +662,10 @@ string MockS3DescribeObservations(const vector<MockS3RequestObservation> &observ
 		if (!result.empty()) {
 			result += "\n";
 		}
-		result += StringUtil::Format("%s %s status=%d key=%s range=%s target=%s", observation.method, observation.path,
-		                             observation.status, observation.key_id, observation.range, observation.target);
+		result += StringUtil::Format(
+		    "%s %s status=%d key=%s region=%s range=%s target=%s user_agent=%s session_header=%s", observation.method,
+		    observation.path, observation.status, observation.key_id, observation.region, observation.range,
+		    observation.target, observation.user_agent, observation.session_header);
 	}
 	return result;
 }

--- a/test/unittest/mock_s3_server.cpp
+++ b/test/unittest/mock_s3_server.cpp
@@ -104,6 +104,7 @@ struct MockS3Server::Impl {
 		remaining_get_failures = config.transient_get_failures;
 		remaining_range_behavior_requests = config.range_behavior_requests;
 		remaining_head_failures = config.transient_head_failures;
+		remaining_head_not_found = config.head_not_found_requests;
 		remaining_delete_failures = config.transient_delete_failures;
 		remaining_post_failures = config.transient_post_failures;
 		remaining_complete_post_failures = config.transient_complete_post_failures;
@@ -343,6 +344,12 @@ struct MockS3Server::Impl {
 				SendAuthFailure(request, response);
 				return httplib::Server::HandlerResponse::Handled;
 			}
+			if (remaining_head_not_found.load() > 0) {
+				remaining_head_not_found--;
+				response.status = 404;
+				Record(request, response.status);
+				return httplib::Server::HandlerResponse::Handled;
+			}
 			if (remaining_head_failures.load() > 0) {
 				remaining_head_failures--;
 				SendS3Error400(request, response, config.failure_is_request_timeout);
@@ -571,6 +578,7 @@ struct MockS3Server::Impl {
 	mutable std::atomic<idx_t> remaining_get_failures {0};
 	mutable std::atomic<idx_t> remaining_range_behavior_requests {0};
 	mutable std::atomic<idx_t> remaining_head_failures {0};
+	mutable std::atomic<idx_t> remaining_head_not_found {0};
 	mutable std::atomic<idx_t> remaining_delete_failures {0};
 	mutable std::atomic<idx_t> remaining_post_failures {0};
 	mutable std::atomic<idx_t> remaining_complete_post_failures {0};

--- a/test/unittest/mock_s3_server.hpp
+++ b/test/unittest/mock_s3_server.hpp
@@ -24,6 +24,8 @@ struct MockS3ServerConfig {
 	string object_key = "object.bin";
 	string object_data = "abcdefghijklmnopqrstuvwxyz0123456789";
 	string stale_key_id = "STALE_KEY";
+	int stale_auth_status = 403;
+	string stale_auth_error_code = "AccessDenied";
 	string etag = "\"httpfs-refresh-test-etag\"";
 	//! Redirect signed requests to this region when their credential scope uses a different one
 	string required_region;

--- a/test/unittest/mock_s3_server.hpp
+++ b/test/unittest/mock_s3_server.hpp
@@ -25,6 +25,8 @@ struct MockS3ServerConfig {
 	string object_data = "abcdefghijklmnopqrstuvwxyz0123456789";
 	string stale_key_id = "STALE_KEY";
 	string etag = "\"httpfs-refresh-test-etag\"";
+	//! Redirect signed requests to this region when their credential scope uses a different one
+	string required_region;
 	MockS3RefreshTarget refresh_target = MockS3RefreshTarget::HEAD;
 	//! Answer this many leading ListObjectsV2 requests with HTTP 503 SlowDown
 	idx_t transient_503_lists = 0;
@@ -70,6 +72,11 @@ struct MockS3RequestObservation {
 	string target;
 	string range;
 	string key_id;
+	string region;
+	string user_agent;
+	string session_header;
+	idx_t user_agent_count = 0;
+	idx_t session_header_count = 0;
 	int status = 0;
 	//! Client's ephemeral source port; a new connection shows a new port
 	int remote_port = 0;

--- a/test/unittest/mock_s3_server.hpp
+++ b/test/unittest/mock_s3_server.hpp
@@ -56,6 +56,8 @@ struct MockS3ServerConfig {
 	bool block_full_get_until_released = false;
 	//! Number of object HEADs to fail with a 400 before succeeding
 	idx_t transient_head_failures = 0;
+	//! Number of object HEADs to answer with 404 before succeeding
+	idx_t head_not_found_requests = 0;
 	//! Number of object DELETEs to fail with a 400 before succeeding
 	idx_t transient_delete_failures = 0;
 	//! Number of multipart-init POSTs (uploads=) to fail with a 400 before succeeding

--- a/test/unittest/short_read_test.cpp
+++ b/test/unittest/short_read_test.cpp
@@ -36,11 +36,11 @@ static void RequireQueryOk(Connection &con, const string &query) {
 	REQUIRE_FALSE(result->HasError());
 }
 
-static void ConfigureHTTPTest(DuckDB &db, Connection &con, idx_t retries,
-                              const string &client_implementation = "curl") {
+static void ConfigureHTTPTest(DuckDB &db, Connection &con, idx_t retries, const string &client_implementation = "curl",
+                              bool connection_caching = false) {
 	LoadHTTPFSExtension(db);
 	RequireQueryOk(con, "SET httpfs_client_implementation='" + client_implementation + "'");
-	RequireQueryOk(con, "SET httpfs_connection_caching=false");
+	RequireQueryOk(con, StringUtil::Format("SET httpfs_connection_caching=%s", connection_caching ? "true" : "false"));
 	RequireQueryOk(con, "SET http_retries=" + to_string(retries));
 	RequireQueryOk(con, "SET http_retry_wait_ms=1");
 	RequireQueryOk(con, "SET http_retry_backoff=1");
@@ -55,6 +55,17 @@ static idx_t CountRequests(const vector<MockS3RequestObservation> &observations,
 		}
 	}
 	return count;
+}
+
+static vector<int> RequestPorts(const vector<MockS3RequestObservation> &observations, const string &method, int status,
+                                const string &range = string()) {
+	vector<int> result;
+	for (auto &observation : observations) {
+		if (observation.method == method && observation.status == status && observation.range == range) {
+			result.push_back(observation.remote_port);
+		}
+	}
+	return result;
 }
 
 static idx_t CountRangeRequests(const vector<MockS3RequestObservation> &observations, int status) {
@@ -233,6 +244,55 @@ static void RunParallelRangeHeaderRelease(const string &client_implementation) {
 	RequireQueryOk(con, "COMMIT");
 }
 
+static void RunCompletedErrorConnectionReuse(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.transient_head_failures = 1;
+	config.failure_is_request_timeout = false;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureHTTPTest(db, con, 0, client_implementation);
+
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(server.HTTPPath(), FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	REQUIRE(handle);
+	RequireQueryOk(con, "COMMIT");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	auto error_ports = RequestPorts(observations, "HEAD", 400);
+	auto success_ports = RequestPorts(observations, "GET", 206, "bytes=0-1");
+	REQUIRE(error_ports.size() == 1);
+	REQUIRE(success_ports.size() == 1);
+	REQUIRE(error_ports[0] != 0);
+	REQUIRE(error_ports[0] == success_ports[0]);
+}
+
+static void RunSharedConnectionNotFoundReuse() {
+	MockS3ServerConfig config;
+	config.head_not_found_requests = 2;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureHTTPTest(db, con, 0, "curl", true);
+
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	REQUIRE_FALSE(fs.FileExists(server.HTTPPath()));
+	REQUIRE_FALSE(fs.FileExists(server.HTTPPath()));
+	RequireQueryOk(con, "COMMIT");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	auto not_found_ports = RequestPorts(observations, "HEAD", 404);
+	REQUIRE(not_found_ports.size() == 2);
+	REQUIRE(not_found_ports[0] != 0);
+	REQUIRE(not_found_ports[0] == not_found_ports[1]);
+}
+
 static void RunFullDownloadSingleFlight(const string &client_implementation, bool shared_handle) {
 	static constexpr idx_t READ_LENGTH = 1024;
 	const vector<idx_t> offsets {0, 2048, 4096, 6144};
@@ -314,6 +374,18 @@ TEST_CASE("HTTP range readers resume after the first response headers", "[httpfs
 	}
 	SECTION("httplib") {
 		RunParallelRangeHeaderRelease("httplib");
+	}
+}
+
+TEST_CASE("HTTP request sessions reuse connections after completed errors", "[httpfs][request-session]") {
+	SECTION("httplib reuses a session-local connection") {
+		RunCompletedErrorConnectionReuse("httplib");
+	}
+	SECTION("curl reuses a session-local connection") {
+		RunCompletedErrorConnectionReuse("curl");
+	}
+	SECTION("curl reuses a shared connection across missing-file probes") {
+		RunSharedConnectionNotFoundReuse();
 	}
 }
 

--- a/test/unittest/short_read_test.cpp
+++ b/test/unittest/short_read_test.cpp
@@ -222,12 +222,12 @@ static void RunParallelRangeHeaderRelease(const string &client_implementation) {
 	first_reader.join();
 	second_reader.join();
 
+	auto observations = server.Observations();
 	INFO(first_outcome.error);
 	INFO(second_outcome.error);
+	INFO(MockS3DescribeObservations(observations));
 	REQUIRE_FALSE(first_outcome.failed);
 	REQUIRE_FALSE(second_outcome.failed);
-	auto observations = server.Observations();
-	INFO(MockS3DescribeObservations(observations));
 	REQUIRE(CountRequests(observations, "GET", 206, "bytes=0-1023") == 1);
 	REQUIRE(CountRequests(observations, "GET", 206, "bytes=1024-2047") == 1);
 	RequireQueryOk(con, "COMMIT");


### PR DESCRIPTION
This PR replaces HTTPFS's mutable request/authentication state and handle-local client cache with immutable request
snapshots published through an `HTTPRequestSession`.

The main goal is to give each request a stable view of its HTTP and S3 configuration, while keeping credential refresh, region redirects, and scalar client reuse safe when requests overlap.

## Current Implementation

`HTTPFileHandle` currently owns an `HTTPInput`, references into its mutable parameters, and a separate `HTTPClientCache`. S3 adds another mutable input type for authentication and has similar, but separate, refresh paths for handles, LIST requests, and multipart operations.

This spreads request ownership across several objects and requires updating authentication, transport parameters, and
cached clients together.

## Request Sessions

`HTTPFileHandle` now owns one `HTTPRequestSession`. LIST/glob and bulk-delete operations create their own sessions, while multipart uploads share the file handle's session (pending changes when I get to the multi part upload).

Each request captures a `shared_ptr` to an immutable snapshot before building its URL, headers, and signature. Generic
HTTP snapshots own a copied `HTTPFSParams`; S3 snapshots additionally contain copied authentication state and a
credential generation. The mutable `HTTPFSParams` required by the current core HTTP API is created per request attempt and is not shared.

Scalar clients are checked out through an exclusive `HTTPClientLease`. Session-local clients are reinitialized when
reused, while curl's shared connection cache keeps its existing database-wide reuse behavior. Failed or invalidated
clients are not returned to either cache.

## Credential and Region Updates

Credential-provider I/O happens without holding the session lock. A completed refresh publishes a new snapshot using
a CAS loop, rebuilding it on top of the latest region and request state if another update won the race.
Region redirects use the same pattern and preserve concurrently refreshed credentials. Client invalidation has a
separate generation and therefore cannot reject a completed snapshot update.

All migrated S3 operations rebuild their signed request after a credential or region update, including reads, writes,
multipart requests, LIST, and bulk delete. HTTP 400 responses with `ExpiredToken`, `InvalidToken`, or `TokenRefreshRequired` are treated as credential failures, without retrying arbitrary bad requests.

## Thread Safety

The session, connection caches, metadata caches, credential-refresh coordination, and throughput state use annotated
mutexes. HTTP/client initialization, provider I/O, callbacks, client return, and object destruction happen outside these locks.