### PR TITLE
Remove read-ahead buffer and make positional reads independent

### DIFF
--- a/src/create_secret_functions.cpp
+++ b/src/create_secret_functions.cpp
@@ -153,7 +153,9 @@ CreateSecretInput CreateS3SecretFunctions::GenerateRefreshSecretInfo(const Secre
 	result.type = kv_secret.GetType();
 	result.name = kv_secret.GetName();
 	result.provider = Identifier(kv_secret.GetProvider());
-	result.storage_type = Identifier(secret_entry.storage_mode);
+	if (result.persist_type != SecretPersistType::TRANSACTION) {
+		result.storage_type = Identifier(secret_entry.storage_mode);
+	}
 	result.scope = kv_secret.GetScope();
 
 	auto result_child_count = StructType::GetChildCount(refresh_info.type());

--- a/src/hffs.cpp
+++ b/src/hffs.cpp
@@ -262,18 +262,21 @@ unique_ptr<HTTPResponse> HuggingFaceFileSystem::HeadRequest(FileHandle &handle, 
 }
 
 unique_ptr<HTTPResponse> HuggingFaceFileSystem::GetRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
+                                                           const HTTPReadConfig &read_config,
                                                            CachedFileDownload &download) {
 	auto &hf_handle = handle.Cast<HFFileHandle>();
 	auto http_url = HuggingFaceFileSystem::GetFileUrl(hf_handle.parsed_url);
-	return HTTPFileSystem::GetRequest(handle, http_url, header_map, download);
+	return HTTPFileSystem::GetRequest(handle, http_url, header_map, read_config, download);
 }
 
 unique_ptr<HTTPResponse> HuggingFaceFileSystem::GetRangeRequest(FileHandle &handle, string s3_url,
-                                                                HTTPHeaders header_map, idx_t file_offset,
+                                                                HTTPHeaders header_map,
+                                                                const HTTPReadConfig &read_config, idx_t file_offset,
                                                                 char *buffer_out, idx_t buffer_out_len) {
 	auto &hf_handle = handle.Cast<HFFileHandle>();
 	auto http_url = HuggingFaceFileSystem::GetFileUrl(hf_handle.parsed_url);
-	return HTTPFileSystem::GetRangeRequest(handle, http_url, header_map, file_offset, buffer_out, buffer_out_len);
+	return HTTPFileSystem::GetRangeRequest(handle, http_url, header_map, read_config, file_offset, buffer_out,
+	                                       buffer_out_len);
 }
 
 unique_ptr<HTTPFileHandle> HuggingFaceFileSystem::CreateHandle(const OpenFileInfo &file, FileOpenFlags flags,

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -17,7 +17,6 @@
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "http_state.hpp"
 
-#include <chrono>
 #include <map>
 #include <string>
 
@@ -399,8 +398,7 @@ HTTPFileHandle::HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpe
                                unique_ptr<HTTPParams> params_p)
     : FileHandle(fs, file.path, flags), request_session(make_shared_ptr<HTTPRequestSession>(
                                             make_shared_ptr<HTTPRequestSnapshot>(params_p->Cast<HTTPFSParams>()))),
-      flags(flags), length(0), last_modified(0), force_full_download(false), buffer_available(0), buffer_idx(0),
-      file_offset(0), buffer_start(0), buffer_end(0) {
+      flags(flags), length(0), last_modified(0), force_full_download(false), file_offset(0) {
 	// check if the handle has extended properties that can be set directly in the handle
 	// if we have these properties we don't need to do a head request to obtain them later
 	if (file.extended_info) {
@@ -480,16 +478,11 @@ unique_ptr<FileHandle> HTTPFileSystem::OpenFileExtended(const OpenFileInfo &file
 	return std::move(handle);
 }
 
-void HTTPFileHandle::AddStatistics(idx_t read_offset, idx_t read_length, idx_t read_duration) {
-	annotated_lock_guard<annotated_mutex> guard(throughput_lock);
-	range_request_statistics.push_back({read_offset, read_length, read_duration});
-}
-
 void HTTPFileHandle::RecordNetworkSample(double total_seconds, idx_t bytes, bool sample_has_ttfb, double ttfb_seconds) {
 	if (!(total_seconds > 0)) {
 		return;
 	}
-	annotated_lock_guard<annotated_mutex> guard(throughput_lock);
+	annotated_lock_guard<annotated_mutex> guard(network_estimator_lock);
 	const idx_t n = tp_sample_count + 1;
 	const double alpha = MaxValue<double>(0.2, 1.0 / static_cast<double>(n));
 
@@ -507,34 +500,13 @@ void HTTPFileHandle::RecordNetworkSample(double total_seconds, idx_t bytes, bool
 }
 
 bool HTTPFileHandle::TryGetNetworkThroughput(NetworkThroughputEstimate &result) {
-	annotated_lock_guard<annotated_mutex> guard(throughput_lock);
+	annotated_lock_guard<annotated_mutex> guard(network_estimator_lock);
 	if (tp_sample_count == 0 || tp_latency_seconds <= 0 || tp_bandwidth_bps <= 0) {
 		return false;
 	}
 	result.latency_seconds = tp_latency_seconds;
 	result.bandwidth_bytes_per_s = tp_bandwidth_bps;
 	return true;
-}
-
-void HTTPFileHandle::AdaptReadBufferSize(idx_t next_read_offset) {
-	D_ASSERT(!SkipBuffer());
-	{
-		annotated_lock_guard<annotated_mutex> guard(throughput_lock);
-		if (range_request_statistics.empty()) {
-			return;
-		}
-		const auto &last_read = range_request_statistics.back();
-		if (last_read.offset + last_read.length != next_read_offset) {
-			return;
-		}
-	}
-
-	if (read_buffer.GetSize() >= MAXIMUM_READ_BUFFER_LEN) {
-		return;
-	}
-	// Grow the buffer
-	// TODO: can use statistics to estimate per-byte and round-trip cost using least squares, and do something smarter
-	read_buffer = read_buffer.GetAllocator()->Allocate(read_buffer.GetSize() * 2);
 }
 
 static bool RespondedWithRangeRequestNotSupported(const HTTPResponse &res) {
@@ -550,7 +522,6 @@ bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders
                                      char *buffer_out, idx_t buffer_out_len) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
 
-	const auto timestamp_before = std::chrono::steady_clock::now();
 	auto res = GetRangeRequest(handle, url, header_map, file_offset, buffer_out, buffer_out_len);
 
 	if (res) {
@@ -569,14 +540,6 @@ bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders
 		// Request succeeded TODO: fix upstream that 206 is not considered success
 		if (res->Success() || res->status == HTTPStatusCode::PartialContent_206 ||
 		    res->status == HTTPStatusCode::Accepted_202) {
-			if (!hfh.flags.RequireParallelAccess()) {
-				// Update range request statistics
-				const auto timestamp_after = std::chrono::steady_clock::now();
-				const auto duration = NumericCast<idx_t>(
-				    std::chrono::duration_cast<std::chrono::microseconds>(timestamp_after - timestamp_before).count());
-				hfh.AddStatistics(file_offset, buffer_out_len, duration);
-			}
-
 			return true;
 		}
 
@@ -588,107 +551,35 @@ bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders
 
 bool HTTPFileSystem::ReadInternal(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
+	auto read_size = NumericCast<idx_t>(nr_bytes);
+	auto read_end = location + read_size;
 
 	D_ASSERT(hfh.file_state);
 	auto cached_file = hfh.file_state->TryGetCachedFileHandle();
 	if (cached_file) {
-		if (cached_file->GetSize() < location + nr_bytes) {
+		if (cached_file->GetSize() < read_end) {
 			throw IOException("Cached file length can't satisfy the requested Read. You can try to resolve this by "
 			                  "enabling `SET force_download=true`");
 		}
-		memcpy(buffer, cached_file->GetData() + location, nr_bytes);
-		DUCKDB_LOG_FILE_SYSTEM_READ(handle, nr_bytes, location);
-		if (hfh.flags.RequireParallelAccess()) {
-			std::lock_guard<mutex> lck(hfh.mu);
-			hfh.file_offset = location + nr_bytes;
-			return true;
+		if (read_size > 0) {
+			memcpy(buffer, cached_file->GetData() + location, read_size);
 		}
-		hfh.file_offset = location + nr_bytes;
-		return true;
-	}
-
-	idx_t to_read = nr_bytes;
-	idx_t buffer_offset = 0;
-
-	// Don't buffer when DirectIO is set or when we are doing parallel reads
-	if (hfh.SkipBuffer() && to_read > 0) {
-		if (!TryRangeRequest(hfh, hfh.path, {}, location, (char *)buffer, to_read)) {
+	} else if (read_size > 0) {
+		if (!TryRangeRequest(hfh, hfh.path, {}, location, static_cast<char *>(buffer), read_size)) {
 			return false;
 		}
-		DUCKDB_LOG_FILE_SYSTEM_READ(handle, nr_bytes, location);
-		// Update handle status within critical section for parallel access.
-		if (hfh.flags.RequireParallelAccess()) {
-			std::lock_guard<mutex> lck(hfh.mu);
-			hfh.buffer_available = 0;
-			hfh.buffer_idx = 0;
-			hfh.file_offset = location + nr_bytes;
-			return true;
-		}
-
-		hfh.buffer_available = 0;
-		hfh.buffer_idx = 0;
-		hfh.file_offset = location + nr_bytes;
-		return true;
 	}
 
-	if (location >= hfh.buffer_start && location < hfh.buffer_end) {
-		hfh.buffer_idx = location - hfh.buffer_start;
-		hfh.buffer_available = (hfh.buffer_end - hfh.buffer_start) - hfh.buffer_idx;
-	} else {
-		// reset buffer
-		hfh.buffer_available = 0;
-		hfh.buffer_idx = 0;
-	}
-
-	idx_t start_offset = location; // Start file offset to read from.
-	while (to_read > 0) {
-		auto buffer_read_len = MinValue<idx_t>(hfh.buffer_available, to_read);
-		if (buffer_read_len > 0) {
-			D_ASSERT(hfh.buffer_start + hfh.buffer_idx + buffer_read_len <= hfh.buffer_end);
-			memcpy((char *)buffer + buffer_offset, hfh.read_buffer.get() + hfh.buffer_idx, buffer_read_len);
-
-			buffer_offset += buffer_read_len;
-			to_read -= buffer_read_len;
-
-			hfh.buffer_idx += buffer_read_len;
-			hfh.buffer_available -= buffer_read_len;
-			start_offset += buffer_read_len;
-		}
-
-		if (to_read > 0 && hfh.buffer_available == 0) {
-			auto new_buffer_available = MinValue<idx_t>(hfh.read_buffer.GetSize(), hfh.length - start_offset);
-
-			// Bypass buffer if we read more than buffer size
-			if (to_read > new_buffer_available) {
-				if (!TryRangeRequest(hfh, hfh.path, {}, location + buffer_offset, (char *)buffer + buffer_offset,
-				                     to_read)) {
-					return false;
-				}
-				hfh.buffer_available = 0;
-				hfh.buffer_idx = 0;
-				start_offset += to_read;
-				break;
-			} else {
-				hfh.AdaptReadBufferSize(start_offset);
-				new_buffer_available = MinValue<idx_t>(hfh.read_buffer.GetSize(), hfh.length - start_offset);
-				if (!TryRangeRequest(hfh, hfh.path, {}, start_offset, (char *)hfh.read_buffer.get(),
-				                     new_buffer_available)) {
-					return false;
-				}
-				hfh.buffer_available = new_buffer_available;
-				hfh.buffer_idx = 0;
-				hfh.buffer_start = start_offset;
-				hfh.buffer_end = hfh.buffer_start + new_buffer_available;
-			}
-		}
-	}
-	hfh.file_offset = location + nr_bytes;
 	DUCKDB_LOG_FILE_SYSTEM_READ(handle, nr_bytes, location);
+	if (hfh.flags.RequireParallelAccess()) {
+		std::lock_guard<mutex> lck(hfh.mu);
+		hfh.file_offset = read_end;
+	} else {
+		hfh.file_offset = read_end;
+	}
 	return true;
 }
 
-// Buffered read from http file.
-// Note that buffering is disabled when FileFlags::FILE_FLAGS_DIRECT_IO is set
 void HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
 	auto success = ReadInternal(handle, buffer, nr_bytes, location);
 	if (success) {
@@ -729,10 +620,13 @@ void HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, id
 
 int64_t HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
-	idx_t max_read = hfh.length - hfh.file_offset;
-	nr_bytes = MinValue<idx_t>(max_read, nr_bytes);
-	Read(handle, buffer, nr_bytes, hfh.file_offset);
-	return nr_bytes;
+	auto read_size = NumericCast<idx_t>(nr_bytes);
+	if (read_size == 0 || hfh.file_offset >= hfh.length) {
+		return 0;
+	}
+	read_size = MinValue<idx_t>(hfh.length - hfh.file_offset, read_size);
+	Read(handle, buffer, NumericCast<int64_t>(read_size), hfh.file_offset);
+	return NumericCast<int64_t>(read_size);
 }
 
 void HTTPFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
@@ -987,14 +881,6 @@ void HTTPFileHandle::TryAddLogger(FileOpener &opener) {
 	}
 }
 
-void HTTPFileHandle::AllocateReadBuffer(optional_ptr<FileOpener> opener) {
-	D_ASSERT(!SkipBuffer());
-	D_ASSERT(!read_buffer.IsSet());
-	auto &allocator = opener && opener->TryGetClientContext() ? BufferAllocator::Get(*opener->TryGetClientContext())
-	                                                          : Allocator::DefaultAllocator();
-	read_buffer = allocator.Allocate(INITIAL_READ_BUFFER_LEN);
-}
-
 void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cache_entry) {
 	last_modified = cache_entry.last_modified;
 	length = cache_entry.length;
@@ -1052,10 +938,6 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 
 			if (found) {
 				InitializeFromCacheEntry(value);
-
-				if (flags.OpenForReading() && !SkipBuffer()) {
-					AllocateReadBuffer(opener);
-				}
 				return;
 			}
 
@@ -1077,11 +959,6 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 		}
 		if (should_write_cache) {
 			current_cache->Insert(path, GetCacheEntry());
-		}
-
-		if (!should_full_download && !SkipBuffer()) {
-			// Initialize the read buffer now that we know the file exists
-			AllocateReadBuffer(opener);
 		}
 	}
 

--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -130,6 +130,42 @@ static string StripETagQuotes(const string &etag) {
 	return etag;
 }
 
+static bool IsStrongETag(string etag) {
+	StringUtil::Trim(etag);
+	if (etag.size() < 2 || etag.front() != '"' || etag.back() != '"' || StringUtil::StartsWith(etag, "W/")) {
+		return false;
+	}
+	for (idx_t i = 1; i + 1 < etag.size(); i++) {
+		const auto character = static_cast<uint8_t>(etag[i]);
+		if (character <= 0x20 || character == 0x22 || character == 0x7F) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static void ApplyReadCondition(HTTPHeaders &headers, const HTTPReadConfig &read_config) {
+	if (read_config.condition.type == HTTPReadConditionType::ETAG) {
+		headers["If-Match"] = read_config.condition.value;
+	}
+}
+
+static HTTPHeaders RemoveRangeHeader(const HTTPHeaders &headers) {
+	HTTPHeaders result;
+	for (const auto &header : headers) {
+		if (!StringUtil::CIEquals(header.first, "Range")) {
+			result[header.first] = header.second;
+		}
+	}
+	return result;
+}
+
+static HTTPHeaders PrepareFullGetHeaders(const HTTPHeaders &headers, const HTTPReadConfig &read_config) {
+	auto result = RemoveRangeHeader(headers);
+	ApplyReadCondition(result, read_config);
+	return result;
+}
+
 static unique_ptr<HTTPResponse> SendSessionRequest(HTTPRequestSession &session,
                                                    const CapturedHTTPRequestSnapshot &captured,
                                                    HTTPFSParams &request_params, BaseRequest &request) {
@@ -149,7 +185,9 @@ static unique_ptr<HTTPResponse> SendSessionRequest(HTTPRequestSession &session,
 
 unique_ptr<HTTPResponse> HTTPFileSystem::RunHeadRequest(string url, HTTPHeaders header_map, HTTPFSParams &http_params,
                                                         HTTPSendCallback send_request) {
-	HeadRequestInfo head_request(url, header_map, http_params);
+	auto request_headers = RemoveRangeHeader(header_map);
+	http_params.extra_headers.erase("Range");
+	HeadRequestInfo head_request(url, request_headers, http_params);
 	return send_request(head_request);
 }
 
@@ -177,13 +215,23 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunPutRequest(string url, HTTPHeaders h
 }
 
 unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRequest(HTTPFileHandle &hfh, string url, HTTPHeaders header_map,
-                                                       HTTPFSParams &http_params, CachedFileDownload &download,
-                                                       HTTPErrorCallback get_error, HTTPSendCallback send_request) {
+                                                       HTTPFSParams &http_params, const HTTPReadConfig &read_config,
+                                                       CachedFileDownload &download, HTTPErrorCallback get_error,
+                                                       HTTPSendCallback send_request) {
+	auto request_headers = PrepareFullGetHeaders(header_map, read_config);
+	http_params.extra_headers.erase("Range");
 	GetRequestInfo get_request(
-	    url, header_map, http_params,
+	    url, request_headers, http_params,
 	    [&](const HTTPResponse &response) {
+		    if (response.status == HTTPStatusCode::PreconditionFailed_412 &&
+		        read_config.condition.type == HTTPReadConditionType::ETAG) {
+			    return false;
+		    }
 		    if (static_cast<int>(response.status) >= 400) {
 			    throw get_error(response);
+		    }
+		    if (static_cast<int>(response.status) < 300) {
+			    ValidateResponseETag(hfh, read_config, response);
 		    }
 		    download.Reset();
 		    optional_idx content_length;
@@ -196,12 +244,6 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRequest(HTTPFileHandle &hfh, stri
 		    }
 		    if (content_length.IsValid() && content_length.GetIndex() > 0) {
 			    download.Reserve(content_length.GetIndex());
-		    }
-		    if (http_params.s3_version_id_pinning && response.HasHeader("x-amz-version-id")) {
-			    lock_guard<mutex> lck(hfh.mu);
-			    if (hfh.version_id.empty()) {
-				    hfh.version_id = response.GetHeaderValue("x-amz-version-id");
-			    }
 		    }
 		    return true;
 	    },
@@ -222,19 +264,18 @@ static void SetRangeRequestNotSupported(HTTPResponse &response) {
 	}
 }
 
-unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh, string url, HTTPHeaders header_map,
-                                                            HTTPFSParams &http_params, const string &etag,
-                                                            bool auto_fallback_to_full_file_download, idx_t file_offset,
-                                                            char *buffer_out, idx_t buffer_out_len,
-                                                            HTTPErrorCallback get_error,
-                                                            HTTPSendCallback send_request) {
+unique_ptr<HTTPResponse>
+HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh, string url, HTTPHeaders header_map, HTTPFSParams &http_params,
+                                   const HTTPReadConfig &read_config, idx_t file_offset, char *buffer_out,
+                                   idx_t buffer_out_len, HTTPErrorCallback get_error, HTTPSendCallback send_request) {
 	// send the Range header to read only subset of file
 	string range_expr = "bytes=" + to_string(file_offset) + "-" + to_string(file_offset + buffer_out_len - 1);
-	header_map.Insert("Range", range_expr);
+	header_map["Range"] = range_expr;
+	ApplyReadCondition(header_map, read_config);
 
 	D_ASSERT(hfh.file_state);
-	auto range_request = hfh.file_state->BeginRangeRequest(auto_fallback_to_full_file_download);
-	if (range_request.Support() == RangeRequestSupport::NOT_SUPPORTED && auto_fallback_to_full_file_download) {
+	auto range_request = hfh.file_state->BeginRangeRequest(read_config.auto_fallback_to_full_download);
+	if (range_request.Support() == RangeRequestSupport::NOT_SUPPORTED && read_config.auto_fallback_to_full_download) {
 		auto response = make_uniq<HTTPResponse>(HTTPStatusCode::INVALID);
 		SetRangeRequestNotSupported(*response);
 		return response;
@@ -245,35 +286,16 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh,
 	GetRequestInfo get_request(
 	    url, header_map, http_params,
 	    [&](const HTTPResponse &response) {
+		    if (response.status == HTTPStatusCode::PreconditionFailed_412 &&
+		        read_config.condition.type == HTTPReadConditionType::ETAG) {
+			    return false;
+		    }
 		    if (static_cast<int>(response.status) >= 400) {
 			    throw get_error(response);
 		    }
 		    if (static_cast<int>(response.status) < 300) { // done redirecting
 			    out_offset = 0;
-
-			    if (!http_params.unsafe_disable_etag_checks && !etag.empty() && response.HasHeader("ETag")) {
-				    string responseEtag = response.GetHeaderValue("ETag");
-
-				    if (!responseEtag.empty() && StripETagQuotes(responseEtag) != StripETagQuotes(etag)) {
-					    EraseGlobalCacheEntry(hfh.path);
-					    throw HTTPException(
-					        response,
-					        "ETag on reading file \"%s\" was initially %s and now it returned %s, this likely means "
-					        "the remote file has changed.\nFor parquet or similar single table sources, consider "
-					        "retrying the query, for "
-					        "persistent FileHandles such as databases consider `DETACH` and re-`ATTACH` "
-					        "\nYou can disable checking etags via `SET "
-					        "unsafe_disable_etag_checks = true;`",
-					        hfh.path, etag, response.GetHeaderValue("ETag"));
-				    }
-			    }
-
-			    if (http_params.s3_version_id_pinning && response.HasHeader("x-amz-version-id")) {
-				    lock_guard<mutex> lck(hfh.mu);
-				    if (hfh.version_id.empty()) {
-					    hfh.version_id = response.GetHeaderValue("x-amz-version-id");
-				    }
-			    }
+			    ValidateResponseETag(hfh, read_config, response);
 
 			    if (response.HasHeader("Content-Length")) {
 				    unsigned long long content_length;
@@ -308,7 +330,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh,
 		    return true;
 	    });
 
-	get_request.try_request = auto_fallback_to_full_file_download;
+	get_request.try_request = read_config.auto_fallback_to_full_download;
 	auto response = send_request(get_request);
 	if (range_request_not_supported) {
 		SetRangeRequestNotSupported(*response);
@@ -366,14 +388,44 @@ HTTPException HTTPFileSystem::GetHTTPError(FileHandle &, const HTTPResponse &res
 	return HTTPException(response, error);
 }
 
+void HTTPFileSystem::ValidateResponseETag(HTTPFileHandle &hfh, const HTTPReadConfig &read_config,
+                                          const HTTPResponse &response) {
+	if (!read_config.validate_etag || read_config.etag.empty() || !response.HasHeader("ETag")) {
+		return;
+	}
+	auto response_etag = response.GetHeaderValue("ETag");
+	if (response_etag.empty() || StripETagQuotes(response_etag) == StripETagQuotes(read_config.etag)) {
+		return;
+	}
+	EraseGlobalCacheEntry(hfh.path);
+	throw HTTPException(
+	    response,
+	    "ETag on reading file \"%s\" was initially %s and now it returned %s, this likely means "
+	    "the remote file has changed.\nFor parquet or similar single table sources, consider "
+	    "retrying the query, for persistent FileHandles such as databases consider `DETACH` and re-`ATTACH` "
+	    "\nYou can disable checking etags via `SET unsafe_disable_etag_checks = true;`",
+	    hfh.path, read_config.etag, response_etag);
+}
+
+void HTTPFileSystem::ThrowIfReadConditionFailed(HTTPFileHandle &hfh, const HTTPReadConfig &read_config,
+                                                const HTTPResponse &response) {
+	if (response.status != HTTPStatusCode::PreconditionFailed_412 ||
+	    read_config.condition.type != HTTPReadConditionType::ETAG) {
+		return;
+	}
+	EraseGlobalCacheEntry(hfh.path);
+	throw HTTPException(response, "ETag on reading file \"%s\" changed after it was opened: the server rejected %s",
+	                    hfh.path, read_config.condition.value);
+}
+
 unique_ptr<HTTPResponse> HTTPFileSystem::GetRequest(FileHandle &handle, string url, HTTPHeaders header_map,
-                                                    CachedFileDownload &download) {
+                                                    const HTTPReadConfig &read_config, CachedFileDownload &download) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
 	auto captured = hfh.request_session->Capture();
 	captured.snapshot->AddConfiguredHeaders(header_map);
 	auto request_params = captured.snapshot->CreateRequestParams();
 	return RunGetRequest(
-	    hfh, url, header_map, *request_params, download,
+	    hfh, url, header_map, *request_params, read_config, download,
 	    [&](const HTTPResponse &response) { return GetHTTPError(handle, response, url); },
 	    [&](BaseRequest &request) {
 		    return SendSessionRequest(*hfh.request_session, captured, *request_params, request);
@@ -381,14 +433,15 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRequest(FileHandle &handle, string u
 }
 
 unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, string url, HTTPHeaders header_map,
-                                                         idx_t file_offset, char *buffer_out, idx_t buffer_out_len) {
+                                                         const HTTPReadConfig &read_config, idx_t file_offset,
+                                                         char *buffer_out, idx_t buffer_out_len) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
 	auto captured = hfh.request_session->Capture();
 	captured.snapshot->AddConfiguredHeaders(header_map);
 	auto request_params = captured.snapshot->CreateRequestParams();
 	return RunGetRangeRequest(
-	    hfh, url, header_map, *request_params, hfh.etag, hfh.auto_fallback_to_full_file_download, file_offset,
-	    buffer_out, buffer_out_len, [&](const HTTPResponse &response) { return GetHTTPError(handle, response, url); },
+	    hfh, url, header_map, *request_params, read_config, file_offset, buffer_out, buffer_out_len,
+	    [&](const HTTPResponse &response) { return GetHTTPError(handle, response, url); },
 	    [&](BaseRequest &request) {
 		    return SendSessionRequest(*hfh.request_session, captured, *request_params, request);
 	    });
@@ -425,6 +478,42 @@ HTTPFileHandle::HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpe
 			initialized = true;
 		}
 	}
+}
+
+HTTPReadConfig HTTPFileHandle::BuildReadConfig() const {
+	auto captured = request_session->Capture();
+	auto &params = captured.snapshot->Params();
+
+	HTTPReadConfig result;
+	result.etag = etag;
+	result.validate_etag = !params.unsafe_disable_etag_checks;
+	result.auto_fallback_to_full_download =
+	    auto_fallback_to_full_file_download && params.auto_fallback_to_full_download;
+	if (result.validate_etag && IsStrongETag(result.etag)) {
+		result.condition.type = HTTPReadConditionType::ETAG;
+		result.condition.value = result.etag;
+		StringUtil::Trim(result.condition.value);
+	}
+	return result;
+}
+
+void HTTPFileHandle::FinalizeReadConfig() {
+	D_ASSERT(!read_config_initialized);
+	read_config = BuildReadConfig();
+	read_config_initialized = true;
+}
+
+const HTTPReadConfig &HTTPFileHandle::GetReadConfig() const {
+	D_ASSERT(read_config_initialized);
+	return read_config;
+}
+
+string HTTPFileHandle::GetVersionId() const {
+	return version_id;
+}
+
+void HTTPFileHandle::SetVersionId(string version_id_p) {
+	version_id = std::move(version_id_p);
 }
 
 unique_ptr<HTTPFileHandle> HTTPFileSystem::CreateHandle(const OpenFileInfo &file, FileOpenFlags flags,
@@ -518,20 +607,20 @@ static bool RespondedWithRangeRequestNotSupported(const HTTPResponse &res) {
 	       error.RawMessage() == RangeRequestNotSupportedException::MESSAGE;
 }
 
-bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders header_map, idx_t file_offset,
-                                     char *buffer_out, idx_t buffer_out_len) {
+bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders header_map,
+                                     const HTTPReadConfig &read_config, idx_t file_offset, char *buffer_out,
+                                     idx_t buffer_out_len) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
 
-	auto res = GetRangeRequest(handle, url, header_map, file_offset, buffer_out, buffer_out_len);
+	auto res = GetRangeRequest(handle, url, header_map, read_config, file_offset, buffer_out, buffer_out_len);
 
 	if (res) {
+		ThrowIfReadConditionFailed(hfh, read_config, *res);
 		// Request failed and we have a request error
 		if (res->HasRequestError()) {
 			// Special case: we can do a retry with a full file download
-			if (RespondedWithRangeRequestNotSupported(*res)) {
-				if (hfh.request_session->Capture().snapshot->Params().auto_fallback_to_full_download) {
-					return false;
-				}
+			if (RespondedWithRangeRequestNotSupported(*res) && read_config.auto_fallback_to_full_download) {
+				return false;
 			}
 			ErrorData error(res->GetRequestError());
 			error.Throw();
@@ -549,9 +638,12 @@ bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders
 	throw IOException("Unknown error for HTTP %s to '%s'", EnumUtil::ToString(RequestType::GET_REQUEST), url);
 }
 
-bool HTTPFileSystem::ReadInternal(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+bool HTTPFileSystem::ReadAt(FileHandle &handle, void *buffer, idx_t read_size, idx_t location,
+                            const HTTPReadConfig &read_config) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
-	auto read_size = NumericCast<idx_t>(nr_bytes);
+	if (read_size > NumericLimits<idx_t>::Maximum() - location) {
+		throw IOException("HTTP read range overflow for file \"%s\"", hfh.path);
+	}
 	auto read_end = location + read_size;
 
 	D_ASSERT(hfh.file_state);
@@ -565,28 +657,23 @@ bool HTTPFileSystem::ReadInternal(FileHandle &handle, void *buffer, int64_t nr_b
 			memcpy(buffer, cached_file->GetData() + location, read_size);
 		}
 	} else if (read_size > 0) {
-		if (!TryRangeRequest(hfh, hfh.path, {}, location, static_cast<char *>(buffer), read_size)) {
+		if (!TryRangeRequest(hfh, hfh.path, {}, read_config, location, static_cast<char *>(buffer), read_size)) {
 			return false;
 		}
 	}
 
-	DUCKDB_LOG_FILE_SYSTEM_READ(handle, nr_bytes, location);
-	if (hfh.flags.RequireParallelAccess()) {
-		std::lock_guard<mutex> lck(hfh.mu);
-		hfh.file_offset = read_end;
-	} else {
-		hfh.file_offset = read_end;
-	}
+	DUCKDB_LOG_FILE_SYSTEM_READ(handle, NumericCast<int64_t>(read_size), location);
 	return true;
 }
 
-void HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
-	auto success = ReadInternal(handle, buffer, nr_bytes, location);
+void HTTPFileSystem::ReadAtWithFallback(FileHandle &handle, void *buffer, idx_t read_size, idx_t location,
+                                        const HTTPReadConfig &read_config) {
+	auto success = ReadAt(handle, buffer, read_size, location, read_config);
 	if (success) {
 		return;
 	}
 
-	// ReadInternal returned false. This means the regular path of querying the file with range requests failed. We will
+	// ReadAt returned false. This means the regular path of querying the file with range requests failed. We will
 	// attempt to download the full file and retry.
 
 	if (handle.logger) {
@@ -600,7 +687,7 @@ void HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, id
 	const auto head_reported_length = hfh.length;
 
 	bool should_write_cache = false;
-	auto cached_file = FullDownload(hfh, should_write_cache);
+	auto cached_file = FullDownload(hfh, read_config, should_write_cache);
 
 	const auto downloaded_length = cached_file->GetSize();
 	if (downloaded_length != head_reported_length) {
@@ -613,19 +700,33 @@ void HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, id
 		    static_cast<unsigned long long>(downloaded_length)));
 	}
 
-	if (!ReadInternal(handle, buffer, nr_bytes, location)) {
+	if (!ReadAt(handle, buffer, read_size, location, read_config)) {
 		throw HTTPException("Failed to read from HTTP file after automatically retrying a full file download.");
 	}
+}
+
+void HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	auto &hfh = handle.Cast<HTTPFileHandle>();
+	auto read_size = NumericCast<idx_t>(nr_bytes);
+	if (read_size == 0) {
+		return;
+	}
+	auto read_config = hfh.GetReadConfig();
+	ReadAtWithFallback(handle, buffer, read_size, location, read_config);
 }
 
 int64_t HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
 	auto read_size = NumericCast<idx_t>(nr_bytes);
+	annotated_lock_guard<annotated_mutex> guard(hfh.cursor_mutex);
 	if (read_size == 0 || hfh.file_offset >= hfh.length) {
 		return 0;
 	}
 	read_size = MinValue<idx_t>(hfh.length - hfh.file_offset, read_size);
-	Read(handle, buffer, NumericCast<int64_t>(read_size), hfh.file_offset);
+	const auto location = hfh.file_offset;
+	auto read_config = hfh.GetReadConfig();
+	ReadAtWithFallback(handle, buffer, read_size, location, read_config);
+	hfh.file_offset += read_size;
 	return NumericCast<int64_t>(read_size);
 }
 
@@ -635,7 +736,12 @@ void HTTPFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, i
 
 int64_t HTTPFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
-	Write(handle, buffer, nr_bytes, hfh.file_offset);
+	idx_t location;
+	{
+		annotated_lock_guard<annotated_mutex> guard(hfh.cursor_mutex);
+		location = hfh.file_offset;
+	}
+	Write(handle, buffer, nr_bytes, location);
 	return nr_bytes;
 }
 
@@ -674,11 +780,13 @@ bool HTTPFileSystem::CanHandleFile(const string &fpath) {
 
 void HTTPFileSystem::Seek(FileHandle &handle, idx_t location) {
 	auto &sfh = handle.Cast<HTTPFileHandle>();
+	annotated_lock_guard<annotated_mutex> guard(sfh.cursor_mutex);
 	sfh.file_offset = location;
 }
 
 idx_t HTTPFileSystem::SeekPosition(FileHandle &handle) {
 	auto &sfh = handle.Cast<HTTPFileHandle>();
+	annotated_lock_guard<annotated_mutex> guard(sfh.cursor_mutex);
 	return sfh.file_offset;
 }
 
@@ -720,7 +828,8 @@ static optional_ptr<HTTPMetadataCache> TryGetMetadataCache(optional_ptr<FileOpen
 	return nullptr;
 }
 
-unique_ptr<CachedFileHandle> HTTPFileSystem::FullDownload(HTTPFileHandle &hfh, bool &should_write_cache) {
+unique_ptr<CachedFileHandle> HTTPFileSystem::FullDownload(HTTPFileHandle &hfh, const HTTPReadConfig &read_config,
+                                                          bool &should_write_cache) {
 	D_ASSERT(hfh.file_state);
 	D_ASSERT(hfh.buffer_allocator);
 	should_write_cache = false;
@@ -734,7 +843,8 @@ unique_ptr<CachedFileHandle> HTTPFileSystem::FullDownload(HTTPFileHandle &hfh, b
 		if (!download) {
 			continue;
 		}
-		auto full_download_result = GetRequest(hfh, hfh.path, {}, *download);
+		auto full_download_result = GetRequest(hfh, hfh.path, {}, read_config, *download);
+		ThrowIfReadConditionFailed(hfh, read_config, *full_download_result);
 		if (full_download_result->status != HTTPStatusCode::OK_200) {
 			throw HTTPException(*full_download_result, "Full download failed to to URL \"%s\": %d (%s)",
 			                    full_download_result->url, static_cast<int>(full_download_result->status),
@@ -823,12 +933,13 @@ void HTTPFileHandle::LoadFileInfo() {
 			// HEAD request fail, use Range request for another try (read only one byte)
 			if (flags.OpenForReading() && res->status != HTTPStatusCode::NotFound_404 &&
 			    res->status != HTTPStatusCode::MovedPermanently_301) {
-				auto range_res = hfs.GetRangeRequest(*this, path, {}, 0, nullptr, 2);
+				auto read_config = BuildReadConfig();
+				auto range_res = hfs.GetRangeRequest(*this, path, {}, read_config, 0, nullptr, 2);
 				if (range_res->status != HTTPStatusCode::PartialContent_206 &&
 				    range_res->status != HTTPStatusCode::Accepted_202 && range_res->status != HTTPStatusCode::OK_200) {
 					// It failed again, check whether we can fall back to full download
 					if (RespondedWithRangeRequestNotSupported(*range_res) &&
-					    request_session->Capture().snapshot->Params().auto_fallback_to_full_download) {
+					    read_config.auto_fallback_to_full_download) {
 						force_full_download = true;
 					} else {
 						throw hfs.GetHTTPError(*this, *range_res, path);
@@ -857,7 +968,7 @@ void HTTPFileHandle::LoadFileInfo() {
 	}
 	if (request_session->Capture().snapshot->Params().s3_version_id_pinning &&
 	    res->headers.HasHeader("x-amz-version-id")) {
-		version_id = res->headers.GetHeaderValue("x-amz-version-id");
+		SetVersionId(res->headers.GetHeaderValue("x-amz-version-id"));
 	}
 	if (res->headers.HasHeader("Accept-Ranges")) {
 		auto accept_ranges = res->headers.GetHeaderValue("Accept-Ranges");
@@ -885,7 +996,7 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
 	last_modified = cache_entry.last_modified;
 	length = cache_entry.length;
 	etag = cache_entry.etag;
-	version_id = cache_entry.version_id;
+	SetVersionId(cache_entry.version_id);
 
 	// TODO: handle properties
 }
@@ -895,7 +1006,7 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
 	result.length = length;
 	result.last_modified = last_modified;
 	result.etag = etag;
-	result.version_id = version_id;
+	result.version_id = GetVersionId();
 	// TODO: handle properties
 	return result;
 }
@@ -928,7 +1039,8 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 	bool should_write_cache = false;
 	if (flags.OpenForReading()) {
 		if (request_snapshot->Params().force_download) {
-			length = hfs.FullDownload(*this, should_write_cache)->GetSize();
+			FinalizeReadConfig();
+			length = hfs.FullDownload(*this, GetReadConfig(), should_write_cache)->GetSize();
 			return;
 		}
 
@@ -938,6 +1050,7 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 
 			if (found) {
 				InitializeFromCacheEntry(value);
+				FinalizeReadConfig();
 				return;
 			}
 
@@ -945,6 +1058,7 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 		}
 	}
 	LoadFileInfo();
+	FinalizeReadConfig();
 
 	if (flags.OpenForReading()) {
 
@@ -955,7 +1069,7 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 		const auto should_full_download = has_cache_state || meets_threshold || always_download;
 
 		if (should_full_download) {
-			length = hfs.FullDownload(*this, should_write_cache)->GetSize();
+			length = hfs.FullDownload(*this, GetReadConfig(), should_write_cache)->GetSize();
 		}
 		if (should_write_cache) {
 			current_cache->Insert(path, GetCacheEntry());

--- a/src/include/hffs.hpp
+++ b/src/include/hffs.hpp
@@ -26,10 +26,11 @@ public:
 
 	duckdb::unique_ptr<HTTPResponse> HeadRequest(FileHandle &handle, string hf_url, HTTPHeaders header_map) override;
 	duckdb::unique_ptr<HTTPResponse> GetRequest(FileHandle &handle, string hf_url, HTTPHeaders header_map,
+	                                            const HTTPReadConfig &read_config,
 	                                            CachedFileDownload &download) override;
 	duckdb::unique_ptr<HTTPResponse> GetRangeRequest(FileHandle &handle, string hf_url, HTTPHeaders header_map,
-	                                                 idx_t file_offset, char *buffer_out,
-	                                                 idx_t buffer_out_len) override;
+	                                                 const HTTPReadConfig &read_config, idx_t file_offset,
+	                                                 char *buffer_out, idx_t buffer_out_len) override;
 
 	bool CanHandleFile(const string &fpath) override {
 		return fpath.rfind("hf://", 0) == 0;

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -59,53 +59,23 @@ public:
 	shared_ptr<HTTPFileState> file_state;
 	optional_ptr<Allocator> buffer_allocator;
 
-	// Read info
-	idx_t buffer_available;
-	idx_t buffer_idx;
+	// Sequential read position
 	idx_t file_offset;
-	idx_t buffer_start;
-	idx_t buffer_end;
 
 	// Used when file handle created with parallel access flag specified.
 	mutex mu;
 
-	// Read buffer
-	AllocatedData read_buffer;
-	constexpr static idx_t INITIAL_READ_BUFFER_LEN = 1048576;
-	constexpr static idx_t MAXIMUM_READ_BUFFER_LEN = 33554432;
-
-	// Adaptively resizes read_buffer based on range_request_statistics
-	void AddStatistics(idx_t read_offset, idx_t read_length, idx_t read_duration) DUCKDB_EXCLUDES(throughput_lock);
-	void AdaptReadBufferSize(idx_t next_read_offset) DUCKDB_EXCLUDES(throughput_lock);
-
 	// Record a completed range request into the network throughput estimate (latency + bandwidth)
 	void RecordNetworkSample(double total_seconds, idx_t bytes, bool sample_has_ttfb, double ttfb_seconds)
-	    DUCKDB_EXCLUDES(throughput_lock);
+	    DUCKDB_EXCLUDES(network_estimator_lock);
 	// Expose the measured network throughput estimate to the (parquet) prefetch cost model.
-	bool TryGetNetworkThroughput(NetworkThroughputEstimate &result) DUCKDB_EXCLUDES(throughput_lock);
-
-	// Whether to bypass the read buffer
-	bool SkipBuffer() const {
-		return flags.DirectIO() || flags.RequireParallelAccess();
-	}
+	bool TryGetNetworkThroughput(NetworkThroughputEstimate &result) DUCKDB_EXCLUDES(network_estimator_lock);
 
 private:
-	void AllocateReadBuffer(optional_ptr<FileOpener> opener);
-
-	// Statistics that are used to adaptively grow the read_buffer
-	struct RangeRequestStatistics {
-		idx_t offset;
-		idx_t length;
-		idx_t duration;
-	};
-	vector<RangeRequestStatistics> range_request_statistics DUCKDB_GUARDED_BY(throughput_lock);
-
-	// throughput_lock guards the throughput estimate (fed by RecordNetworkSample) and range_request_statistics against
-	// concurrent prefetch reads.
-	mutable annotated_mutex throughput_lock;
-	double tp_latency_seconds DUCKDB_GUARDED_BY(throughput_lock) = 0;
-	double tp_bandwidth_bps DUCKDB_GUARDED_BY(throughput_lock) = 0;
-	idx_t tp_sample_count DUCKDB_GUARDED_BY(throughput_lock) = 0;
+	mutable annotated_mutex network_estimator_lock;
+	double tp_latency_seconds DUCKDB_GUARDED_BY(network_estimator_lock) = 0;
+	double tp_bandwidth_bps DUCKDB_GUARDED_BY(network_estimator_lock) = 0;
+	idx_t tp_sample_count DUCKDB_GUARDED_BY(network_estimator_lock) = 0;
 	// Minimum payload size for a request to contribute a bandwidth sample
 	constexpr static idx_t MIN_BANDWIDTH_SAMPLE_BYTES = 1 << 16; // 64 KiB
 
@@ -198,7 +168,7 @@ protected:
 	virtual unique_ptr<HTTPFileHandle> CreateHandle(const OpenFileInfo &file, FileOpenFlags flags,
 	                                                optional_ptr<FileOpener> opener);
 
-	//! Internal read helpers shared by buffered and direct reads.
+	//! Internal read helpers.
 	bool TryRangeRequest(FileHandle &handle, string url, HTTPHeaders header_map, idx_t file_offset, char *buffer_out,
 	                     idx_t buffer_out_len);
 	bool ReadInternal(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location);

--- a/src/include/httpfs.hpp
+++ b/src/include/httpfs.hpp
@@ -15,6 +15,20 @@
 
 namespace duckdb {
 
+enum class HTTPReadConditionType : uint8_t { NONE, ETAG, S3_VERSION_ID };
+
+struct HTTPReadCondition {
+	HTTPReadConditionType type = HTTPReadConditionType::NONE;
+	string value;
+};
+
+struct HTTPReadConfig {
+	HTTPReadCondition condition;
+	string etag;
+	bool validate_etag = false;
+	bool auto_fallback_to_full_download = false;
+};
+
 class RangeRequestNotSupportedException {
 public:
 	// Call static Throw instead: if thrown as exception DuckDB can't catch it.
@@ -31,8 +45,12 @@ public:
 };
 
 class HTTPFileSystem;
+class S3FileSystem;
 
 class HTTPFileHandle : public FileHandle {
+	friend class HTTPFileSystem;
+	friend class S3FileSystem;
+
 public:
 	HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags, unique_ptr<HTTPParams> params);
 	~HTTPFileHandle() override;
@@ -46,7 +64,6 @@ public:
 	idx_t length;
 	timestamp_t last_modified;
 	string etag;
-	string version_id;
 	bool force_full_download;
 	bool initialized = false;
 
@@ -59,11 +76,9 @@ public:
 	shared_ptr<HTTPFileState> file_state;
 	optional_ptr<Allocator> buffer_allocator;
 
-	// Sequential read position
-	idx_t file_offset;
-
-	// Used when file handle created with parallel access flag specified.
-	mutex mu;
+	const HTTPReadConfig &GetReadConfig() const;
+	string GetVersionId() const;
+	void SetVersionId(string version_id);
 
 	// Record a completed range request into the network throughput estimate (latency + bandwidth)
 	void RecordNetworkSample(double total_seconds, idx_t bytes, bool sample_has_ttfb, double ttfb_seconds)
@@ -72,6 +87,14 @@ public:
 	bool TryGetNetworkThroughput(NetworkThroughputEstimate &result) DUCKDB_EXCLUDES(network_estimator_lock);
 
 private:
+	// Sequential read/write position
+	mutable annotated_mutex cursor_mutex;
+	idx_t file_offset DUCKDB_GUARDED_BY(cursor_mutex);
+
+	string version_id;
+	HTTPReadConfig read_config;
+	bool read_config_initialized = false;
+
 	mutable annotated_mutex network_estimator_lock;
 	double tp_latency_seconds DUCKDB_GUARDED_BY(network_estimator_lock) = 0;
 	double tp_bandwidth_bps DUCKDB_GUARDED_BY(network_estimator_lock) = 0;
@@ -85,6 +108,7 @@ public:
 
 protected:
 	virtual shared_ptr<const HTTPRequestSnapshot> CreateRequestSnapshot(const HTTPFSParams &params) const;
+	virtual HTTPReadConfig BuildReadConfig() const;
 	//! Perform a HEAD request to get the file info (if not yet loaded)
 	void LoadFileInfo();
 	//! TODO: make base function virtual?
@@ -92,6 +116,9 @@ protected:
 
 	virtual void InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cache_entry);
 	virtual HTTPMetadataCacheEntry GetCacheEntry() const;
+
+private:
+	void FinalizeReadConfig();
 };
 
 class HTTPFileSystem : public FileSystem {
@@ -150,13 +177,15 @@ public:
 	virtual unique_ptr<HTTPResponse> HeadRequest(FileHandle &handle, string url, HTTPHeaders header_map);
 	// Get Request with range parameter that GETs exactly buffer_out_len bytes from the url
 	virtual unique_ptr<HTTPResponse> GetRangeRequest(FileHandle &handle, string url, HTTPHeaders header_map,
-	                                                 idx_t file_offset, char *buffer_out, idx_t buffer_out_len);
+	                                                 const HTTPReadConfig &read_config, idx_t file_offset,
+	                                                 char *buffer_out, idx_t buffer_out_len);
 	// Get Request without a range (i.e., downloads full file)
 	virtual unique_ptr<HTTPResponse> GetRequest(FileHandle &handle, string url, HTTPHeaders header_map,
-	                                            CachedFileDownload &download);
+	                                            const HTTPReadConfig &read_config, CachedFileDownload &download);
 	virtual unique_ptr<HTTPResponse> DeleteRequest(FileHandle &handle, string url, HTTPHeaders header_map);
 	//! Fully download a file, or wait for an in-progress download of the same path
-	unique_ptr<CachedFileHandle> FullDownload(HTTPFileHandle &handle, bool &should_write_cache);
+	unique_ptr<CachedFileHandle> FullDownload(HTTPFileHandle &handle, const HTTPReadConfig &read_config,
+	                                          bool &should_write_cache);
 
 protected:
 	//! FileSystem extension points used by HTTP handle setup.
@@ -169,9 +198,11 @@ protected:
 	                                                optional_ptr<FileOpener> opener);
 
 	//! Internal read helpers.
-	bool TryRangeRequest(FileHandle &handle, string url, HTTPHeaders header_map, idx_t file_offset, char *buffer_out,
-	                     idx_t buffer_out_len);
-	bool ReadInternal(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location);
+	bool TryRangeRequest(FileHandle &handle, string url, HTTPHeaders header_map, const HTTPReadConfig &read_config,
+	                     idx_t file_offset, char *buffer_out, idx_t buffer_out_len);
+	bool ReadAt(FileHandle &handle, void *buffer, idx_t read_size, idx_t location, const HTTPReadConfig &read_config);
+	void ReadAtWithFallback(FileHandle &handle, void *buffer, idx_t read_size, idx_t location,
+	                        const HTTPReadConfig &read_config);
 
 	//! Shared request runners used by subclasses that need custom request setup/retry behavior.
 	using HTTPSendCallback = std::function<unique_ptr<HTTPResponse>(BaseRequest &)>;
@@ -188,15 +219,18 @@ protected:
 	                                       char *buffer_in, idx_t buffer_in_len, const string &content_type,
 	                                       HTTPSendCallback send_request);
 	unique_ptr<HTTPResponse> RunGetRequest(HTTPFileHandle &handle, string url, HTTPHeaders header_map,
-	                                       HTTPFSParams &http_params, CachedFileDownload &download,
-	                                       HTTPErrorCallback get_error, HTTPSendCallback send_request);
+	                                       HTTPFSParams &http_params, const HTTPReadConfig &read_config,
+	                                       CachedFileDownload &download, HTTPErrorCallback get_error,
+	                                       HTTPSendCallback send_request);
 	unique_ptr<HTTPResponse> RunGetRangeRequest(HTTPFileHandle &handle, string url, HTTPHeaders header_map,
-	                                            HTTPFSParams &http_params, const string &etag,
-	                                            bool auto_fallback_to_full_file_download, idx_t file_offset,
-	                                            char *buffer_out, idx_t buffer_out_len, HTTPErrorCallback get_error,
-	                                            HTTPSendCallback send_request);
+	                                            HTTPFSParams &http_params, const HTTPReadConfig &read_config,
+	                                            idx_t file_offset, char *buffer_out, idx_t buffer_out_len,
+	                                            HTTPErrorCallback get_error, HTTPSendCallback send_request);
 
 private:
+	void ValidateResponseETag(HTTPFileHandle &handle, const HTTPReadConfig &read_config, const HTTPResponse &response);
+	void ThrowIfReadConditionFailed(HTTPFileHandle &handle, const HTTPReadConfig &read_config,
+	                                const HTTPResponse &response);
 	void EraseGlobalCacheEntry(const string &path) DUCKDB_EXCLUDES(global_cache_lock);
 
 	// Global cache

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -164,6 +164,7 @@ public:
 
 protected:
 	shared_ptr<const HTTPRequestSnapshot> CreateRequestSnapshot(const HTTPFSParams &params) const override;
+	HTTPReadConfig BuildReadConfig() const override;
 	void InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cache_entry) override;
 	HTTPMetadataCacheEntry GetCacheEntry() const override;
 
@@ -198,9 +199,10 @@ public:
 	//! HTTP request overrides.
 	unique_ptr<HTTPResponse> HeadRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map) override;
 	unique_ptr<HTTPResponse> GetRequest(FileHandle &handle, string url, HTTPHeaders header_map,
-	                                    CachedFileDownload &download) override;
+	                                    const HTTPReadConfig &read_config, CachedFileDownload &download) override;
 	unique_ptr<HTTPResponse> GetRangeRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
-	                                         idx_t file_offset, char *buffer_out, idx_t buffer_out_len) override;
+	                                         const HTTPReadConfig &read_config, idx_t file_offset, char *buffer_out,
+	                                         idx_t buffer_out_len) override;
 	unique_ptr<HTTPResponse> PostRequest(HTTPRequestSession &session, string s3_url, string &buffer_out,
 	                                     char *buffer_in, idx_t buffer_in_len, string http_params = "");
 	unique_ptr<HTTPResponse> PutRequest(HTTPRequestSession &session, string s3_url, char *buffer_in,
@@ -251,7 +253,7 @@ private:
 	                                                            const string &content_md5, REQUEST request);
 	template <class REQUEST>
 	unique_ptr<HTTPResponse> RunS3HandleRequestWithAuthRefresh(S3FileHandle &s3_handle, const string &s3_url,
-	                                                           const string &method, bool use_version_id,
+	                                                           const string &method, const string &version_id,
 	                                                           REQUEST request);
 	unique_ptr<HTTPResponse> RunS3BulkDeleteRequest(HTTPRequestSession &session, const string &secret_lookup_url,
 	                                                const string &body, string &result);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -316,8 +316,6 @@ struct S3RequestData {
 	string source_url;
 	string http_url;
 	HTTPHeaders headers;
-	string etag;
-	bool auto_fallback_to_full_file_download = false;
 };
 
 static S3RequestData CreateS3RequestData(EncryptionUtil &encryption_util, const CapturedHTTPRequestSnapshot &captured,
@@ -348,27 +346,15 @@ static S3RequestData CreateS3RequestData(EncryptionUtil &encryption_util, const 
 }
 
 static S3RequestData CreateS3HandleRequestData(EncryptionUtil &encryption_util, S3FileHandle &s3_handle,
-                                               const string &s3_url, const string &method, bool use_version_id) {
+                                               const string &s3_url, const string &method, const string &version_id) {
 	auto captured = s3_handle.request_session->Capture();
-	string version_id;
-	string etag;
-	bool auto_fallback_to_full_file_download;
-	{
-		lock_guard<mutex> lck(s3_handle.mu);
-		version_id = s3_handle.version_id;
-		etag = s3_handle.etag;
-		auto_fallback_to_full_file_download = s3_handle.auto_fallback_to_full_file_download;
-	}
 
 	string query_string;
-	if (use_version_id && !version_id.empty()) {
+	if (!version_id.empty()) {
 		query_string = "versionId=" + S3FileSystem::UrlEncode(version_id, true);
 	}
 
-	auto result = CreateS3RequestData(encryption_util, captured, s3_url, method, query_string);
-	result.etag = std::move(etag);
-	result.auto_fallback_to_full_file_download = auto_fallback_to_full_file_download;
-	return result;
+	return CreateS3RequestData(encryption_util, captured, s3_url, method, query_string);
 }
 
 static optional_idx GetRegionRedirect(const HTTPResponse &response, const S3AuthParams &auth_params,
@@ -580,11 +566,10 @@ unique_ptr<HTTPResponse> S3FileSystem::RunS3SessionRequestWithAuthRefresh(
 
 template <class REQUEST>
 unique_ptr<HTTPResponse> S3FileSystem::RunS3HandleRequestWithAuthRefresh(S3FileHandle &s3_handle, const string &s3_url,
-                                                                         const string &method, bool use_version_id,
+                                                                         const string &method, const string &version_id,
                                                                          REQUEST request) {
 	return RunS3RequestWithAuthRefreshInternal(
-	    s3_url,
-	    [&]() { return CreateS3HandleRequestData(GetEncryptionUtil(), s3_handle, s3_url, method, use_version_id); },
+	    s3_url, [&]() { return CreateS3HandleRequestData(GetEncryptionUtil(), s3_handle, s3_url, method, version_id); },
 	    IsTransientRetryEligibleMethod(method), request,
 	    [&](const S3RequestData &request_data) {
 		    return TryRefreshS3Session(*s3_handle.request_session, request_data);
@@ -815,6 +800,19 @@ S3FileHandle::S3FileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFla
 	if (flags.OpenForWriting()) {
 		multi_part_upload = make_shared_ptr<S3MultiPartUpload>(*this);
 	}
+}
+
+HTTPReadConfig S3FileHandle::BuildReadConfig() const {
+	auto result = HTTPFileHandle::BuildReadConfig();
+	if (!request_session->Capture().snapshot->Params().s3_version_id_pinning) {
+		return result;
+	}
+	auto version_id = GetVersionId();
+	if (!version_id.empty()) {
+		result.condition.type = HTTPReadConditionType::S3_VERSION_ID;
+		result.condition.value = std::move(version_id);
+	}
+	return result;
 }
 
 shared_ptr<const HTTPRequestSnapshot> S3FileHandle::CreateRequestSnapshot(const HTTPFSParams &params) const {
@@ -1085,7 +1083,7 @@ unique_ptr<HTTPResponse> S3FileSystem::PutRequest(HTTPRequestSession &session, s
 
 unique_ptr<HTTPResponse> S3FileSystem::HeadRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
-	return RunS3HandleRequestWithAuthRefresh(s3_handle, s3_url, "HEAD", false, [&](S3RequestData &request_data) {
+	return RunS3HandleRequestWithAuthRefresh(s3_handle, s3_url, "HEAD", {}, [&](S3RequestData &request_data) {
 		auto &params = request_data.http_params->Cast<HTTPFSParams>();
 		return RunHeadRequest(request_data.http_url, request_data.headers, params, [&](BaseRequest &request) {
 			return SendS3HandleRequestWithClientCache(s3_handle, request_data.captured, params, request);
@@ -1094,12 +1092,14 @@ unique_ptr<HTTPResponse> S3FileSystem::HeadRequest(FileHandle &handle, string s3
 }
 
 unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
-                                                  CachedFileDownload &download) {
+                                                  const HTTPReadConfig &read_config, CachedFileDownload &download) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
-	return RunS3HandleRequestWithAuthRefresh(s3_handle, s3_url, "GET", true, [&](S3RequestData &request_data) {
+	const auto version_id =
+	    read_config.condition.type == HTTPReadConditionType::S3_VERSION_ID ? read_config.condition.value : string();
+	return RunS3HandleRequestWithAuthRefresh(s3_handle, s3_url, "GET", version_id, [&](S3RequestData &request_data) {
 		auto &params = request_data.http_params->Cast<HTTPFSParams>();
 		return RunGetRequest(
-		    s3_handle, request_data.http_url, request_data.headers, params, download,
+		    s3_handle, request_data.http_url, request_data.headers, params, read_config, download,
 		    [&](const HTTPResponse &response) { return GetS3RequestError(request_data, response); },
 		    [&](BaseRequest &request) {
 			    return SendS3HandleRequestWithClientCache(s3_handle, request_data.captured, params, request);
@@ -1108,14 +1108,16 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_
 }
 
 unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
-                                                       idx_t file_offset, char *buffer_out, idx_t buffer_out_len) {
+                                                       const HTTPReadConfig &read_config, idx_t file_offset,
+                                                       char *buffer_out, idx_t buffer_out_len) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
-	return RunS3HandleRequestWithAuthRefresh(s3_handle, s3_url, "GET", true, [&](S3RequestData &request_data) {
+	const auto version_id =
+	    read_config.condition.type == HTTPReadConditionType::S3_VERSION_ID ? read_config.condition.value : string();
+	return RunS3HandleRequestWithAuthRefresh(s3_handle, s3_url, "GET", version_id, [&](S3RequestData &request_data) {
 		auto &params = request_data.http_params->Cast<HTTPFSParams>();
 		return RunGetRangeRequest(
-		    s3_handle, request_data.http_url, request_data.headers, params, request_data.etag,
-		    request_data.auto_fallback_to_full_file_download, file_offset, buffer_out, buffer_out_len,
-		    [&](const HTTPResponse &response) { return GetS3RequestError(request_data, response); },
+		    s3_handle, request_data.http_url, request_data.headers, params, read_config, file_offset, buffer_out,
+		    buffer_out_len, [&](const HTTPResponse &response) { return GetS3RequestError(request_data, response); },
 		    [&](BaseRequest &request) {
 			    return SendS3HandleRequestWithClientCache(s3_handle, request_data.captured, params, request);
 		    });
@@ -1124,7 +1126,7 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, strin
 
 unique_ptr<HTTPResponse> S3FileSystem::DeleteRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
-	return RunS3HandleRequestWithAuthRefresh(s3_handle, s3_url, "DELETE", false, [&](S3RequestData &request_data) {
+	return RunS3HandleRequestWithAuthRefresh(s3_handle, s3_url, "DELETE", {}, [&](S3RequestData &request_data) {
 		auto &params = request_data.http_params->Cast<HTTPFSParams>();
 		return RunDeleteRequest(request_data.http_url, request_data.headers, params, [&](BaseRequest &request) {
 			return SendS3HandleRequestWithClientCache(s3_handle, request_data.captured, params, request);
@@ -1539,6 +1541,7 @@ void S3FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx
 	if (!s3fh.flags.OpenForWriting()) {
 		throw InternalException("Write called on file not opened in write mode");
 	}
+	annotated_lock_guard<annotated_mutex> guard(s3fh.cursor_mutex);
 	int64_t bytes_written = 0;
 
 	while (bytes_written < nr_bytes) {

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -6,8 +6,13 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../src/include)
 
 add_executable(
   unittest_httpfs EXCLUDE_FROM_ALL
-  main.cpp mock_s3_server.cpp httpfs_refresh_test.cpp s3_list_retry_test.cpp
-  short_read_test.cpp http_request_session_test.cpp)
+  main.cpp
+  mock_s3_server.cpp
+  httpfs_refresh_test.cpp
+  s3_list_retry_test.cpp
+  short_read_test.cpp
+  positional_read_test.cpp
+  http_request_session_test.cpp)
 set_target_properties(unittest_httpfs PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                                  ${CMAKE_BINARY_DIR}/test)
 

--- a/test/unittest/httpfs_refresh_test.cpp
+++ b/test/unittest/httpfs_refresh_test.cpp
@@ -8,12 +8,14 @@
 #include "s3fs.hpp"
 
 #include "duckdb.hpp"
+#include "duckdb/catalog/catalog_transaction.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/main/secret/secret.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
 
 #include <array>
 #include <atomic>
@@ -172,6 +174,26 @@ static void RequireQueryOk(Connection &con, const string &query) {
 static string NextTestId() {
 	static std::atomic<idx_t> next_id(0);
 	return StringUtil::Format("httpfs_refresh_test_%llu", static_cast<unsigned long long>(++next_id));
+}
+
+static CreateSecretInput CreateTransactionRefreshInput(const string &test_id) {
+	CreateSecretInput input;
+	input.type = "s3";
+	input.provider = TEST_PROVIDER;
+	input.name = "transaction_refresh_s3";
+	input.scope = {"s3://refresh-bucket/"};
+	input.on_conflict = OnCreateConflict::REPLACE_ON_CONFLICT;
+	input.persist_type = SecretPersistType::TRANSACTION;
+	input.options["key_id"] = STALE_KEY_ID;
+	input.options["secret"] = STALE_SECRET;
+	input.options["test_id"] = test_id;
+
+	InsertionOrderPreservingMap<string> refresh_info;
+	refresh_info.insert("key_id", FRESH_KEY_ID);
+	refresh_info.insert("secret", FRESH_SECRET);
+	refresh_info.insert("test_id", test_id);
+	input.options["refresh_info"] = Value::MAP(refresh_info);
+	return input;
 }
 
 static string ConfigureRefreshTest(DuckDB &db, Connection &con, MockS3Server &server,
@@ -1282,6 +1304,40 @@ TEST_CASE("HTTPFS refreshes S3 credentials across request methods", "[httpfs][s3
 	SECTION("curl without connection caching") {
 		RunAllRequestRefreshScenarios("curl", false);
 	}
+}
+
+TEST_CASE("HTTPFS preserves transaction-scoped S3 secrets during refresh", "[httpfs][s3][refresh]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	LoadHTTPFSExtension(db);
+	RegisterRefreshTestProvider(db);
+
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto test_id = NextTestId();
+	auto input = CreateTransactionRefreshInput(test_id);
+	auto &secret_manager = SecretManager::Get(*db.instance);
+	auto created_secret = secret_manager.CreateSecret(*con.context, input);
+	REQUIRE(created_secret);
+	REQUIRE(created_secret->persist_type == SecretPersistType::TRANSACTION);
+	REQUIRE(created_secret->storage_mode == SecretManager::TRANSACTION_STORAGE_NAME);
+
+	REQUIRE(CreateS3SecretFunctions::TryRefreshS3Secret(*con.context, *created_secret));
+	AssertSingleRefresh(test_id);
+
+	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(*con.context);
+	auto refreshed_secret = secret_manager.GetSecretByName(transaction, input.name.GetIdentifierName());
+	REQUIRE(refreshed_secret);
+	REQUIRE(refreshed_secret->persist_type == SecretPersistType::TRANSACTION);
+	REQUIRE(refreshed_secret->storage_mode == SecretManager::TRANSACTION_STORAGE_NAME);
+	auto secret_string = refreshed_secret->secret->ToString(SecretDisplayType::UNREDACTED);
+	REQUIRE(StringUtil::Contains(secret_string, StringUtil::Format("key_id=%s", FRESH_KEY_ID)));
+	REQUIRE_FALSE(StringUtil::Contains(secret_string, StringUtil::Format("key_id=%s", STALE_KEY_ID)));
+
+	RequireQueryOk(con, "COMMIT");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto next_transaction = CatalogTransaction::GetSystemCatalogTransaction(*con.context);
+	REQUIRE_FALSE(secret_manager.GetSecretByName(next_transaction, input.name.GetIdentifierName()));
+	RequireQueryOk(con, "ROLLBACK");
 }
 
 TEST_CASE("HTTPFS refreshes S3 credentials for token-specific HTTP 400 errors", "[httpfs][s3][refresh]") {

--- a/test/unittest/httpfs_refresh_test.cpp
+++ b/test/unittest/httpfs_refresh_test.cpp
@@ -293,13 +293,13 @@ static vector<MockS3RequestObservation>
 RunRefreshScenario(MockS3RefreshTarget refresh_target, const string &client_implementation, bool connection_caching,
                    OPERATION operation, int stale_auth_status = 403, string stale_auth_error_code = "AccessDenied") {
 	MockS3ServerConfig config;
-	config.bucket = BUCKET;
-	config.object_key = OBJECT_KEY;
-	config.stale_key_id = STALE_KEY_ID;
-	config.stale_auth_status = stale_auth_status;
-	config.stale_auth_error_code = std::move(stale_auth_error_code);
-	config.refresh_target = refresh_target;
-	auto object_data = config.object_data;
+	config.object.bucket = BUCKET;
+	config.object.key = OBJECT_KEY;
+	config.auth.stale_key_id = STALE_KEY_ID;
+	config.auth.stale_status = stale_auth_status;
+	config.auth.stale_error_code = std::move(stale_auth_error_code);
+	config.auth.refresh_target = refresh_target;
+	auto object_data = config.object.data;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -435,17 +435,17 @@ static void RunBulkDeletePostRefreshScenario(const string &client_implementation
 
 static void RunBulkDeleteEndpointRefreshScenario(const string &client_implementation) {
 	MockS3ServerConfig stale_config;
-	stale_config.bucket = BUCKET;
-	stale_config.object_key = OBJECT_KEY;
-	stale_config.stale_key_id = STALE_KEY_ID;
-	stale_config.refresh_target = MockS3RefreshTarget::BULK_DELETE_POST;
+	stale_config.object.bucket = BUCKET;
+	stale_config.object.key = OBJECT_KEY;
+	stale_config.auth.stale_key_id = STALE_KEY_ID;
+	stale_config.auth.refresh_target = MockS3RefreshTarget::BULK_DELETE_POST;
 	MockS3Server stale_server(std::move(stale_config));
 
 	MockS3ServerConfig fresh_config;
-	fresh_config.bucket = BUCKET;
-	fresh_config.object_key = OBJECT_KEY;
-	fresh_config.stale_key_id = "NEVER_STALE";
-	fresh_config.refresh_target = MockS3RefreshTarget::BULK_DELETE_POST;
+	fresh_config.object.bucket = BUCKET;
+	fresh_config.object.key = OBJECT_KEY;
+	fresh_config.auth.stale_key_id = "NEVER_STALE";
+	fresh_config.auth.refresh_target = MockS3RefreshTarget::BULK_DELETE_POST;
 	MockS3Server fresh_server(std::move(fresh_config));
 
 	DuckDB db(nullptr);
@@ -521,12 +521,12 @@ static void RunTokenListRefreshScenario(const string &client_implementation, con
 
 static void RunNonAuth400NoRefreshScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.bucket = BUCKET;
-	config.object_key = OBJECT_KEY;
-	config.stale_key_id = STALE_KEY_ID;
-	config.stale_auth_status = 400;
-	config.stale_auth_error_code = "InvalidRequest";
-	config.refresh_target = MockS3RefreshTarget::FULL_GET;
+	config.object.bucket = BUCKET;
+	config.object.key = OBJECT_KEY;
+	config.auth.stale_key_id = STALE_KEY_ID;
+	config.auth.stale_status = 400;
+	config.auth.stale_error_code = "InvalidRequest";
+	config.auth.refresh_target = MockS3RefreshTarget::FULL_GET;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -573,10 +573,10 @@ static void RunHandleRequestRefreshScenarios(const string &client_implementation
 
 static void RunRangeRefreshDisabledScenario() {
 	MockS3ServerConfig config;
-	config.bucket = BUCKET;
-	config.object_key = OBJECT_KEY;
-	config.stale_key_id = STALE_KEY_ID;
-	config.refresh_target = MockS3RefreshTarget::RANGE_GET;
+	config.object.bucket = BUCKET;
+	config.object.key = OBJECT_KEY;
+	config.auth.stale_key_id = STALE_KEY_ID;
+	config.auth.refresh_target = MockS3RefreshTarget::RANGE_GET;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -602,10 +602,10 @@ static void RunRangeRefreshDisabledScenario() {
 
 static void RunFullGetErrorBodyScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.bucket = BUCKET;
-	config.object_key = OBJECT_KEY;
-	config.stale_key_id = STALE_KEY_ID;
-	config.refresh_target = MockS3RefreshTarget::FULL_GET;
+	config.object.bucket = BUCKET;
+	config.object.key = OBJECT_KEY;
+	config.auth.stale_key_id = STALE_KEY_ID;
+	config.auth.refresh_target = MockS3RefreshTarget::FULL_GET;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -634,12 +634,12 @@ static void RunFullGetErrorBodyScenario(const string &client_implementation) {
 
 static void RunChunkedFullGetScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.bucket = BUCKET;
-	config.object_key = OBJECT_KEY;
-	config.stale_key_id = STALE_KEY_ID;
-	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
-	config.chunked_full_get = true;
-	auto object_data = config.object_data;
+	config.object.bucket = BUCKET;
+	config.object.key = OBJECT_KEY;
+	config.auth.stale_key_id = STALE_KEY_ID;
+	config.auth.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.full_get.chunked = true;
+	auto object_data = config.object.data;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -663,10 +663,10 @@ static void RunChunkedFullGetScenario(const string &client_implementation) {
 
 static void RunListGlobRefreshDisabledScenario() {
 	MockS3ServerConfig config;
-	config.bucket = BUCKET;
-	config.object_key = OBJECT_KEY;
-	config.stale_key_id = STALE_KEY_ID;
-	config.refresh_target = MockS3RefreshTarget::LIST_OBJECTS_GET;
+	config.object.bucket = BUCKET;
+	config.object.key = OBJECT_KEY;
+	config.auth.stale_key_id = STALE_KEY_ID;
+	config.auth.refresh_target = MockS3RefreshTarget::LIST_OBJECTS_GET;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -688,7 +688,7 @@ static void RunListGlobRefreshDisabledScenario() {
 
 static void RunS3HeaderScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.stale_key_id = "NEVER_STALE";
+	config.auth.stale_key_id = "NEVER_STALE";
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -731,8 +731,8 @@ CREATE SECRET s3_headers (
 
 static void RunS3RegionRedirectScenario(const string &client_implementation, bool list_request) {
 	MockS3ServerConfig config;
-	config.stale_key_id = "NEVER_STALE";
-	config.required_region = "us-east-1";
+	config.auth.stale_key_id = "NEVER_STALE";
+	config.auth.required_region = "us-east-1";
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -794,11 +794,11 @@ CREATE SECRET s3_region_redirect (
 
 static void RunMultipleStaleHandlesSingleRefreshScenario() {
 	MockS3ServerConfig config;
-	config.bucket = BUCKET;
-	config.object_key = OBJECT_KEY;
-	config.stale_key_id = STALE_KEY_ID;
-	config.refresh_target = MockS3RefreshTarget::RANGE_GET;
-	auto object_data = config.object_data;
+	config.object.bucket = BUCKET;
+	config.object.key = OBJECT_KEY;
+	config.auth.stale_key_id = STALE_KEY_ID;
+	config.auth.refresh_target = MockS3RefreshTarget::RANGE_GET;
+	auto object_data = config.object.data;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -851,11 +851,11 @@ static void PublishTestS3Region(const shared_ptr<HTTPRequestSession> &session, c
 static void RunRefreshPublicationScenario(const string &client_implementation, bool invalidate_clients,
                                           bool publish_region) {
 	MockS3ServerConfig config;
-	config.bucket = BUCKET;
-	config.object_key = OBJECT_KEY;
-	config.stale_key_id = STALE_KEY_ID;
-	config.refresh_target = MockS3RefreshTarget::RANGE_GET;
-	auto object_data = config.object_data;
+	config.object.bucket = BUCKET;
+	config.object.key = OBJECT_KEY;
+	config.auth.stale_key_id = STALE_KEY_ID;
+	config.auth.refresh_target = MockS3RefreshTarget::RANGE_GET;
+	auto object_data = config.object.data;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -909,12 +909,12 @@ static void RunRefreshPublicationScenario(const string &client_implementation, b
 
 static void RunTransientPutRetryScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.bucket = BUCKET;
-	config.object_key = OBJECT_KEY;
-	config.stale_key_id = STALE_KEY_ID;
+	config.object.bucket = BUCKET;
+	config.object.key = OBJECT_KEY;
+	config.auth.stale_key_id = STALE_KEY_ID;
 	// Use a refresh target that writes never exercise, so credential refresh never triggers here.
-	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
-	config.transient_put_failures = 2;
+	config.auth.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.failures.transient_put_failures = 2;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -952,12 +952,12 @@ static idx_t CountObservationsTarget(const vector<MockS3RequestObservation> &obs
 // request is expected, distinguishing "not retried" from "retried N times and still failed".
 static void RunGenericErrorNotRetriedScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.bucket = BUCKET;
-	config.object_key = OBJECT_KEY;
-	config.stale_key_id = STALE_KEY_ID;
-	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
-	config.transient_put_failures = 1000;
-	config.failure_is_request_timeout = false;
+	config.object.bucket = BUCKET;
+	config.object.key = OBJECT_KEY;
+	config.auth.stale_key_id = STALE_KEY_ID;
+	config.auth.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.failures.transient_put_failures = 1000;
+	config.failures.failure_is_request_timeout = false;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -979,12 +979,12 @@ static void RunGenericErrorNotRetriedScenario(const string &client_implementatio
 // not classified as transient (no retry) and never escalated to a DB-invalidating InternalException.
 static void RunTruncatedErrorBodyScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.bucket = BUCKET;
-	config.object_key = OBJECT_KEY;
-	config.stale_key_id = STALE_KEY_ID;
-	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
-	config.transient_put_failures = 1000;
-	config.truncated_failure_body = true;
+	config.object.bucket = BUCKET;
+	config.object.key = OBJECT_KEY;
+	config.auth.stale_key_id = STALE_KEY_ID;
+	config.auth.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.failures.transient_put_failures = 1000;
+	config.failures.truncated_failure_body = true;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -1016,11 +1016,11 @@ static void RunTruncatedErrorBodyScenario(const string &client_implementation) {
 // Even a retryable RequestTimeout must NOT replay a multipart-init POST (it would orphan an upload id).
 static void RunMultipartInitNotRetriedScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.bucket = BUCKET;
-	config.object_key = OBJECT_KEY;
-	config.stale_key_id = STALE_KEY_ID;
-	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
-	config.transient_post_failures = 1000;
+	config.object.bucket = BUCKET;
+	config.object.key = OBJECT_KEY;
+	config.auth.stale_key_id = STALE_KEY_ID;
+	config.auth.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.failures.transient_post_failures = 1000;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -1041,11 +1041,11 @@ static void RunMultipartInitNotRetriedScenario(const string &client_implementati
 // A RequestTimeout retry must run on a fresh connection instead of the stalled one.
 static void RunFreshConnectionRetryScenario(const string &client_implementation, bool connection_caching) {
 	MockS3ServerConfig config;
-	config.bucket = BUCKET;
-	config.object_key = OBJECT_KEY;
-	config.stale_key_id = STALE_KEY_ID;
-	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
-	config.transient_put_failures = 1;
+	config.object.bucket = BUCKET;
+	config.object.key = OBJECT_KEY;
+	config.auth.stale_key_id = STALE_KEY_ID;
+	config.auth.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.failures.transient_put_failures = 1;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -1080,11 +1080,11 @@ static void RunFreshConnectionRetryScenario(const string &client_implementation,
 // A RequestTimeout that never clears exhausts exactly http_retries retries (one initial + http_retries).
 static void RunRetryBudgetScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.bucket = BUCKET;
-	config.object_key = OBJECT_KEY;
-	config.stale_key_id = STALE_KEY_ID;
-	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
-	config.transient_put_failures = 1000;
+	config.object.bucket = BUCKET;
+	config.object.key = OBJECT_KEY;
+	config.auth.stale_key_id = STALE_KEY_ID;
+	config.auth.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.failures.transient_put_failures = 1000;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -1105,12 +1105,12 @@ static void RunRetryBudgetScenario(const string &client_implementation) {
 
 static void RunTransientGetRetryScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.bucket = BUCKET;
-	config.object_key = OBJECT_KEY;
-	config.stale_key_id = STALE_KEY_ID;
-	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
-	config.transient_get_failures = 2;
-	auto object_data = config.object_data;
+	config.object.bucket = BUCKET;
+	config.object.key = OBJECT_KEY;
+	config.auth.stale_key_id = STALE_KEY_ID;
+	config.auth.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.failures.transient_get_failures = 2;
+	auto object_data = config.object.data;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -1137,12 +1137,12 @@ static void RunTransientGetRetryScenario(const string &client_implementation) {
 
 static void RunTransientDeleteRetryScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.bucket = BUCKET;
-	config.object_key = OBJECT_KEY;
-	config.stale_key_id = STALE_KEY_ID;
+	config.object.bucket = BUCKET;
+	config.object.key = OBJECT_KEY;
+	config.auth.stale_key_id = STALE_KEY_ID;
 	// Use a refresh target that deletes never exercise, so credential refresh never triggers here.
-	config.refresh_target = MockS3RefreshTarget::PUT;
-	config.transient_delete_failures = 2;
+	config.auth.refresh_target = MockS3RefreshTarget::PUT;
+	config.failures.transient_delete_failures = 2;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -1166,11 +1166,11 @@ static void RunTransientDeleteRetryScenario(const string &client_implementation)
 // the HEAD is not retried and the open recovers through httpfs's range-GET fallback instead.
 static void RunHeadNotRetriedScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.bucket = BUCKET;
-	config.object_key = OBJECT_KEY;
-	config.stale_key_id = STALE_KEY_ID;
-	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
-	config.transient_head_failures = 1000;
+	config.object.bucket = BUCKET;
+	config.object.key = OBJECT_KEY;
+	config.auth.stale_key_id = STALE_KEY_ID;
+	config.auth.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.failures.transient_head_failures = 1000;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -1200,11 +1200,11 @@ static void RunHeadNotRetriedScenario(const string &client_implementation) {
 // Like multipart-init, a multipart-complete POST must not be replayed even on RequestTimeout.
 static void RunMultipartCompleteNotRetriedScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.bucket = BUCKET;
-	config.object_key = OBJECT_KEY;
-	config.stale_key_id = STALE_KEY_ID;
-	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
-	config.transient_complete_post_failures = 1000;
+	config.object.bucket = BUCKET;
+	config.object.key = OBJECT_KEY;
+	config.auth.stale_key_id = STALE_KEY_ID;
+	config.auth.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.failures.transient_complete_post_failures = 1000;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);

--- a/test/unittest/mock_s3_server.cpp
+++ b/test/unittest/mock_s3_server.cpp
@@ -108,15 +108,15 @@ static string GetParameter(const httplib::Request &request, const string &parame
 
 struct MockS3Server::Impl {
 	explicit Impl(MockS3ServerConfig config_p) : config(std::move(config_p)) {
-		remaining_put_failures = config.transient_put_failures;
-		remaining_get_failures = config.transient_get_failures;
-		remaining_range_behavior_requests = config.range_behavior_requests;
-		remaining_head_failures = config.transient_head_failures;
-		remaining_head_not_found = config.head_not_found_requests;
-		remaining_delete_failures = config.transient_delete_failures;
-		remaining_post_failures = config.transient_post_failures;
-		remaining_complete_post_failures = config.transient_complete_post_failures;
-		if (config.range_behavior == MockS3RangeBehavior::SHORT_SUCCESS && config.range_behavior_requests > 0) {
+		remaining_put_failures = config.failures.transient_put_failures;
+		remaining_get_failures = config.failures.transient_get_failures;
+		remaining_range_behavior_requests = config.range.behavior_requests;
+		remaining_head_failures = config.failures.transient_head_failures;
+		remaining_head_not_found = config.failures.head_not_found_requests;
+		remaining_delete_failures = config.failures.transient_delete_failures;
+		remaining_post_failures = config.failures.transient_post_failures;
+		remaining_complete_post_failures = config.failures.transient_complete_post_failures;
+		if (config.range.behavior == MockS3RangeBehavior::SHORT_SUCCESS && config.range.behavior_requests > 0) {
 			server.set_keep_alive_max_count(1);
 		}
 		RegisterRoutes();
@@ -140,11 +140,11 @@ struct MockS3Server::Impl {
 	}
 
 	string S3Path() const {
-		return StringUtil::Format("s3://%s/%s", config.bucket, config.object_key);
+		return StringUtil::Format("s3://%s/%s", config.object.bucket, config.object.key);
 	}
 
 	string HTTPPath() const {
-		return StringUtil::Format("http://%s/%s/%s", Endpoint(), config.bucket, config.object_key);
+		return StringUtil::Format("http://%s/%s/%s", Endpoint(), config.object.bucket, config.object.key);
 	}
 
 	vector<MockS3RequestObservation> Observations() const DUCKDB_EXCLUDES(observation_lock) {
@@ -167,7 +167,7 @@ struct MockS3Server::Impl {
 
 	bool MatchesRefreshTarget(const httplib::Request &request) const {
 		auto range = GetHeader(request, "Range");
-		switch (config.refresh_target) {
+		switch (config.auth.refresh_target) {
 		case MockS3RefreshTarget::HEAD:
 			return request.method == "HEAD";
 		case MockS3RefreshTarget::FULL_GET:
@@ -192,13 +192,13 @@ struct MockS3Server::Impl {
 	}
 
 	bool ShouldRejectStaleCredentials(const httplib::Request &request) const {
-		return ExtractCredentialKey(GetHeader(request, "Authorization")) == config.stale_key_id &&
+		return ExtractCredentialKey(GetHeader(request, "Authorization")) == config.auth.stale_key_id &&
 		       MatchesRefreshTarget(request);
 	}
 
 	bool ShouldRedirectRegion(const httplib::Request &request) const {
-		return !config.required_region.empty() &&
-		       ExtractCredentialRegion(GetHeader(request, "Authorization")) != config.required_region;
+		return !config.auth.required_region.empty() &&
+		       ExtractCredentialRegion(GetHeader(request, "Authorization")) != config.auth.required_region;
 	}
 
 	void Record(const httplib::Request &request, int status) const DUCKDB_EXCLUDES(observation_lock) {
@@ -223,28 +223,29 @@ struct MockS3Server::Impl {
 	}
 
 	void SetObjectHeaders(httplib::Response &response) const {
-		if (config.advertise_ranges) {
+		if (config.range.advertise) {
 			response.set_header("Accept-Ranges", "bytes");
 		} else {
 			response.set_header("Accept-Ranges", "none");
 		}
-		auto content_length =
-		    config.head_content_length.IsValid() ? config.head_content_length.GetIndex() : config.object_data.size();
+		auto content_length = config.metadata.head_content_length.IsValid()
+		                          ? config.metadata.head_content_length.GetIndex()
+		                          : config.object.data.size();
 		response.set_header("Content-Length", std::to_string(content_length));
-		response.set_header("ETag", config.etag);
-		if (config.version_id_on_head && !config.version_id.empty()) {
-			response.set_header("x-amz-version-id", config.version_id);
+		response.set_header("ETag", config.metadata.etag);
+		if (config.metadata.version_on_head && !config.metadata.version_id.empty()) {
+			response.set_header("x-amz-version-id", config.metadata.version_id);
 		}
 	}
 
 	string GetResponseETag() const {
-		return config.get_etag.empty() ? config.etag : config.get_etag;
+		return config.metadata.get_etag.empty() ? config.metadata.etag : config.metadata.get_etag;
 	}
 
 	void SetGetHeaders(httplib::Response &response) const {
 		response.set_header("ETag", GetResponseETag());
-		if (config.version_id_on_get && !config.version_id.empty()) {
-			response.set_header("x-amz-version-id", config.version_id);
+		if (config.metadata.version_on_get && !config.metadata.version_id.empty()) {
+			response.set_header("x-amz-version-id", config.metadata.version_id);
 		}
 	}
 
@@ -256,16 +257,16 @@ struct MockS3Server::Impl {
 	}
 
 	void SendAuthFailure(const httplib::Request &request, httplib::Response &response) const {
-		response.status = config.stale_auth_status;
+		response.status = config.auth.stale_status;
 		response.set_content(StringUtil::Format("<Error><Code>%s</Code><Message>stale credentials</Message></Error>",
-		                                        config.stale_auth_error_code),
+		                                        config.auth.stale_error_code),
 		                     "application/xml");
 		Record(request, response.status);
 	}
 
 	void SendRegionRedirect(const httplib::Request &request, httplib::Response &response) const {
 		response.status = 301;
-		response.set_header("x-amz-bucket-region", config.required_region);
+		response.set_header("x-amz-bucket-region", config.auth.required_region);
 		response.set_content("<Error><Code>PermanentRedirect</Code></Error>", "application/xml");
 		Record(request, response.status);
 	}
@@ -278,7 +279,7 @@ struct MockS3Server::Impl {
 
 	void SendS3Error400(const httplib::Request &request, httplib::Response &response, bool request_timeout) const {
 		response.status = 400;
-		if (config.truncated_failure_body) {
+		if (config.failures.truncated_failure_body) {
 			response.set_content("<?xml version=\"1.0\" encoding=\"UTF-8\"?><Error><Code>RequestTimeout",
 			                     "application/xml");
 		} else if (request_timeout) {
@@ -320,7 +321,7 @@ struct MockS3Server::Impl {
 
 	void SendListObjectsSuccess(const httplib::Request &request, httplib::Response &response) const {
 		response.status = 200;
-		auto unquoted_etag = StringUtil::Replace(config.etag, "\"", "");
+		auto unquoted_etag = StringUtil::Replace(config.metadata.etag, "\"", "");
 		response.set_content(StringUtil::Format("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
 		                                        "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">"
 		                                        "<Name>%s</Name>"
@@ -334,21 +335,21 @@ struct MockS3Server::Impl {
 		                                        "<Size>%llu</Size>"
 		                                        "</Contents>"
 		                                        "</ListBucketResult>",
-		                                        config.bucket, config.object_key, unquoted_etag,
-		                                        static_cast<unsigned long long>(config.object_data.size())),
+		                                        config.object.bucket, config.object.key, unquoted_etag,
+		                                        static_cast<unsigned long long>(config.object.data.size())),
 		                     "application/xml");
 		Record(request, response.status);
 	}
 
 	void RegisterRoutes() {
-		const string path = StringUtil::Format("/%s/%s", config.bucket, config.object_key);
-		const string bucket_path = StringUtil::Format("/%s", config.bucket);
+		const string path = StringUtil::Format("/%s/%s", config.object.bucket, config.object.key);
+		const string bucket_path = StringUtil::Format("/%s", config.object.bucket);
 		const string bucket_path_with_slash = bucket_path + "/";
 		server.set_post_routing_handler([this](const httplib::Request &, httplib::Response &response) {
 			if (!response.has_header("X-Mock-Successful-Short-Response")) {
 				return;
 			}
-			auto omitted_bytes = MinValue<idx_t>(config.truncated_range_bytes, response.body.size());
+			auto omitted_bytes = MinValue<idx_t>(config.range.truncated_bytes, response.body.size());
 			response.body.resize(response.body.size() - omitted_bytes);
 			auto content_length = response.headers.equal_range("Content-Length");
 			response.headers.erase(content_length.first, content_length.second);
@@ -376,7 +377,7 @@ struct MockS3Server::Impl {
 			}
 			if (remaining_head_failures.load() > 0) {
 				remaining_head_failures--;
-				SendS3Error400(request, response, config.failure_is_request_timeout);
+				SendS3Error400(request, response, config.failures.failure_is_request_timeout);
 				return httplib::Server::HandlerResponse::Handled;
 			}
 			response.status = 200;
@@ -392,10 +393,10 @@ struct MockS3Server::Impl {
 			}
 			if (remaining_get_failures.load() > 0) {
 				remaining_get_failures--;
-				SendS3Error400(request, response, config.failure_is_request_timeout);
+				SendS3Error400(request, response, config.failures.failure_is_request_timeout);
 				return;
 			}
-			if (config.enforce_if_match && GetHeader(request, "If-Match") != GetResponseETag()) {
+			if (config.metadata.enforce_if_match && GetHeader(request, "If-Match") != GetResponseETag()) {
 				response.status = 412;
 				Record(request, response.status);
 				return;
@@ -405,9 +406,9 @@ struct MockS3Server::Impl {
 			if (range.empty()) {
 				response.status = 200;
 				SetGetHeaders(response);
-				if (config.block_full_get_until_released) {
+				if (config.full_get.block_until_released) {
 					response.set_content_provider(
-					    config.object_data.size(), "application/octet-stream",
+					    config.object.data.size(), "application/octet-stream",
 					    [this](size_t offset, size_t length, httplib::DataSink &sink) {
 						    if (offset == 0) {
 							    std::unique_lock<std::mutex> lock(full_get_lock);
@@ -418,23 +419,23 @@ struct MockS3Server::Impl {
 								    return false;
 							    }
 						    }
-						    return sink.write(config.object_data.data() + offset, length);
+						    return sink.write(config.object.data.data() + offset, length);
 					    });
 					Record(request, response.status);
 					return;
 				}
-				if (config.chunked_full_get) {
+				if (config.full_get.chunked) {
 					response.set_chunked_content_provider(
 					    "application/octet-stream", [this](size_t offset, httplib::DataSink &sink) {
-						    if (offset >= config.object_data.size()) {
+						    if (offset >= config.object.data.size()) {
 							    sink.done();
 							    return true;
 						    }
-						    const auto length = MinValue<size_t>(7, config.object_data.size() - offset);
-						    if (!sink.write(config.object_data.data() + offset, length)) {
+						    const auto length = MinValue<size_t>(7, config.object.data.size() - offset);
+						    if (!sink.write(config.object.data.data() + offset, length)) {
 							    return false;
 						    }
-						    if (offset + length == config.object_data.size()) {
+						    if (offset + length == config.object.data.size()) {
 							    sink.done();
 						    }
 						    return true;
@@ -442,21 +443,21 @@ struct MockS3Server::Impl {
 					Record(request, response.status);
 					return;
 				}
-				response.set_content(config.object_data, "application/octet-stream");
+				response.set_content(config.object.data, "application/octet-stream");
 				Record(request, response.status);
 				return;
 			}
-			if (config.range_behavior == MockS3RangeBehavior::IGNORE_RANGE) {
+			if (config.range.behavior == MockS3RangeBehavior::IGNORE_RANGE) {
 				response.status = 200;
 				SetGetHeaders(response);
-				response.set_content(config.object_data, "application/octet-stream");
+				response.set_content(config.object.data, "application/octet-stream");
 				Record(request, response.status);
 				return;
 			}
 
 			idx_t range_start;
 			idx_t range_end;
-			if (!ParseRange(range, config.object_data.size(), range_start, range_end)) {
+			if (!ParseRange(range, config.object.data.size(), range_start, range_end)) {
 				response.status = 416;
 				Record(request, response.status);
 				return;
@@ -471,8 +472,8 @@ struct MockS3Server::Impl {
 			response.status = 206;
 			response.set_header("Accept-Ranges", "bytes");
 			SetGetHeaders(response);
-			if (!config.blocked_range.empty() && range == config.blocked_range) {
-				response.set_content_provider(config.object_data.size(), "application/octet-stream",
+			if (!config.range.blocked.empty() && range == config.range.blocked) {
+				response.set_content_provider(config.object.data.size(), "application/octet-stream",
 				                              [this](size_t offset, size_t length, httplib::DataSink &sink) {
 					                              std::unique_lock<std::mutex> lock(range_release_lock);
 					                              if (!range_release.wait_for(lock, std::chrono::seconds(5), [this]() {
@@ -480,16 +481,16 @@ struct MockS3Server::Impl {
 					                                  })) {
 						                              return false;
 					                              }
-					                              return sink.write(config.object_data.data() + offset, length);
+					                              return sink.write(config.object.data.data() + offset, length);
 				                              });
 				Record(request, response.status);
 				return;
 			}
-			if (!config.release_range.empty() && range == config.release_range) {
-				response.set_content_provider(config.object_data.size(), "application/octet-stream",
+			if (!config.range.release.empty() && range == config.range.release) {
+				response.set_content_provider(config.object.data.size(), "application/octet-stream",
 				                              [this](size_t offset, size_t length, httplib::DataSink &sink) {
 					                              const auto success =
-					                                  sink.write(config.object_data.data() + offset, length);
+					                                  sink.write(config.object.data.data() + offset, length);
 					                              if (success) {
 						                              {
 							                              std::lock_guard<std::mutex> lock(range_release_lock);
@@ -502,10 +503,10 @@ struct MockS3Server::Impl {
 				Record(request, response.status);
 				return;
 			}
-			if (config.block_first_range_body_until_second_range && range_request_index == 1) {
+			if (config.range.block_first_body_until_second && range_request_index == 1) {
 				auto wait_for_second_request = make_shared_ptr<std::atomic<bool>>(true);
 				response.set_content_provider(
-				    config.object_data.size(), "application/octet-stream",
+				    config.object.data.size(), "application/octet-stream",
 				    [this, wait_for_second_request](size_t offset, size_t length, httplib::DataSink &sink) {
 					    if (wait_for_second_request->exchange(false)) {
 						    std::unique_lock<std::mutex> lock(range_request_lock);
@@ -514,34 +515,34 @@ struct MockS3Server::Impl {
 							    return false;
 						    }
 					    }
-					    return sink.write(config.object_data.data() + offset, length);
+					    return sink.write(config.object.data.data() + offset, length);
 				    });
 				Record(request, response.status);
 				return;
 			}
-			if (config.range_behavior == MockS3RangeBehavior::SHORT_SUCCESS &&
+			if (config.range.behavior == MockS3RangeBehavior::SHORT_SUCCESS &&
 			    ConsumeBehavior(remaining_range_behavior_requests)) {
 				response.set_header("X-Mock-Successful-Short-Response", "1");
-				response.set_content(config.object_data, "application/octet-stream");
+				response.set_content(config.object.data, "application/octet-stream");
 				Record(request, response.status);
 				return;
 			}
-			if (config.range_behavior == MockS3RangeBehavior::TRUNCATE_TRANSFER &&
+			if (config.range.behavior == MockS3RangeBehavior::TRUNCATE_TRANSFER &&
 			    ConsumeBehavior(remaining_range_behavior_requests)) {
-				response.set_content_provider(config.object_data.size(), "application/octet-stream",
+				response.set_content_provider(config.object.data.size(), "application/octet-stream",
 				                              [this](size_t offset, size_t length, httplib::DataSink &sink) {
 					                              auto omitted_bytes =
-					                                  MinValue<idx_t>(config.truncated_range_bytes, length);
+					                                  MinValue<idx_t>(config.range.truncated_bytes, length);
 					                              auto emitted_bytes = length - omitted_bytes;
 					                              if (emitted_bytes > 0) {
-						                              sink.write(config.object_data.data() + offset, emitted_bytes);
+						                              sink.write(config.object.data.data() + offset, emitted_bytes);
 					                              }
 					                              return false;
 				                              });
 				Record(request, response.status);
 				return;
 			}
-			response.set_content(config.object_data, "application/octet-stream");
+			response.set_content(config.object.data, "application/octet-stream");
 			Record(request, response.status);
 		});
 
@@ -559,12 +560,14 @@ struct MockS3Server::Impl {
 				SendAuthFailure(request, response);
 				return;
 			}
-			if (config.transient_503_lists > 0 && transient_503_lists_sent.fetch_add(1) < config.transient_503_lists) {
+			if (config.failures.transient_503_lists > 0 &&
+			    transient_503_lists_sent.fetch_add(1) < config.failures.transient_503_lists) {
 				SendSlowDown(request, response);
 				return;
 			}
-			if (config.transient_400_lists > 0 && transient_400_lists_sent.fetch_add(1) < config.transient_400_lists) {
-				SendS3Error400(request, response, config.failure_is_request_timeout);
+			if (config.failures.transient_400_lists > 0 &&
+			    transient_400_lists_sent.fetch_add(1) < config.failures.transient_400_lists) {
+				SendS3Error400(request, response, config.failures.failure_is_request_timeout);
 				return;
 			}
 			SendListObjectsSuccess(request, response);
@@ -579,7 +582,7 @@ struct MockS3Server::Impl {
 			}
 			if (remaining_put_failures.load() > 0) {
 				remaining_put_failures--;
-				SendS3Error400(request, response, config.failure_is_request_timeout);
+				SendS3Error400(request, response, config.failures.failure_is_request_timeout);
 				return;
 			}
 			SendPutSuccess(request, response);
@@ -592,12 +595,12 @@ struct MockS3Server::Impl {
 			}
 			if (request.target.find("uploads") != string::npos && remaining_post_failures.load() > 0) {
 				remaining_post_failures--;
-				SendS3Error400(request, response, config.failure_is_request_timeout);
+				SendS3Error400(request, response, config.failures.failure_is_request_timeout);
 				return;
 			}
 			if (request.target.find("uploadId") != string::npos && remaining_complete_post_failures.load() > 0) {
 				remaining_complete_post_failures--;
-				SendS3Error400(request, response, config.failure_is_request_timeout);
+				SendS3Error400(request, response, config.failures.failure_is_request_timeout);
 				return;
 			}
 			SendMultipartPostSuccess(request, response);
@@ -620,7 +623,7 @@ struct MockS3Server::Impl {
 			}
 			if (remaining_delete_failures.load() > 0) {
 				remaining_delete_failures--;
-				SendS3Error400(request, response, config.failure_is_request_timeout);
+				SendS3Error400(request, response, config.failures.failure_is_request_timeout);
 				return;
 			}
 			response.status = 204;
@@ -676,7 +679,7 @@ string MockS3Server::HTTPPath() const {
 }
 
 const string &MockS3Server::ObjectData() const {
-	return impl->config.object_data;
+	return impl->config.object.data;
 }
 
 vector<MockS3RequestObservation> MockS3Server::Observations() const {

--- a/test/unittest/mock_s3_server.cpp
+++ b/test/unittest/mock_s3_server.cpp
@@ -1,6 +1,7 @@
 #include "mock_s3_server.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/string_util.hpp"
 
 #include "httplib.hpp"
@@ -96,6 +97,13 @@ static idx_t CountHeader(const httplib::Request &request, const string &header) 
 	return result;
 }
 
+static string GetParameter(const httplib::Request &request, const string &parameter) {
+	if (!request.has_param(parameter)) {
+		return string();
+	}
+	return request.get_param_value(parameter);
+}
+
 } // namespace
 
 struct MockS3Server::Impl {
@@ -139,8 +147,8 @@ struct MockS3Server::Impl {
 		return StringUtil::Format("http://%s/%s/%s", Endpoint(), config.bucket, config.object_key);
 	}
 
-	vector<MockS3RequestObservation> Observations() const {
-		std::lock_guard<std::mutex> lock(observation_lock);
+	vector<MockS3RequestObservation> Observations() const DUCKDB_EXCLUDES(observation_lock) {
+		annotated_lock_guard<annotated_mutex> lock(observation_lock);
 		return observations;
 	}
 
@@ -193,12 +201,14 @@ struct MockS3Server::Impl {
 		       ExtractCredentialRegion(GetHeader(request, "Authorization")) != config.required_region;
 	}
 
-	void Record(const httplib::Request &request, int status) const {
+	void Record(const httplib::Request &request, int status) const DUCKDB_EXCLUDES(observation_lock) {
 		MockS3RequestObservation observation;
 		observation.method = request.method;
 		observation.path = request.path;
 		observation.target = request.target;
 		observation.range = GetHeader(request, "Range");
+		observation.if_match = GetHeader(request, "If-Match");
+		observation.version_id = GetParameter(request, "versionId");
 		observation.key_id = ExtractCredentialKey(GetHeader(request, "Authorization"));
 		observation.region = ExtractCredentialRegion(GetHeader(request, "Authorization"));
 		observation.user_agent = GetHeader(request, "User-Agent");
@@ -208,7 +218,7 @@ struct MockS3Server::Impl {
 		observation.status = status;
 		observation.remote_port = request.remote_port;
 
-		std::lock_guard<std::mutex> lock(observation_lock);
+		annotated_lock_guard<annotated_mutex> lock(observation_lock);
 		observations.push_back(std::move(observation));
 	}
 
@@ -222,6 +232,20 @@ struct MockS3Server::Impl {
 		    config.head_content_length.IsValid() ? config.head_content_length.GetIndex() : config.object_data.size();
 		response.set_header("Content-Length", std::to_string(content_length));
 		response.set_header("ETag", config.etag);
+		if (config.version_id_on_head && !config.version_id.empty()) {
+			response.set_header("x-amz-version-id", config.version_id);
+		}
+	}
+
+	string GetResponseETag() const {
+		return config.get_etag.empty() ? config.etag : config.get_etag;
+	}
+
+	void SetGetHeaders(httplib::Response &response) const {
+		response.set_header("ETag", GetResponseETag());
+		if (config.version_id_on_get && !config.version_id.empty()) {
+			response.set_header("x-amz-version-id", config.version_id);
+		}
 	}
 
 	void SendSlowDown(const httplib::Request &request, httplib::Response &response) const {
@@ -371,11 +395,16 @@ struct MockS3Server::Impl {
 				SendS3Error400(request, response, config.failure_is_request_timeout);
 				return;
 			}
+			if (config.enforce_if_match && GetHeader(request, "If-Match") != GetResponseETag()) {
+				response.status = 412;
+				Record(request, response.status);
+				return;
+			}
 
 			auto range = GetHeader(request, "Range");
 			if (range.empty()) {
 				response.status = 200;
-				response.set_header("ETag", config.etag);
+				SetGetHeaders(response);
 				if (config.block_full_get_until_released) {
 					response.set_content_provider(
 					    config.object_data.size(), "application/octet-stream",
@@ -419,7 +448,7 @@ struct MockS3Server::Impl {
 			}
 			if (config.range_behavior == MockS3RangeBehavior::IGNORE_RANGE) {
 				response.status = 200;
-				response.set_header("ETag", config.etag);
+				SetGetHeaders(response);
 				response.set_content(config.object_data, "application/octet-stream");
 				Record(request, response.status);
 				return;
@@ -441,7 +470,38 @@ struct MockS3Server::Impl {
 			range_request_started.notify_all();
 			response.status = 206;
 			response.set_header("Accept-Ranges", "bytes");
-			response.set_header("ETag", config.etag);
+			SetGetHeaders(response);
+			if (!config.blocked_range.empty() && range == config.blocked_range) {
+				response.set_content_provider(config.object_data.size(), "application/octet-stream",
+				                              [this](size_t offset, size_t length, httplib::DataSink &sink) {
+					                              std::unique_lock<std::mutex> lock(range_release_lock);
+					                              if (!range_release.wait_for(lock, std::chrono::seconds(5), [this]() {
+						                                  return release_range_completed;
+					                                  })) {
+						                              return false;
+					                              }
+					                              return sink.write(config.object_data.data() + offset, length);
+				                              });
+				Record(request, response.status);
+				return;
+			}
+			if (!config.release_range.empty() && range == config.release_range) {
+				response.set_content_provider(config.object_data.size(), "application/octet-stream",
+				                              [this](size_t offset, size_t length, httplib::DataSink &sink) {
+					                              const auto success =
+					                                  sink.write(config.object_data.data() + offset, length);
+					                              if (success) {
+						                              {
+							                              std::lock_guard<std::mutex> lock(range_release_lock);
+							                              release_range_completed = true;
+						                              }
+						                              range_release.notify_all();
+					                              }
+					                              return success;
+				                              });
+				Record(request, response.status);
+				return;
+			}
 			if (config.block_first_range_body_until_second_range && range_request_index == 1) {
 				auto wait_for_second_request = make_shared_ptr<std::atomic<bool>>(true);
 				response.set_content_provider(
@@ -582,11 +642,14 @@ struct MockS3Server::Impl {
 	mutable std::atomic<idx_t> remaining_delete_failures {0};
 	mutable std::atomic<idx_t> remaining_post_failures {0};
 	mutable std::atomic<idx_t> remaining_complete_post_failures {0};
-	mutable std::mutex observation_lock;
-	mutable vector<MockS3RequestObservation> observations;
+	mutable annotated_mutex observation_lock;
+	mutable vector<MockS3RequestObservation> observations DUCKDB_GUARDED_BY(observation_lock);
 	std::mutex range_request_lock;
 	std::condition_variable range_request_started;
 	idx_t range_requests_seen = 0;
+	std::mutex range_release_lock;
+	std::condition_variable range_release;
+	bool release_range_completed = false;
 	std::mutex full_get_lock;
 	std::condition_variable full_get_started;
 	std::condition_variable full_get_release;
@@ -672,9 +735,11 @@ string MockS3DescribeObservations(const vector<MockS3RequestObservation> &observ
 			result += "\n";
 		}
 		result += StringUtil::Format(
-		    "%s %s status=%d key=%s region=%s range=%s target=%s user_agent=%s session_header=%s", observation.method,
-		    observation.path, observation.status, observation.key_id, observation.region, observation.range,
-		    observation.target, observation.user_agent, observation.session_header);
+		    "%s %s status=%d key=%s region=%s range=%s if_match=%s version_id=%s target=%s user_agent=%s "
+		    "session_header=%s",
+		    observation.method, observation.path, observation.status, observation.key_id, observation.region,
+		    observation.range, observation.if_match, observation.version_id, observation.target, observation.user_agent,
+		    observation.session_header);
 	}
 	return result;
 }

--- a/test/unittest/mock_s3_server.hpp
+++ b/test/unittest/mock_s3_server.hpp
@@ -19,25 +19,35 @@ enum class MockS3RefreshTarget : uint8_t {
 
 enum class MockS3RangeBehavior : uint8_t { NORMAL, IGNORE_RANGE, TRUNCATE_TRANSFER, SHORT_SUCCESS };
 
-struct MockS3ServerConfig {
+struct MockS3ObjectConfig {
 	string bucket = "refresh-bucket";
-	string object_key = "object.bin";
-	string object_data = "abcdefghijklmnopqrstuvwxyz0123456789";
+	string key = "object.bin";
+	string data = "abcdefghijklmnopqrstuvwxyz0123456789";
+};
+
+struct MockS3AuthConfig {
 	string stale_key_id = "STALE_KEY";
-	int stale_auth_status = 403;
-	string stale_auth_error_code = "AccessDenied";
+	int stale_status = 403;
+	string stale_error_code = "AccessDenied";
+	string required_region;
+	MockS3RefreshTarget refresh_target = MockS3RefreshTarget::HEAD;
+};
+
+struct MockS3MetadataConfig {
 	string etag = "\"httpfs-refresh-test-etag\"";
 	//! ETag returned by GET; use etag when empty
 	string get_etag;
 	//! S3 version ID returned by selected metadata/data responses
 	string version_id;
-	bool version_id_on_head = false;
-	bool version_id_on_get = false;
+	bool version_on_head = false;
+	bool version_on_get = false;
 	//! Reject GETs whose If-Match does not equal the GET ETag
 	bool enforce_if_match = false;
-	//! Redirect signed requests to this region when their credential scope uses a different one
-	string required_region;
-	MockS3RefreshTarget refresh_target = MockS3RefreshTarget::HEAD;
+	//! Override the Content-Length reported by HEAD while keeping the GET body unchanged
+	optional_idx head_content_length;
+};
+
+struct MockS3FailureConfig {
 	//! Answer this many leading ListObjectsV2 requests with HTTP 503 SlowDown
 	idx_t transient_503_lists = 0;
 	//! Answer this many leading ListObjectsV2 requests with HTTP 400
@@ -46,25 +56,6 @@ struct MockS3ServerConfig {
 	idx_t transient_put_failures = 0;
 	//! Number of object GETs to fail with a 400 before succeeding
 	idx_t transient_get_failures = 0;
-	//! Range response behavior to inject
-	MockS3RangeBehavior range_behavior = MockS3RangeBehavior::NORMAL;
-	//! Number of leading range GETs affected by transient range behaviors
-	idx_t range_behavior_requests = 0;
-	//! Number of bytes to omit from an injected truncated range response
-	idx_t truncated_range_bytes = 1;
-	//! Override the Content-Length reported by HEAD while keeping the GET body unchanged
-	optional_idx head_content_length;
-	//! Send successful full GETs with chunked transfer encoding and no Content-Length
-	bool chunked_full_get = false;
-	//! Advertise byte-range support on HEAD responses
-	bool advertise_ranges = true;
-	//! Hold the first range response body until a second range request arrives
-	bool block_first_range_body_until_second_range = false;
-	//! Hold this exact range response body until release_range has emitted its body
-	string blocked_range;
-	string release_range;
-	//! Hold a full GET response body until ReleaseFullGet is called
-	bool block_full_get_until_released = false;
 	//! Number of object HEADs to fail with a 400 before succeeding
 	idx_t transient_head_failures = 0;
 	//! Number of object HEADs to answer with 404 before succeeding
@@ -79,6 +70,37 @@ struct MockS3ServerConfig {
 	bool failure_is_request_timeout = true;
 	//! Whether injected 400 bodies are truncated mid-XML (an open <Code> with no closing tag)
 	bool truncated_failure_body = false;
+};
+
+struct MockS3RangeConfig {
+	MockS3RangeBehavior behavior = MockS3RangeBehavior::NORMAL;
+	//! Number of leading range GETs affected by transient range behaviors
+	idx_t behavior_requests = 0;
+	//! Number of bytes to omit from an injected truncated range response
+	idx_t truncated_bytes = 1;
+	//! Advertise byte-range support on HEAD responses
+	bool advertise = true;
+	//! Hold the first range response body until a second range request arrives
+	bool block_first_body_until_second = false;
+	//! Hold this exact range response body until release_range has emitted its body
+	string blocked;
+	string release;
+};
+
+struct MockS3FullGetConfig {
+	//! Send successful responses with chunked transfer encoding and no Content-Length
+	bool chunked = false;
+	//! Hold the response body until ReleaseFullGet is called
+	bool block_until_released = false;
+};
+
+struct MockS3ServerConfig {
+	MockS3ObjectConfig object;
+	MockS3AuthConfig auth;
+	MockS3MetadataConfig metadata;
+	MockS3FailureConfig failures;
+	MockS3RangeConfig range;
+	MockS3FullGetConfig full_get;
 };
 
 struct MockS3RequestObservation {

--- a/test/unittest/mock_s3_server.hpp
+++ b/test/unittest/mock_s3_server.hpp
@@ -27,6 +27,14 @@ struct MockS3ServerConfig {
 	int stale_auth_status = 403;
 	string stale_auth_error_code = "AccessDenied";
 	string etag = "\"httpfs-refresh-test-etag\"";
+	//! ETag returned by GET; use etag when empty
+	string get_etag;
+	//! S3 version ID returned by selected metadata/data responses
+	string version_id;
+	bool version_id_on_head = false;
+	bool version_id_on_get = false;
+	//! Reject GETs whose If-Match does not equal the GET ETag
+	bool enforce_if_match = false;
 	//! Redirect signed requests to this region when their credential scope uses a different one
 	string required_region;
 	MockS3RefreshTarget refresh_target = MockS3RefreshTarget::HEAD;
@@ -52,6 +60,9 @@ struct MockS3ServerConfig {
 	bool advertise_ranges = true;
 	//! Hold the first range response body until a second range request arrives
 	bool block_first_range_body_until_second_range = false;
+	//! Hold this exact range response body until release_range has emitted its body
+	string blocked_range;
+	string release_range;
 	//! Hold a full GET response body until ReleaseFullGet is called
 	bool block_full_get_until_released = false;
 	//! Number of object HEADs to fail with a 400 before succeeding
@@ -75,6 +86,8 @@ struct MockS3RequestObservation {
 	string path;
 	string target;
 	string range;
+	string if_match;
+	string version_id;
 	string key_id;
 	string region;
 	string user_agent;

--- a/test/unittest/positional_read_test.cpp
+++ b/test/unittest/positional_read_test.cpp
@@ -1,0 +1,540 @@
+#include "catch.hpp"
+
+#include "mock_s3_server.hpp"
+
+#include "httpfs.hpp"
+#include "httpfs_extension.hpp"
+
+#include "duckdb.hpp"
+#include "duckdb/common/error_data.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+#include <atomic>
+#include <thread>
+
+namespace duckdb {
+
+namespace {
+
+static void LoadHTTPFSExtension(DuckDB &db) {
+	if (db.ExtensionIsLoaded("httpfs")) {
+		return;
+	}
+	ExtensionInfo extension_info;
+	ExtensionActiveLoad load_info(*db.instance, extension_info, "httpfs", "");
+	ExtensionLoader loader(load_info);
+	HttpfsExtension extension;
+	extension.Load(loader);
+}
+
+static void RequireQueryOk(Connection &con, const string &query) {
+	auto result = con.Query(query);
+	REQUIRE(result);
+	INFO((result->HasError() ? result->GetError() : string()));
+	REQUIRE_FALSE(result->HasError());
+}
+
+static void ConfigureHTTPReadTest(DuckDB &db, Connection &con, const string &client_implementation, idx_t retries = 0) {
+	LoadHTTPFSExtension(db);
+	RequireQueryOk(con, "SET httpfs_client_implementation='" + client_implementation + "'");
+	RequireQueryOk(con, "SET httpfs_connection_caching=false");
+	RequireQueryOk(con, "SET enable_external_file_cache=false");
+	RequireQueryOk(con, "SET http_retries=" + to_string(retries));
+	RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	RequireQueryOk(con, "SET http_retry_backoff=1");
+}
+
+static void ConfigureS3ReadTest(DuckDB &db, Connection &con, MockS3Server &server, const string &client_implementation,
+                                idx_t retries = 0) {
+	ConfigureHTTPReadTest(db, con, client_implementation, retries);
+	RequireQueryOk(con, StringUtil::Format(R"(
+CREATE SECRET positional_read_s3 (
+	TYPE S3,
+	PROVIDER CONFIG,
+	SCOPE 's3://refresh-bucket/',
+	KEY_ID 'POSITIONAL_KEY',
+	SECRET 'POSITIONAL_SECRET',
+	REGION 'us-east-1',
+	ENDPOINT '%s',
+	USE_SSL false,
+	URL_STYLE 'path'
+))",
+	                                       server.Endpoint()));
+}
+
+struct ReadOutcome {
+	bool failed = false;
+	bool internal_error = false;
+	string error;
+	string data;
+};
+
+static ReadOutcome TryReadHandle(Connection &con, FileHandle &handle, idx_t offset, idx_t length) {
+	ReadOutcome result;
+	try {
+		result.data.resize(length, '?');
+		handle.Read(QueryContext(*con.context), result.data.data(), length, offset);
+	} catch (std::exception &ex) {
+		result.failed = true;
+		result.error = ex.what();
+		ErrorData error(ex);
+		result.internal_error = error.Type() == ExceptionType::INTERNAL || error.Type() == ExceptionType::FATAL;
+	}
+	return result;
+}
+
+static string ReadSequential(Connection &con, FileHandle &handle, idx_t length) {
+	string result(length, '?');
+	auto read_count = handle.Read(QueryContext(*con.context), result.data(), length);
+	result.resize(NumericCast<idx_t>(read_count));
+	return result;
+}
+
+static vector<MockS3RequestObservation> RangeObservations(const MockS3Server &server) {
+	vector<MockS3RequestObservation> result;
+	for (auto &observation : server.Observations()) {
+		if (observation.method == "GET" && !observation.range.empty()) {
+			result.push_back(observation);
+		}
+	}
+	return result;
+}
+
+static void RunConcurrentPositionalRead(const string &client_implementation, bool s3, bool parallel_access) {
+	static constexpr idx_t READ_SIZE = 64 * 1024;
+	static constexpr idx_t SECOND_OFFSET = READ_SIZE / 2;
+	MockS3ServerConfig config;
+	config.object_data.resize(READ_SIZE * 2);
+	for (idx_t i = 0; i < config.object_data.size(); i++) {
+		config.object_data[i] = NumericCast<char>('a' + (i % 26));
+	}
+	config.blocked_range = StringUtil::Format("bytes=0-%llu", static_cast<unsigned long long>(READ_SIZE - 1));
+	config.release_range = StringUtil::Format("bytes=%llu-%llu", static_cast<unsigned long long>(SECOND_OFFSET),
+	                                          static_cast<unsigned long long>(SECOND_OFFSET + READ_SIZE - 1));
+	config.version_id = "version-concurrent";
+	config.version_id_on_head = s3;
+	auto expected_data = config.object_data;
+	auto blocked_range = config.blocked_range;
+	auto release_range = config.release_range;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	if (s3) {
+		ConfigureS3ReadTest(db, con, server, client_implementation);
+		RequireQueryOk(con, "SET s3_version_id_pinning=true");
+	} else {
+		ConfigureHTTPReadTest(db, con, client_implementation);
+	}
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto flags = FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO;
+	if (parallel_access) {
+		flags |= FileFlags::FILE_FLAGS_PARALLEL_ACCESS;
+	}
+	auto handle = fs.OpenFile(s3 ? server.S3Path() : server.HTTPPath(), flags);
+	handle->Seek(17);
+
+	std::atomic<bool> start {false};
+	ReadOutcome first;
+	ReadOutcome second;
+	std::thread first_reader([&]() {
+		while (!start.load()) {
+			std::this_thread::yield();
+		}
+		first = TryReadHandle(con, *handle, 0, READ_SIZE);
+	});
+	std::thread second_reader([&]() {
+		while (!start.load()) {
+			std::this_thread::yield();
+		}
+		second = TryReadHandle(con, *handle, SECOND_OFFSET, READ_SIZE);
+	});
+	start = true;
+	first_reader.join();
+	second_reader.join();
+
+	INFO(first.error);
+	INFO(second.error);
+	REQUIRE_FALSE(first.failed);
+	REQUIRE_FALSE(second.failed);
+	REQUIRE(first.data == expected_data.substr(0, READ_SIZE));
+	REQUIRE(second.data == expected_data.substr(SECOND_OFFSET, READ_SIZE));
+	REQUIRE(handle->SeekPosition() == 17);
+
+	auto observations = RangeObservations(server);
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(observations.size() == 2);
+	for (auto &observation : observations) {
+		REQUIRE((observation.range == blocked_range || observation.range == release_range));
+		if (s3) {
+			REQUIRE(observation.version_id == "version-concurrent");
+			REQUIRE(observation.if_match.empty());
+		} else {
+			REQUIRE(observation.if_match == "\"httpfs-refresh-test-etag\"");
+			REQUIRE(observation.version_id.empty());
+		}
+	}
+
+	NetworkThroughputEstimate estimate;
+	REQUIRE(handle->TryGetNetworkThroughput(estimate));
+	REQUIRE(estimate.latency_seconds > 0);
+	REQUIRE(estimate.bandwidth_bytes_per_s > 0);
+	RequireQueryOk(con, "COMMIT");
+}
+
+static void RunSequentialPositionalSeparation(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.object_data = "abcdefghijklmnopqrstuvwxyz0123456789";
+	auto expected_data = config.object_data;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureHTTPReadTest(db, con, client_implementation);
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(server.HTTPPath(), FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	REQUIRE(ReadSequential(con, *handle, 5) == expected_data.substr(0, 5));
+	REQUIRE(TryReadHandle(con, *handle, 20, 4).data == expected_data.substr(20, 4));
+	REQUIRE(handle->SeekPosition() == 5);
+	REQUIRE(ReadSequential(con, *handle, 5) == expected_data.substr(5, 5));
+	REQUIRE(handle->SeekPosition() == 10);
+	RequireQueryOk(con, "COMMIT");
+}
+
+static void RunETagConditionCase(const string &etag, const string &expected_if_match, bool disable_checks = false) {
+	MockS3ServerConfig config;
+	config.etag = etag;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureHTTPReadTest(db, con, "curl");
+	if (disable_checks) {
+		RequireQueryOk(con, "SET unsafe_disable_etag_checks=true");
+	}
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(server.HTTPPath(), FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	auto outcome = TryReadHandle(con, *handle, 2, 5);
+	INFO(outcome.error);
+	REQUIRE_FALSE(outcome.failed);
+
+	auto observations = RangeObservations(server);
+	REQUIRE(observations.size() == 1);
+	REQUIRE(observations[0].if_match == expected_if_match);
+	RequireQueryOk(con, "COMMIT");
+}
+
+static void RunConfiguredReadHeaderCollision() {
+	MockS3ServerConfig config;
+	config.object_data = "abcdefghijklmnopqrstuvwxyz";
+	auto expected_data = config.object_data;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureHTTPReadTest(db, con, "curl");
+	RequireQueryOk(con, StringUtil::Format(R"(
+CREATE SECRET positional_read_headers (
+	TYPE HTTP,
+	SCOPE '%s',
+	EXTRA_HTTP_HEADERS MAP {
+		'Range': 'bytes=10-14'
+	}
+))",
+	                                       server.HTTPPath()));
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(server.HTTPPath(), FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	auto outcome = TryReadHandle(con, *handle, 2, 5);
+	INFO(outcome.error);
+	CHECK_FALSE(outcome.failed);
+	if (!outcome.failed) {
+		CHECK(outcome.data == expected_data.substr(2, 5));
+	}
+
+	auto observations = RangeObservations(server);
+	INFO(MockS3DescribeObservations(observations));
+	CHECK(observations.size() == 1);
+	for (auto &observation : observations) {
+		CHECK(observation.range == "bytes=2-6");
+	}
+	RequireQueryOk(con, "COMMIT");
+}
+
+static void RunConfiguredIfMatchCollision() {
+	MockS3ServerConfig config;
+	config.enforce_if_match = true;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureHTTPReadTest(db, con, "curl");
+	RequireQueryOk(con, StringUtil::Format(R"(
+CREATE SECRET positional_read_headers (
+	TYPE HTTP,
+	SCOPE '%s',
+	EXTRA_HTTP_HEADERS MAP {
+		'If-Match': '"configured-etag"'
+	}
+))",
+	                                       server.HTTPPath()));
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(server.HTTPPath(), FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	auto outcome = TryReadHandle(con, *handle, 2, 5);
+	INFO(outcome.error);
+	CHECK_FALSE(outcome.failed);
+
+	auto observations = RangeObservations(server);
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(observations.size() == 1);
+	CHECK(observations[0].if_match == "\"httpfs-refresh-test-etag\"");
+	RequireQueryOk(con, "COMMIT");
+}
+
+static void RunPreconditionFailure(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.etag = "\"opened-etag\"";
+	config.get_etag = "\"changed-etag\"";
+	config.enforce_if_match = true;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureHTTPReadTest(db, con, client_implementation, 3);
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(server.HTTPPath(), FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	handle->Seek(9);
+	auto outcome = TryReadHandle(con, *handle, 2, 5);
+	INFO(outcome.error);
+	REQUIRE(outcome.failed);
+	REQUIRE_FALSE(outcome.internal_error);
+	REQUIRE(outcome.error.find("changed after it was opened") != string::npos);
+	REQUIRE(handle->SeekPosition() == 9);
+
+	auto observations = RangeObservations(server);
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(observations.size() == 1);
+	REQUIRE(observations[0].status == 412);
+	REQUIRE(observations[0].if_match == "\"opened-etag\"");
+	RequireQueryOk(con, "COMMIT");
+}
+
+static void RunImmutableS3ReadCondition(const string &client_implementation, bool disable_etag_checks) {
+	MockS3ServerConfig config;
+	config.version_id = "version-from-get";
+	config.version_id_on_get = true;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureS3ReadTest(db, con, server, client_implementation);
+	RequireQueryOk(con, "SET s3_version_id_pinning=true");
+	if (disable_etag_checks) {
+		RequireQueryOk(con, "SET unsafe_disable_etag_checks=true");
+	}
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(server.S3Path(), FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	REQUIRE_FALSE(TryReadHandle(con, *handle, 0, 5).failed);
+	REQUIRE_FALSE(TryReadHandle(con, *handle, 5, 5).failed);
+
+	auto observations = RangeObservations(server);
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(observations.size() == 2);
+	REQUIRE(observations[0].version_id.empty());
+	REQUIRE(observations[1].version_id.empty());
+	if (disable_etag_checks) {
+		REQUIRE(observations[0].if_match.empty());
+		REQUIRE(observations[1].if_match.empty());
+	} else {
+		REQUIRE(observations[0].if_match == "\"httpfs-refresh-test-etag\"");
+		REQUIRE(observations[1].if_match == "\"httpfs-refresh-test-etag\"");
+	}
+	RequireQueryOk(con, "COMMIT");
+}
+
+static void RunConditionalFullDownload(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.range_behavior = MockS3RangeBehavior::IGNORE_RANGE;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureHTTPReadTest(db, con, client_implementation);
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(server.HTTPPath(), FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	handle->Seek(11);
+	auto outcome = TryReadHandle(con, *handle, 2, 5);
+	INFO(outcome.error);
+	REQUIRE_FALSE(outcome.failed);
+	REQUIRE(handle->SeekPosition() == 11);
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	idx_t conditional_gets = 0;
+	for (auto &observation : observations) {
+		if (observation.method == "GET") {
+			REQUIRE(observation.if_match == "\"httpfs-refresh-test-etag\"");
+			conditional_gets++;
+		}
+	}
+	REQUIRE(conditional_gets == 2);
+	RequireQueryOk(con, "COMMIT");
+}
+
+static void RunConditionSurvivesRetry(const string &client_implementation, bool s3) {
+	MockS3ServerConfig config;
+	config.transient_get_failures = 1;
+	config.version_id = "version-retry";
+	config.version_id_on_head = s3;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	if (s3) {
+		ConfigureS3ReadTest(db, con, server, client_implementation, 1);
+		RequireQueryOk(con, "SET s3_version_id_pinning=true");
+	} else {
+		ConfigureHTTPReadTest(db, con, client_implementation, 1);
+	}
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(s3 ? server.S3Path() : server.HTTPPath(),
+	                          FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	auto outcome = TryReadHandle(con, *handle, 2, 5);
+	INFO(outcome.error);
+	REQUIRE_FALSE(outcome.failed);
+
+	auto observations = RangeObservations(server);
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(observations.size() == 2);
+	REQUIRE(observations[0].status == 400);
+	REQUIRE(observations[1].status == 206);
+	for (auto &observation : observations) {
+		if (s3) {
+			REQUIRE(observation.version_id == "version-retry");
+			REQUIRE(observation.if_match.empty());
+		} else {
+			REQUIRE(observation.version_id.empty());
+			REQUIRE(observation.if_match == "\"httpfs-refresh-test-etag\"");
+		}
+	}
+	RequireQueryOk(con, "COMMIT");
+}
+
+static void RunS3ThresholdFullDownload(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.version_id = "version-threshold";
+	config.version_id_on_head = true;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureS3ReadTest(db, con, server, client_implementation);
+	RequireQueryOk(con, "SET s3_version_id_pinning=true");
+	RequireQueryOk(con, "SET force_download_threshold=1024");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(server.S3Path(), FileFlags::FILE_FLAGS_READ);
+	REQUIRE(handle);
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	idx_t full_gets = 0;
+	for (auto &observation : observations) {
+		if (observation.method == "GET" && observation.range.empty()) {
+			REQUIRE(observation.version_id == "version-threshold");
+			REQUIRE(observation.if_match.empty());
+			full_gets++;
+		}
+	}
+	REQUIRE(full_gets == 1);
+	RequireQueryOk(con, "COMMIT");
+}
+
+} // namespace
+
+TEST_CASE("HTTP positional reads are independent on one handle", "[httpfs][positional-read]") {
+	for (auto &client : {"curl", "httplib"}) {
+		DYNAMIC_SECTION(client << " generic default flags") {
+			RunConcurrentPositionalRead(client, false, false);
+		}
+		DYNAMIC_SECTION(client << " generic parallel-access flag") {
+			RunConcurrentPositionalRead(client, false, true);
+		}
+		DYNAMIC_SECTION(client << " S3 default flags") {
+			RunConcurrentPositionalRead(client, true, false);
+		}
+		DYNAMIC_SECTION(client << " S3 parallel-access flag") {
+			RunConcurrentPositionalRead(client, true, true);
+		}
+	}
+}
+
+TEST_CASE("HTTP positional reads do not move the sequential cursor", "[httpfs][positional-read]") {
+	RunSequentialPositionalSeparation("curl");
+	RunSequentialPositionalSeparation("httplib");
+}
+
+TEST_CASE("HTTP reads select only usable ETag conditions", "[httpfs][positional-read][etag]") {
+	RunETagConditionCase("\"strong\"", "\"strong\"");
+	RunETagConditionCase("W/\"weak\"", "");
+	RunETagConditionCase("malformed", "");
+	RunETagConditionCase("", "");
+	RunETagConditionCase("\"strong\"", "", true);
+}
+
+TEST_CASE("configured headers do not override positional read headers", "[httpfs][positional-read][headers]") {
+	RunConfiguredReadHeaderCollision();
+	RunConfiguredIfMatchCollision();
+}
+
+TEST_CASE("HTTP ETag precondition failures are terminal", "[httpfs][positional-read][etag]") {
+	RunPreconditionFailure("curl");
+	RunPreconditionFailure("httplib");
+}
+
+TEST_CASE("HTTP read conditions survive transport retries", "[httpfs][positional-read][retry]") {
+	for (auto &client : {"curl", "httplib"}) {
+		DYNAMIC_SECTION(client << " generic HTTP") {
+			RunConditionSurvivesRetry(client, false);
+		}
+		DYNAMIC_SECTION(client << " S3") {
+			RunConditionSurvivesRetry(client, true);
+		}
+	}
+}
+
+TEST_CASE("S3 GET responses do not change the handle's read condition", "[httpfs][positional-read][s3-version]") {
+	RunImmutableS3ReadCondition("curl", false);
+	RunImmutableS3ReadCondition("httplib", false);
+	RunImmutableS3ReadCondition("curl", true);
+	RunImmutableS3ReadCondition("httplib", true);
+}
+
+TEST_CASE("HTTP full downloads retain their read condition", "[httpfs][positional-read][full-download]") {
+	RunConditionalFullDownload("curl");
+	RunConditionalFullDownload("httplib");
+	RunS3ThresholdFullDownload("curl");
+	RunS3ThresholdFullDownload("httplib");
+}
+
+} // namespace duckdb

--- a/test/unittest/positional_read_test.cpp
+++ b/test/unittest/positional_read_test.cpp
@@ -106,18 +106,18 @@ static void RunConcurrentPositionalRead(const string &client_implementation, boo
 	static constexpr idx_t READ_SIZE = 64 * 1024;
 	static constexpr idx_t SECOND_OFFSET = READ_SIZE / 2;
 	MockS3ServerConfig config;
-	config.object_data.resize(READ_SIZE * 2);
-	for (idx_t i = 0; i < config.object_data.size(); i++) {
-		config.object_data[i] = NumericCast<char>('a' + (i % 26));
+	config.object.data.resize(READ_SIZE * 2);
+	for (idx_t i = 0; i < config.object.data.size(); i++) {
+		config.object.data[i] = NumericCast<char>('a' + (i % 26));
 	}
-	config.blocked_range = StringUtil::Format("bytes=0-%llu", static_cast<unsigned long long>(READ_SIZE - 1));
-	config.release_range = StringUtil::Format("bytes=%llu-%llu", static_cast<unsigned long long>(SECOND_OFFSET),
+	config.range.blocked = StringUtil::Format("bytes=0-%llu", static_cast<unsigned long long>(READ_SIZE - 1));
+	config.range.release = StringUtil::Format("bytes=%llu-%llu", static_cast<unsigned long long>(SECOND_OFFSET),
 	                                          static_cast<unsigned long long>(SECOND_OFFSET + READ_SIZE - 1));
-	config.version_id = "version-concurrent";
-	config.version_id_on_head = s3;
-	auto expected_data = config.object_data;
-	auto blocked_range = config.blocked_range;
-	auto release_range = config.release_range;
+	config.metadata.version_id = "version-concurrent";
+	config.metadata.version_on_head = s3;
+	auto expected_data = config.object.data;
+	auto blocked_range = config.range.blocked;
+	auto release_range = config.range.release;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -188,8 +188,8 @@ static void RunConcurrentPositionalRead(const string &client_implementation, boo
 
 static void RunSequentialPositionalSeparation(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.object_data = "abcdefghijklmnopqrstuvwxyz0123456789";
-	auto expected_data = config.object_data;
+	config.object.data = "abcdefghijklmnopqrstuvwxyz0123456789";
+	auto expected_data = config.object.data;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -209,7 +209,7 @@ static void RunSequentialPositionalSeparation(const string &client_implementatio
 
 static void RunETagConditionCase(const string &etag, const string &expected_if_match, bool disable_checks = false) {
 	MockS3ServerConfig config;
-	config.etag = etag;
+	config.metadata.etag = etag;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -234,8 +234,8 @@ static void RunETagConditionCase(const string &etag, const string &expected_if_m
 
 static void RunConfiguredReadHeaderCollision() {
 	MockS3ServerConfig config;
-	config.object_data = "abcdefghijklmnopqrstuvwxyz";
-	auto expected_data = config.object_data;
+	config.object.data = "abcdefghijklmnopqrstuvwxyz";
+	auto expected_data = config.object.data;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -272,7 +272,7 @@ CREATE SECRET positional_read_headers (
 
 static void RunConfiguredIfMatchCollision() {
 	MockS3ServerConfig config;
-	config.enforce_if_match = true;
+	config.metadata.enforce_if_match = true;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -304,9 +304,9 @@ CREATE SECRET positional_read_headers (
 
 static void RunPreconditionFailure(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.etag = "\"opened-etag\"";
-	config.get_etag = "\"changed-etag\"";
-	config.enforce_if_match = true;
+	config.metadata.etag = "\"opened-etag\"";
+	config.metadata.get_etag = "\"changed-etag\"";
+	config.metadata.enforce_if_match = true;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -334,8 +334,8 @@ static void RunPreconditionFailure(const string &client_implementation) {
 
 static void RunImmutableS3ReadCondition(const string &client_implementation, bool disable_etag_checks) {
 	MockS3ServerConfig config;
-	config.version_id = "version-from-get";
-	config.version_id_on_get = true;
+	config.metadata.version_id = "version-from-get";
+	config.metadata.version_on_get = true;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -369,7 +369,7 @@ static void RunImmutableS3ReadCondition(const string &client_implementation, boo
 
 static void RunConditionalFullDownload(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.range_behavior = MockS3RangeBehavior::IGNORE_RANGE;
+	config.range.behavior = MockS3RangeBehavior::IGNORE_RANGE;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -400,9 +400,9 @@ static void RunConditionalFullDownload(const string &client_implementation) {
 
 static void RunConditionSurvivesRetry(const string &client_implementation, bool s3) {
 	MockS3ServerConfig config;
-	config.transient_get_failures = 1;
-	config.version_id = "version-retry";
-	config.version_id_on_head = s3;
+	config.failures.transient_get_failures = 1;
+	config.metadata.version_id = "version-retry";
+	config.metadata.version_on_head = s3;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -441,8 +441,8 @@ static void RunConditionSurvivesRetry(const string &client_implementation, bool 
 
 static void RunS3ThresholdFullDownload(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.version_id = "version-threshold";
-	config.version_id_on_head = true;
+	config.metadata.version_id = "version-threshold";
+	config.metadata.version_on_head = true;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);

--- a/test/unittest/s3_list_retry_test.cpp
+++ b/test/unittest/s3_list_retry_test.cpp
@@ -67,10 +67,10 @@ static idx_t CountListObservations(const vector<MockS3RequestObservation> &obser
 static void RunRecoveringListRetryTest(const string &client_implementation, int status) {
 	MockS3ServerConfig config;
 	if (status == 503) {
-		config.transient_503_lists = 1;
+		config.failures.transient_503_lists = 1;
 	} else {
 		D_ASSERT(status == 400);
-		config.transient_400_lists = 1;
+		config.failures.transient_400_lists = 1;
 	}
 	MockS3Server server(std::move(config));
 
@@ -94,10 +94,10 @@ static void RunRecoveringListRetryTest(const string &client_implementation, int 
 static void RunExhaustedListRetryTest(const string &client_implementation, int status) {
 	MockS3ServerConfig config;
 	if (status == 503) {
-		config.transient_503_lists = 1000;
+		config.failures.transient_503_lists = 1000;
 	} else {
 		D_ASSERT(status == 400);
-		config.transient_400_lists = 1000;
+		config.failures.transient_400_lists = 1000;
 	}
 	MockS3Server server(std::move(config));
 
@@ -120,8 +120,8 @@ static void RunExhaustedListRetryTest(const string &client_implementation, int s
 
 static void RunGeneric400ListTest(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.transient_400_lists = 1000;
-	config.failure_is_request_timeout = false;
+	config.failures.transient_400_lists = 1000;
+	config.failures.failure_is_request_timeout = false;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);

--- a/test/unittest/short_read_test.cpp
+++ b/test/unittest/short_read_test.cpp
@@ -138,10 +138,10 @@ static void RunPersistentShortRead() {
 	const string expected_range = "bytes=113-1136";
 
 	MockS3ServerConfig config;
-	config.object_data = string(8192, 'x');
-	config.range_behavior = MockS3RangeBehavior::TRUNCATE_TRANSFER;
-	config.range_behavior_requests = 4;
-	config.truncated_range_bytes = 17;
+	config.object.data = string(8192, 'x');
+	config.range.behavior = MockS3RangeBehavior::TRUNCATE_TRANSFER;
+	config.range.behavior_requests = 4;
+	config.range.truncated_bytes = 17;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -165,11 +165,11 @@ static void RunTransientShortRead() {
 	const string expected_range = "bytes=113-1136";
 
 	MockS3ServerConfig config;
-	config.object_data = string(8192, 'x');
-	config.range_behavior = MockS3RangeBehavior::TRUNCATE_TRANSFER;
-	config.range_behavior_requests = 1;
-	config.truncated_range_bytes = 17;
-	auto expected = config.object_data.substr(READ_OFFSET, READ_LENGTH);
+	config.object.data = string(8192, 'x');
+	config.range.behavior = MockS3RangeBehavior::TRUNCATE_TRANSFER;
+	config.range.behavior_requests = 1;
+	config.range.truncated_bytes = 17;
+	auto expected = config.object.data.substr(READ_OFFSET, READ_LENGTH);
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -191,10 +191,10 @@ static void RunSuccessfulShortResponse() {
 	const string expected_range = "bytes=113-1136";
 
 	MockS3ServerConfig config;
-	config.object_data = string(8192, 'x');
-	config.range_behavior = MockS3RangeBehavior::SHORT_SUCCESS;
-	config.range_behavior_requests = 1;
-	config.truncated_range_bytes = 17;
+	config.object.data = string(8192, 'x');
+	config.range.behavior = MockS3RangeBehavior::SHORT_SUCCESS;
+	config.range.behavior_requests = 1;
+	config.range.truncated_bytes = 17;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -215,9 +215,9 @@ static void RunSuccessfulShortResponse() {
 
 static void RunParallelRangeHeaderRelease(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.object_data = string(8192, 'x');
-	config.advertise_ranges = false;
-	config.block_first_range_body_until_second_range = true;
+	config.object.data = string(8192, 'x');
+	config.range.advertise = false;
+	config.range.block_first_body_until_second = true;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -261,8 +261,8 @@ static void RunParallelRangeHeaderRelease(const string &client_implementation) {
 
 static void RunCompletedErrorConnectionReuse(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.transient_head_failures = 1;
-	config.failure_is_request_timeout = false;
+	config.failures.transient_head_failures = 1;
+	config.failures.failure_is_request_timeout = false;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -287,7 +287,7 @@ static void RunCompletedErrorConnectionReuse(const string &client_implementation
 
 static void RunSharedConnectionNotFoundReuse() {
 	MockS3ServerConfig config;
-	config.head_not_found_requests = 2;
+	config.failures.head_not_found_requests = 2;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -313,14 +313,14 @@ static void RunFullDownloadSingleFlight(const string &client_implementation, boo
 	const vector<idx_t> offsets {0, 2048, 4096, 6144};
 
 	MockS3ServerConfig config;
-	config.object_data.resize(8192);
-	for (idx_t i = 0; i < config.object_data.size(); i++) {
-		config.object_data[i] = NumericCast<char>('a' + (i % 26));
+	config.object.data.resize(8192);
+	for (idx_t i = 0; i < config.object.data.size(); i++) {
+		config.object.data[i] = NumericCast<char>('a' + (i % 26));
 	}
-	const auto expected_data = config.object_data;
-	config.advertise_ranges = false;
-	config.range_behavior = MockS3RangeBehavior::IGNORE_RANGE;
-	config.block_full_get_until_released = true;
+	const auto expected_data = config.object.data;
+	config.range.advertise = false;
+	config.range.behavior = MockS3RangeBehavior::IGNORE_RANGE;
+	config.full_get.block_until_released = true;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -371,8 +371,8 @@ static void RunFullDownloadSingleFlight(const string &client_implementation, boo
 
 static void RunExactSequentialReadGeometry(const string &client_implementation, FileOpenFlags flags) {
 	MockS3ServerConfig config;
-	config.object_data = CreateObjectData(8192);
-	auto expected_data = config.object_data;
+	config.object.data = CreateObjectData(8192);
+	auto expected_data = config.object.data;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -412,11 +412,11 @@ static void RunSequentialFailureKeepsPosition(const string &client_implementatio
 	static constexpr idx_t READ_LENGTH = 1024;
 
 	MockS3ServerConfig config;
-	config.object_data = CreateObjectData(8192);
-	auto expected_data = config.object_data;
-	config.range_behavior = MockS3RangeBehavior::TRUNCATE_TRANSFER;
-	config.range_behavior_requests = 1;
-	config.truncated_range_bytes = 17;
+	config.object.data = CreateObjectData(8192);
+	auto expected_data = config.object.data;
+	config.range.behavior = MockS3RangeBehavior::TRUNCATE_TRANSFER;
+	config.range.behavior_requests = 1;
+	config.range.truncated_bytes = 17;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -455,10 +455,10 @@ static void RunSequentialFailureKeepsPosition(const string &client_implementatio
 
 static void RunSequentialFullDownloadFallback(const string &client_implementation) {
 	MockS3ServerConfig config;
-	config.object_data = CreateObjectData(8192);
-	auto expected_data = config.object_data;
-	config.advertise_ranges = false;
-	config.range_behavior = MockS3RangeBehavior::IGNORE_RANGE;
+	config.object.data = CreateObjectData(8192);
+	auto expected_data = config.object.data;
+	config.range.advertise = false;
+	config.range.behavior = MockS3RangeBehavior::IGNORE_RANGE;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -533,9 +533,9 @@ TEST_CASE("HTTP full-download fallback is single-flight", "[httpfs][full-downloa
 
 TEST_CASE("HTTP full-download fallback rejects HEAD and GET length mismatches", "[httpfs][full-download][issue-354]") {
 	MockS3ServerConfig config;
-	config.object_data = "AB";
-	config.head_content_length = 3;
-	config.range_behavior = MockS3RangeBehavior::IGNORE_RANGE;
+	config.object.data = "AB";
+	config.metadata.head_content_length = 3;
+	config.range.behavior = MockS3RangeBehavior::IGNORE_RANGE;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);

--- a/test/unittest/short_read_test.cpp
+++ b/test/unittest/short_read_test.cpp
@@ -117,6 +117,21 @@ static string ReadRange(Connection &con, const string &path, idx_t offset, idx_t
 	return buffer;
 }
 
+static string ReadSequential(Connection &con, FileHandle &handle, idx_t length) {
+	string buffer(length, '?');
+	auto read_count = handle.Read(QueryContext(*con.context), buffer.data(), length);
+	buffer.resize(NumericCast<idx_t>(read_count));
+	return buffer;
+}
+
+static string CreateObjectData(idx_t length) {
+	string result(length, '\0');
+	for (idx_t i = 0; i < length; i++) {
+		result[i] = NumericCast<char>('a' + (i % 26));
+	}
+	return result;
+}
+
 static void RunPersistentShortRead() {
 	static constexpr idx_t READ_OFFSET = 113;
 	static constexpr idx_t READ_LENGTH = 1024;
@@ -354,6 +369,118 @@ static void RunFullDownloadSingleFlight(const string &client_implementation, boo
 	RequireQueryOk(con, "COMMIT");
 }
 
+static void RunExactSequentialReadGeometry(const string &client_implementation, FileOpenFlags flags) {
+	MockS3ServerConfig config;
+	config.object_data = CreateObjectData(8192);
+	auto expected_data = config.object_data;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureHTTPTest(db, con, 0, client_implementation);
+	RequireQueryOk(con, "SET enable_external_file_cache=false");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(server.HTTPPath(), flags);
+
+	REQUIRE(ReadSequential(con, *handle, 13) == expected_data.substr(0, 13));
+	REQUIRE(ReadSequential(con, *handle, 17) == expected_data.substr(13, 17));
+	REQUIRE(handle->SeekPosition() == 30);
+
+	handle->Seek(1024);
+	REQUIRE(ReadSequential(con, *handle, 19) == expected_data.substr(1024, 19));
+	REQUIRE(handle->SeekPosition() == 1043);
+
+	auto observations_before_empty_reads = server.Observations();
+	REQUIRE(ReadSequential(con, *handle, 0).empty());
+	handle->Seek(expected_data.size());
+	REQUIRE(ReadSequential(con, *handle, 1).empty());
+	REQUIRE(server.Observations().size() == observations_before_empty_reads.size());
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(CountRequests(observations, "GET", 206, "bytes=0-12") == 1);
+	REQUIRE(CountRequests(observations, "GET", 206, "bytes=13-29") == 1);
+	REQUIRE(CountRequests(observations, "GET", 206, "bytes=1024-1042") == 1);
+	REQUIRE(CountRangeRequests(observations, 206) == 3);
+	RequireQueryOk(con, "COMMIT");
+}
+
+static void RunSequentialFailureKeepsPosition(const string &client_implementation) {
+	static constexpr idx_t READ_OFFSET = 113;
+	static constexpr idx_t READ_LENGTH = 1024;
+
+	MockS3ServerConfig config;
+	config.object_data = CreateObjectData(8192);
+	auto expected_data = config.object_data;
+	config.range_behavior = MockS3RangeBehavior::TRUNCATE_TRANSFER;
+	config.range_behavior_requests = 1;
+	config.truncated_range_bytes = 17;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureHTTPTest(db, con, 0, client_implementation);
+	RequireQueryOk(con, "SET enable_external_file_cache=false");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(server.HTTPPath(), FileFlags::FILE_FLAGS_READ);
+	handle->Seek(READ_OFFSET);
+
+	ReadOutcome outcome;
+	try {
+		ReadSequential(con, *handle, READ_LENGTH);
+	} catch (std::exception &ex) {
+		outcome.failed = true;
+		outcome.error = ex.what();
+		ErrorData error(ex);
+		outcome.internal_error = error.Type() == ExceptionType::INTERNAL || error.Type() == ExceptionType::FATAL;
+	}
+	INFO(outcome.error);
+	REQUIRE(outcome.failed);
+	REQUIRE_FALSE(outcome.internal_error);
+	REQUIRE(handle->SeekPosition() == READ_OFFSET);
+
+	REQUIRE(ReadSequential(con, *handle, 31) == expected_data.substr(READ_OFFSET, 31));
+	REQUIRE(handle->SeekPosition() == READ_OFFSET + 31);
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(CountRequests(observations, "GET", 206, "bytes=113-1136") == 1);
+	REQUIRE(CountRequests(observations, "GET", 206, "bytes=113-143") == 1);
+	RequireQueryOk(con, "COMMIT");
+}
+
+static void RunSequentialFullDownloadFallback(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.object_data = CreateObjectData(8192);
+	auto expected_data = config.object_data;
+	config.advertise_ranges = false;
+	config.range_behavior = MockS3RangeBehavior::IGNORE_RANGE;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureHTTPTest(db, con, 0, client_implementation);
+	RequireQueryOk(con, "SET enable_external_file_cache=false");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(server.HTTPPath(), FileFlags::FILE_FLAGS_READ);
+	REQUIRE(ReadSequential(con, *handle, 17) == expected_data.substr(0, 17));
+	REQUIRE(handle->SeekPosition() == 17);
+	REQUIRE(ReadSequential(con, *handle, 11) == expected_data.substr(17, 11));
+	REQUIRE(handle->SeekPosition() == 28);
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(CountRequests(observations, "GET", 200, "bytes=0-16") == 1);
+	REQUIRE(CountRequests(observations, "GET", 200) == 1);
+	RequireQueryOk(con, "COMMIT");
+}
+
 } // namespace
 
 TEST_CASE("HTTP range reads reject truncated response bodies", "[httpfs][short-read]") {
@@ -447,6 +574,45 @@ TEST_CASE("HTTP full-download fallback rejects HEAD and GET length mismatches", 
 	RequireQueryOk(con, "SET force_download=true");
 	REQUIRE(ReadRange(con, server.HTTPPath(), 0, 2) == "AB");
 	RequireQueryOk(con, "COMMIT");
+}
+
+TEST_CASE("HTTP sequential reads issue exact ranges without read-ahead", "[httpfs][read-ahead]") {
+	SECTION("curl default flags") {
+		RunExactSequentialReadGeometry("curl", FileFlags::FILE_FLAGS_READ);
+	}
+	SECTION("curl DirectIO") {
+		RunExactSequentialReadGeometry("curl", FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	}
+	SECTION("curl parallel access") {
+		RunExactSequentialReadGeometry("curl", FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_PARALLEL_ACCESS);
+	}
+	SECTION("httplib default flags") {
+		RunExactSequentialReadGeometry("httplib", FileFlags::FILE_FLAGS_READ);
+	}
+	SECTION("httplib DirectIO") {
+		RunExactSequentialReadGeometry("httplib", FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	}
+	SECTION("httplib parallel access") {
+		RunExactSequentialReadGeometry("httplib", FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_PARALLEL_ACCESS);
+	}
+}
+
+TEST_CASE("HTTP sequential read failures leave the cursor unchanged", "[httpfs][read-ahead][short-read]") {
+	SECTION("curl") {
+		RunSequentialFailureKeepsPosition("curl");
+	}
+	SECTION("httplib") {
+		RunSequentialFailureKeepsPosition("httplib");
+	}
+}
+
+TEST_CASE("HTTP sequential reads retain full-download fallback", "[httpfs][read-ahead][full-download]") {
+	SECTION("curl") {
+		RunSequentialFullDownloadFallback("curl");
+	}
+	SECTION("httplib") {
+		RunSequentialFullDownloadFallback("httplib");
+	}
 }
 
 } // namespace duckdb


### PR DESCRIPTION
This PR cleans up the HTTP read path by making positional reads independent and removing the handle-local read-ahead buffer. This is legacy behaviour to work around things in DuckDB that have since been fixed properly.

## Reads

Positional reads now own their exact range and immutable read condition, and never touch the sequential cursor. Sequential reads only synchronize the cursor and issue the exact requested range. This also keeps ETag/version ID checks, retries, and full-download fallback consistent for the lifetime of the handle.

The old adaptive 1–32 MiB read-ahead buffer is gone. Small sequential reads can therefore issue more requests; batching and prefetching should happen above HTTPFS instead of being hidden in the file handle.

## Secret Refresh

Also fixes #380. Refreshing a transaction-scoped S3 secret keeps `TRANSACTION`, but does not pass `"transaction"` as an explicit storage backend—the active transaction selects that backend. Temporary, persistent, and custom storage backends are still propagated. We might want to consider a cleaner core `SecretManager` change for this at some point, but this seems OK for now.