### PR TITLE
More cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,14 @@ project(HTTPFsExtension)
 
 add_extension_definitions()
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  add_compile_options(-Wpessimizing-move)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Werror=thread-safety)
+endif()
+
 if (NOT EMSCRIPTEN)
   add_definitions(-DOVERRIDE_ENCRYPTION_UTILS=1)
 else()

--- a/src/create_secret_functions.cpp
+++ b/src/create_secret_functions.cpp
@@ -27,119 +27,110 @@ static Value MapToStruct(const Value &map) {
 	}
 	return Value::STRUCT(struct_fields);
 }
-unique_ptr<BaseSecret> CreateS3SecretFunctions::CreateSecretFunctionInternal(ClientContext &context,
-                                                                             CreateSecretInput &input) {
-	// Set scope to user provided scope or the default
-	auto scope = input.scope;
-	if (scope.empty()) {
-		if (input.type == "s3") {
-			scope.push_back("s3://");
-			scope.push_back("s3n://");
-			scope.push_back("s3a://");
-		} else if (input.type == "r2") {
-			scope.push_back("r2://");
-		} else if (input.type == "gcs") {
-			scope.push_back("gcs://");
-			scope.push_back("gs://");
-		} else if (input.type == "aws") {
-			scope.push_back("");
-		} else {
-			throw InternalException("Unknown secret type found in httpfs extension: '%s'", input.type);
-		}
+
+struct S3SecretBuilder {
+	explicit S3SecretBuilder(CreateSecretInput &input_p) : input(input_p) {
+		auto scope = input.scope.empty() ? DefaultScope() : input.scope;
+		secret = make_uniq<KeyValueSecret>(std::move(scope), input.type, input.provider, input.name);
+		secret->redact_keys = {"secret", "session_token"};
 	}
 
-	auto secret = make_uniq<KeyValueSecret>(scope, input.type, input.provider, input.name);
-	secret->redact_keys = {"secret", "session_token"};
+	unique_ptr<BaseSecret> Create() {
+		ApplyR2Endpoint();
+		for (const auto &option : input.options) {
+			ApplyOption(StringUtil::Lower(option.first), option.second);
+		}
+		return std::move(secret);
+	}
 
-	// for r2 we can set the endpoint using the account id
-	if (input.type == "r2" && input.options.find("account_id") != input.options.end()) {
-		secret->secret_map["endpoint"] = input.options["account_id"].ToString() + ".r2.cloudflarestorage.com";
+private:
+	vector<string> DefaultScope() const {
+		if (input.type == "s3") {
+			return {"s3://", "s3n://", "s3a://"};
+		}
+		if (input.type == "r2") {
+			return {"r2://"};
+		}
+		if (input.type == "gcs") {
+			return {"gcs://", "gs://"};
+		}
+		if (input.type == "aws") {
+			return {""};
+		}
+		throw InternalException("Unknown secret type found in httpfs extension: '%s'", input.type);
+	}
+
+	void ApplyR2Endpoint() {
+		auto account_id = input.options.find("account_id");
+		if (input.type != "r2" || account_id == input.options.end()) {
+			return;
+		}
+		secret->secret_map["endpoint"] = account_id->second.ToString() + ".r2.cloudflarestorage.com";
 		secret->secret_map["url_style"] = "path";
 	}
 
-	bool refresh = false;
-
-	// apply any overridden settings
-	for (const auto &named_param : input.options) {
-		auto lower_name = StringUtil::Lower(named_param.first);
-
-		if (lower_name == "key_id") {
-			secret->secret_map["key_id"] = named_param.second;
-		} else if (lower_name == "secret") {
-			secret->secret_map["secret"] = named_param.second;
-		} else if (lower_name == "region") {
-			secret->secret_map["region"] = named_param.second.ToString();
-		} else if (lower_name == "session_token") {
-			secret->secret_map["session_token"] = named_param.second.ToString();
-		} else if (lower_name == "endpoint") {
-			secret->secret_map["endpoint"] = named_param.second.ToString();
-		} else if (lower_name == "url_style") {
-			secret->secret_map["url_style"] = StringUtil::Lower(named_param.second.ToString());
-		} else if (lower_name == "use_ssl") {
-			if (named_param.second.type() != LogicalType::BOOLEAN) {
-				throw InvalidInputException("Invalid type past to secret option: '%s', found '%s', expected: 'BOOLEAN'",
-				                            lower_name, named_param.second.type().ToString());
-			}
-			secret->secret_map["use_ssl"] = Value::BOOLEAN(named_param.second.GetValue<bool>());
-		} else if (lower_name == "verify_ssl") {
-			if (named_param.second.type() != LogicalType::BOOLEAN) {
-				throw InvalidInputException("Invalid type past to secret option: '%s', found '%s', expected: 'BOOLEAN'",
-				                            lower_name, named_param.second.type().ToString());
-			}
-			secret->secret_map["verify_ssl"] = Value::BOOLEAN(named_param.second.GetValue<bool>());
-		} else if (lower_name == "kms_key_id") {
-			secret->secret_map["kms_key_id"] = named_param.second.ToString();
-		} else if (lower_name == "url_compatibility_mode") {
-			if (named_param.second.type() != LogicalType::BOOLEAN) {
-				throw InvalidInputException("Invalid type past to secret option: '%s', found '%s', expected: 'BOOLEAN'",
-				                            lower_name, named_param.second.type().ToString());
-			}
-			secret->secret_map["url_compatibility_mode"] = Value::BOOLEAN(named_param.second.GetValue<bool>());
-		} else if (lower_name == "account_id") {
-			continue; // handled already
-		} else if (lower_name == "refresh") {
-			if (refresh) {
-				throw InvalidInputException("Can not set `refresh` and `refresh_info` at the same time");
-			}
-			refresh = StringUtil::Lower(named_param.second.GetValue<string>()) == "auto";
-			secret->secret_map["refresh"] = Value("auto");
-			child_list_t<Value> struct_fields;
-			for (const auto &named_param : input.options) {
-				auto lower_name = StringUtil::Lower(named_param.first);
-				struct_fields.emplace_back(lower_name, named_param.second);
-			}
-			secret->secret_map["refresh_info"] = Value::STRUCT(struct_fields);
-		} else if (lower_name == "refresh_info") {
-			if (refresh) {
-				throw InvalidInputException("Can not set `refresh` and `refresh_info` at the same time");
-			}
-			refresh = true;
-			secret->secret_map["refresh_info"] = MapToStruct(named_param.second);
-		} else if (lower_name == "requester_pays") {
-			if (named_param.second.type() != LogicalType::BOOLEAN) {
-				throw InvalidInputException("Invalid type past to secret option: '%s', found '%s', expected: 'BOOLEAN'",
-				                            lower_name, named_param.second.type().ToString());
-			}
-			secret->secret_map["requester_pays"] = Value::BOOLEAN(named_param.second.GetValue<bool>());
-		} else if (lower_name == "bearer_token" && input.type == "gcs") {
-			secret->secret_map["bearer_token"] = named_param.second.ToString();
-			// Mark it as sensitive
+	void ApplyOption(const string &name, const Value &value) {
+		if (name == "key_id" || name == "secret" || name == "http_proxy" || name == "http_proxy_password" ||
+		    name == "http_proxy_username" || name == "extra_http_headers") {
+			secret->secret_map[Identifier(name)] = value;
+		} else if (name == "region" || name == "session_token" || name == "endpoint" || name == "kms_key_id") {
+			secret->secret_map[Identifier(name)] = value.ToString();
+		} else if (name == "url_style") {
+			secret->secret_map[Identifier(name)] = StringUtil::Lower(value.ToString());
+		} else if (name == "use_ssl" || name == "verify_ssl" || name == "url_compatibility_mode" ||
+		           name == "requester_pays") {
+			SetBooleanOption(name, value);
+		} else if (name == "account_id") {
+			return;
+		} else if (name == "refresh") {
+			SetRefresh(value);
+		} else if (name == "refresh_info") {
+			SetRefreshInfo(value);
+		} else if (name == "bearer_token" && input.type == "gcs") {
+			secret->secret_map["bearer_token"] = value.ToString();
 			secret->redact_keys.insert("bearer_token");
-		} else if (lower_name == "http_proxy") {
-			secret->secret_map["http_proxy"] = named_param.second;
-		} else if (lower_name == "http_proxy_password") {
-			secret->secret_map["http_proxy_password"] = named_param.second;
-		} else if (lower_name == "http_proxy_username") {
-			secret->secret_map["http_proxy_username"] = named_param.second;
-		} else if (lower_name == "extra_http_headers") {
-			secret->secret_map["extra_http_headers"] = named_param.second;
 		} else {
-			throw InvalidInputException("Unknown named parameter passed to CreateSecretFunctionInternal: " +
-			                            lower_name);
+			throw InvalidInputException("Unknown named parameter passed to CreateSecretFunctionInternal: " + name);
 		}
 	}
 
-	return std::move(secret);
+	void SetBooleanOption(const string &name, const Value &value) {
+		if (value.type() != LogicalType::BOOLEAN) {
+			throw InvalidInputException("Invalid type passed to secret option: '%s', found '%s', expected: 'BOOLEAN'",
+			                            name, value.type().ToString());
+		}
+		secret->secret_map[Identifier(name)] = Value::BOOLEAN(value.GetValue<bool>());
+	}
+
+	void SetRefresh(const Value &value) {
+		if (refresh) {
+			throw InvalidInputException("Can not set `refresh` and `refresh_info` at the same time");
+		}
+		refresh = StringUtil::Lower(value.GetValue<string>()) == "auto";
+		secret->secret_map["refresh"] = Value("auto");
+		child_list_t<Value> struct_fields;
+		for (const auto &option : input.options) {
+			struct_fields.emplace_back(StringUtil::Lower(option.first), option.second);
+		}
+		secret->secret_map["refresh_info"] = Value::STRUCT(struct_fields);
+	}
+
+	void SetRefreshInfo(const Value &value) {
+		if (refresh) {
+			throw InvalidInputException("Can not set `refresh` and `refresh_info` at the same time");
+		}
+		refresh = true;
+		secret->secret_map["refresh_info"] = MapToStruct(value);
+	}
+
+	CreateSecretInput &input;
+	unique_ptr<KeyValueSecret> secret;
+	bool refresh = false;
+};
+
+unique_ptr<BaseSecret> CreateS3SecretFunctions::CreateSecretFunctionInternal(ClientContext &context,
+                                                                             CreateSecretInput &input) {
+	return S3SecretBuilder(input).Create();
 }
 
 CreateSecretInput CreateS3SecretFunctions::GenerateRefreshSecretInfo(const SecretEntry &secret_entry,

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -140,27 +140,27 @@ const EVP_CIPHER *AESStateSSL::GetCipher() {
 }
 
 void AESStateSSL::GenerateRandomData(data_ptr_t data, idx_t len) {
-	auto res = RAND_bytes(data, len);
+	auto res = RAND_bytes(data, NumericCast<int>(len));
 	if (res != 1) {
 		throw duckdb::InternalException("Failed to generate random data from RAND_bytes");
 	}
 }
 
 void AESStateSSL::InitializeIVEncrypt(EncryptionNonce &nonce, const_data_ptr_t key) {
-	if (1 != EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_GCM_SET_IVLEN, nonce.total_size(), NULL)) {
+	if (1 != EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_GCM_SET_IVLEN, NumericCast<int>(nonce.total_size()), nullptr)) {
 		throw InternalException("EVP_CIPHER_CTX_ctrl failed (EVP_CTRL_GCM_SET_IVLEN)");
 	}
 
-	if (1 != EVP_EncryptInit_ex(context, NULL, NULL, key, nonce.data())) {
+	if (1 != EVP_EncryptInit_ex(context, nullptr, nullptr, key, nonce.data())) {
 		throw InternalException("EncryptInit failed (attempt 2)");
 	}
 }
 
 void AESStateSSL::InitializeIVDecrypt(EncryptionNonce &nonce, const_data_ptr_t key) {
-	if (1 != EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_GCM_SET_IVLEN, nonce.total_size(), NULL)) {
+	if (1 != EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_GCM_SET_IVLEN, NumericCast<int>(nonce.total_size()), nullptr)) {
 		throw InternalException("EVP_CIPHER_CTX_ctrl failed to set GCM iv len");
 	}
-	if (1 != EVP_DecryptInit_ex(context, NULL, NULL, key, nonce.data())) {
+	if (1 != EVP_DecryptInit_ex(context, nullptr, nullptr, key, nonce.data())) {
 		throw InternalException("EVP_DecryptInit_ex failed to set iv/key");
 	}
 }
@@ -169,7 +169,7 @@ void AESStateSSL::InitializeEncryption(EncryptionNonce &nonce, const_data_ptr_t 
                                        idx_t aad_len) {
 	mode = EncryptionTypes::ENCRYPT;
 
-	if (1 != EVP_EncryptInit_ex(context, GetCipher(), NULL, NULL, NULL)) {
+	if (1 != EVP_EncryptInit_ex(context, GetCipher(), nullptr, nullptr, nullptr)) {
 		throw InternalException("EncryptInit failed (attempt 1)");
 	}
 
@@ -177,7 +177,7 @@ void AESStateSSL::InitializeEncryption(EncryptionNonce &nonce, const_data_ptr_t 
 
 	int len;
 	if (aad_len > 0) {
-		if (!EVP_DecryptUpdate(context, NULL, &len, aad, aad_len)) {
+		if (!EVP_DecryptUpdate(context, nullptr, &len, aad, NumericCast<int>(aad_len))) {
 			throw InternalException("Setting Additional Authenticated Data  failed");
 		}
 	}
@@ -187,7 +187,7 @@ void AESStateSSL::InitializeDecryption(EncryptionNonce &nonce, const_data_ptr_t 
                                        idx_t aad_len) {
 	mode = EncryptionTypes::DECRYPT;
 
-	if (1 != EVP_DecryptInit_ex(context, GetCipher(), NULL, NULL, NULL)) {
+	if (1 != EVP_DecryptInit_ex(context, GetCipher(), nullptr, nullptr, nullptr)) {
 		throw InternalException("EVP_DecryptInit_ex failed to set cipher");
 	}
 
@@ -195,34 +195,33 @@ void AESStateSSL::InitializeDecryption(EncryptionNonce &nonce, const_data_ptr_t 
 
 	int len;
 	if (aad_len > 0) {
-		if (!EVP_DecryptUpdate(context, NULL, &len, aad, aad_len)) {
+		if (!EVP_DecryptUpdate(context, nullptr, &len, aad, NumericCast<int>(aad_len))) {
 			throw InternalException("Setting Additional Authenticated Data  failed");
 		}
 	}
 }
 
 size_t AESStateSSL::Process(const_data_ptr_t in, idx_t in_len, data_ptr_t out, idx_t out_len) {
+	int output_length;
 	switch (mode) {
 	case EncryptionTypes::ENCRYPT:
-		if (1 != EVP_EncryptUpdate(context, data_ptr_cast(out), reinterpret_cast<int *>(&out_len),
-		                           const_data_ptr_cast(in), (int)in_len)) {
+		if (1 != EVP_EncryptUpdate(context, out, &output_length, in, NumericCast<int>(in_len))) {
 			throw InternalException("EncryptUpdate failed");
 		}
 		break;
 
 	case EncryptionTypes::DECRYPT:
-		if (1 != EVP_DecryptUpdate(context, data_ptr_cast(out), reinterpret_cast<int *>(&out_len),
-		                           const_data_ptr_cast(in), (int)in_len)) {
-
+		if (1 != EVP_DecryptUpdate(context, out, &output_length, in, NumericCast<int>(in_len))) {
 			throw InternalException("DecryptUpdate failed");
 		}
 		break;
 	}
 
-	if (out_len != in_len) {
+	const auto result_length = NumericCast<idx_t>(output_length);
+	if (result_length > out_len || result_length != in_len) {
 		throw InternalException("AES GCM failed, in- and output lengths differ");
 	}
-	return out_len;
+	return result_length;
 }
 
 size_t AESStateSSL::FinalizeGCM(data_ptr_t out, idx_t out_len, data_ptr_t tag, idx_t tag_len) {
@@ -230,26 +229,28 @@ size_t AESStateSSL::FinalizeGCM(data_ptr_t out, idx_t out_len, data_ptr_t tag, i
 
 	switch (mode) {
 	case EncryptionTypes::ENCRYPT: {
-		if (1 != EVP_EncryptFinal_ex(context, data_ptr_cast(out) + out_len, reinterpret_cast<int *>(&out_len))) {
+		int output_length;
+		if (1 != EVP_EncryptFinal_ex(context, out + out_len, &output_length)) {
 			throw InternalException("EncryptFinal failed");
 		}
-		text_len += out_len;
+		text_len += NumericCast<idx_t>(output_length);
 
 		// The computed tag is written at the end of a chunk
-		if (1 != EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_GCM_GET_TAG, tag_len, tag)) {
+		if (1 != EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_GCM_GET_TAG, NumericCast<int>(tag_len), tag)) {
 			throw InternalException("Calculating the tag failed");
 		}
 		return text_len;
 	}
 	case EncryptionTypes::DECRYPT: {
 		// Set expected tag value
-		if (!EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_GCM_SET_TAG, tag_len, tag)) {
+		if (!EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_GCM_SET_TAG, NumericCast<int>(tag_len), tag)) {
 			throw InternalException("Finalizing tag failed");
 		}
 
 		// EVP_DecryptFinal() will return an error code if final block is not correctly formatted.
-		int ret = EVP_DecryptFinal_ex(context, data_ptr_cast(out) + out_len, reinterpret_cast<int *>(&out_len));
-		text_len += out_len;
+		int output_length;
+		int ret = EVP_DecryptFinal_ex(context, out + out_len, &output_length);
+		text_len += NumericCast<idx_t>(output_length);
 
 		if (ret > 0) {
 			// success
@@ -272,16 +273,18 @@ size_t AESStateSSL::Finalize(data_ptr_t out, idx_t out_len, data_ptr_t tag, idx_
 	switch (mode) {
 
 	case EncryptionTypes::ENCRYPT: {
-		if (1 != EVP_EncryptFinal_ex(context, data_ptr_cast(out) + out_len, reinterpret_cast<int *>(&out_len))) {
+		int output_length;
+		if (1 != EVP_EncryptFinal_ex(context, out + out_len, &output_length)) {
 			throw InternalException("EncryptFinal failed");
 		}
-		return text_len += out_len;
+		return text_len + NumericCast<idx_t>(output_length);
 	}
 
 	case EncryptionTypes::DECRYPT: {
 		// EVP_DecryptFinal() will return an error code if final block is not correctly formatted.
-		int ret = EVP_DecryptFinal_ex(context, data_ptr_cast(out) + out_len, reinterpret_cast<int *>(&out_len));
-		text_len += out_len;
+		int output_length;
+		int ret = EVP_DecryptFinal_ex(context, out + out_len, &output_length);
+		text_len += NumericCast<idx_t>(output_length);
 		if (ret > 0) {
 			// success
 			return text_len;
@@ -337,7 +340,7 @@ void AESStateSSLFactory::Hmac(duckdb::CryptoHashFunction function, duckdb::const
 	}
 
 	unsigned int output_size = 0;
-	if (!HMAC(GetOpenSSLHashFunction(function), key, static_cast<int>(key_len), input, input_len, output,
+	if (!HMAC(GetOpenSSLHashFunction(function), key, duckdb::NumericCast<int>(key_len), input, input_len, output,
 	          &output_size)) {
 		throw duckdb::InternalException("OpenSSL failed to compute HMAC");
 	}

--- a/src/hash_functions.cpp
+++ b/src/hash_functions.cpp
@@ -2,24 +2,24 @@
 
 namespace duckdb {
 
-void sha256(EncryptionUtil &encryption_util, const char *in, size_t in_len, hash_bytes &out) {
+void sha256(EncryptionUtil &encryption_util, const_data_ptr_t in, idx_t in_len, hash_bytes &out) {
 	D_ASSERT(CryptoHash::GetDigestSize(CryptoHashFunction::SHA256) == sizeof(hash_bytes));
-	encryption_util.Hash(CryptoHashFunction::SHA256, const_data_ptr_cast(in), in_len, out);
+	encryption_util.Hash(CryptoHashFunction::SHA256, in, in_len, out);
 }
 
-void hmac256(EncryptionUtil &encryption_util, const std::string &message, const char *secret, size_t secret_len,
+void hmac256(EncryptionUtil &encryption_util, const std::string &message, const_data_ptr_t secret, idx_t secret_len,
              hash_bytes &out) {
 	D_ASSERT(CryptoHash::GetDigestSize(CryptoHashFunction::SHA256) == sizeof(hash_bytes));
-	encryption_util.Hmac(CryptoHashFunction::SHA256, const_data_ptr_cast(secret), secret_len,
-	                     const_data_ptr_cast(message.data()), message.size(), out);
+	encryption_util.Hmac(CryptoHashFunction::SHA256, secret, secret_len, const_data_ptr_cast(message.data()),
+	                     message.size(), out);
 }
 
 void hmac256(EncryptionUtil &encryption_util, std::string message, hash_bytes secret, hash_bytes &out) {
-	hmac256(encryption_util, message, reinterpret_cast<const char *>(secret), sizeof(hash_bytes), out);
+	hmac256(encryption_util, message, secret, sizeof(hash_bytes), out);
 }
 
 void hex256(hash_bytes &in, hash_str &out) {
-	CryptoHash::ToHex(in, sizeof(hash_bytes), reinterpret_cast<char *>(out));
+	CryptoHash::ToHex(in, sizeof(hash_bytes), char_ptr_cast(out));
 }
 
 } // namespace duckdb

--- a/src/hffs.cpp
+++ b/src/hffs.cpp
@@ -112,74 +112,109 @@ static bool Match(vector<string>::const_iterator key, vector<string>::const_iter
 	return key == key_end && pattern == pattern_end;
 }
 
-void ParseListResult(string &input, vector<string> &files, vector<string> &directories) {
-	enum parse_entry { FILE, DIR, UNKNOWN };
-	idx_t idx = 0;
-	idx_t nested = 0;
-	bool found_path;
-	parse_entry type;
-	string current_string;
-base:
-	found_path = false;
-	type = parse_entry::UNKNOWN;
-	for (; idx < input.size(); idx++) {
-		if (input[idx] == '{') {
-			idx++;
-			goto entry;
+struct HFListResultParser {
+	enum class EntryType : uint8_t { FILE, DIRECTORY, UNKNOWN };
+
+	HFListResultParser(const string &input_p, vector<string> &files_p, vector<string> &directories_p)
+	    : input(input_p), files(files_p), directories(directories_p) {
+	}
+
+	static void Parse(const string &input, vector<string> &files, vector<string> &directories) {
+		HFListResultParser(input, files, directories).ParseEntries();
+	}
+
+private:
+	void ParseEntries() {
+		while (SeekEntry()) {
+			ParseEntry();
 		}
 	}
-	goto end;
-entry:
-	while (idx < input.size()) {
-		if (input[idx] == '}') {
-			if (nested) {
-				idx++;
-				nested--;
-				continue;
-			} else if (!found_path || type == parse_entry::UNKNOWN) {
-				throw IOException("Failed to parse list result");
-			} else if (type == parse_entry::FILE) {
-				files.push_back("/" + current_string);
-			} else {
-				directories.push_back("/" + current_string);
+
+	bool SeekEntry() {
+		position = input.find('{', position);
+		if (position == string::npos) {
+			return false;
+		}
+		position++;
+		return true;
+	}
+
+	void ParseEntry() {
+		idx_t nested = 0;
+		EntryType type = EntryType::UNKNOWN;
+		optional_idx path_position;
+		string path;
+		while (position < input.size()) {
+			if (input[position] == '}') {
+				position++;
+				if (nested > 0) {
+					nested--;
+					continue;
+				}
+				AppendEntry(type, path_position, path);
+				return;
 			}
-			current_string = "";
-			idx++;
-			goto base;
-		} else if (input[idx] == '{') {
-			nested++;
-			idx++;
-		} else if (strncmp(input.c_str() + idx, "\"type\":\"directory\"", 18) == 0) {
-			type = parse_entry::DIR;
-			idx += 18;
-		} else if (strncmp(input.c_str() + idx, "\"type\":\"file\"", 13) == 0) {
-			type = parse_entry::FILE;
-			idx += 13;
-		} else if (strncmp(input.c_str() + idx, "\"path\":\"", 8) == 0) {
-			idx += 8;
-			found_path = true;
-			goto pathname;
-		} else {
-			idx++;
+			if (input[position] == '{') {
+				nested++;
+				position++;
+			} else if (Consume("\"type\":\"directory\"")) {
+				type = EntryType::DIRECTORY;
+			} else if (Consume("\"type\":\"file\"")) {
+				type = EntryType::FILE;
+			} else if (Consume("\"path\":\"")) {
+				path_position = position;
+				path = ParseString();
+			} else {
+				position++;
+			}
 		}
 	}
-	goto end;
-pathname:
-	while (idx < input.size()) {
-		// Handle escaped quote in url
-		if (input[idx] == '\\' && idx + 1 < input.size() && input[idx] == '\"') {
-			current_string += '\"';
-			idx += 2;
-		} else if (input[idx] == '\"') {
-			idx++;
-			goto entry;
+
+	bool Consume(const string &token) {
+		if (input.compare(position, token.size(), token) != 0) {
+			return false;
+		}
+		position += token.size();
+		return true;
+	}
+
+	string ParseString() {
+		string result;
+		while (position < input.size()) {
+			if (input[position] == '"') {
+				position++;
+				return result;
+			}
+			if (input[position] == '\\' && position + 1 < input.size() &&
+			    (input[position + 1] == '"' || input[position + 1] == '\\')) {
+				result += input[position + 1];
+				position += 2;
+				continue;
+			}
+			result += input[position++];
+		}
+		return result;
+	}
+
+	void AppendEntry(EntryType type, optional_idx path_position, const string &path) {
+		if (!path_position.IsValid() || type == EntryType::UNKNOWN) {
+			throw IOException("Failed to parse list result");
+		}
+		if (type == EntryType::FILE) {
+			files.push_back("/" + path);
 		} else {
-			current_string += input[idx];
-			idx++;
+			directories.push_back("/" + path);
 		}
 	}
-end:
-	return;
+
+	const string &input;
+	vector<string> &files;
+	vector<string> &directories;
+	idx_t position = 0;
+};
+
+void HuggingFaceFileSystem::ParseListResult(const string &input, vector<string> &files, vector<string> &directories) {
+	HFListResultParser::Parse(input, files, directories);
 }
 
 // Some valid example Urls:
@@ -213,7 +248,7 @@ vector<OpenFileInfo> HuggingFaceFileSystem::Glob(const string &path, FileOpener 
 	auto params = http_util.InitializeParameters(opener, info);
 	auto &http_params = params->Cast<HTTPFSParams>();
 	SetParams(http_params, path, opener);
-	auto http_state = HTTPState::TryGetState(opener).get();
+	auto http_state = HTTPState::TryGetState(opener);
 
 	ParsedHFUrl curr_hf_path = parsed_glob_url;
 	curr_hf_path.path = shared_path;
@@ -272,7 +307,7 @@ unique_ptr<HTTPResponse> HuggingFaceFileSystem::GetRequest(FileHandle &handle, s
 unique_ptr<HTTPResponse> HuggingFaceFileSystem::GetRangeRequest(FileHandle &handle, string s3_url,
                                                                 HTTPHeaders header_map,
                                                                 const HTTPReadConfig &read_config, idx_t file_offset,
-                                                                char *buffer_out, idx_t buffer_out_len) {
+                                                                data_ptr_t buffer_out, idx_t buffer_out_len) {
 	auto &hf_handle = handle.Cast<HFFileHandle>();
 	auto http_url = HuggingFaceFileSystem::GetFileUrl(hf_handle.parsed_url);
 	return HTTPFileSystem::GetRangeRequest(handle, http_url, header_map, read_config, file_offset, buffer_out,

--- a/src/http/CMakeLists.txt
+++ b/src/http/CMakeLists.txt
@@ -1,5 +1,6 @@
-target_sources(httpfs_library PRIVATE httpfs.cpp http_request.cpp
-                                      http_request_session.cpp http_state.cpp)
+target_sources(
+  httpfs_library PRIVATE httpfs.cpp http_request.cpp http_settings.cpp
+                         http_request_session.cpp http_state.cpp)
 
 if(NOT EMSCRIPTEN)
   target_sources(

--- a/src/http/http_request.cpp
+++ b/src/http/http_request.cpp
@@ -67,19 +67,18 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunDeleteRequest(string url, HTTPHeader
 }
 
 unique_ptr<HTTPResponse> HTTPFileSystem::RunPostRequest(string url, HTTPHeaders header_map, HTTPFSParams &http_params,
-                                                        string &buffer_out, char *buffer_in, idx_t buffer_in_len,
-                                                        HTTPSendCallback send_request) {
-	PostRequestInfo post_request(url, header_map, http_params, const_data_ptr_cast(buffer_in), buffer_in_len);
+                                                        string &buffer_out, const_data_ptr_t buffer_in,
+                                                        idx_t buffer_in_len, HTTPSendCallback send_request) {
+	PostRequestInfo post_request(url, header_map, http_params, buffer_in, buffer_in_len);
 	auto result = send_request(post_request);
 	buffer_out = std::move(post_request.buffer_out);
 	return result;
 }
 
 unique_ptr<HTTPResponse> HTTPFileSystem::RunPutRequest(string url, HTTPHeaders header_map, HTTPFSParams &http_params,
-                                                       char *buffer_in, idx_t buffer_in_len, const string &content_type,
-                                                       HTTPSendCallback send_request) {
-	PutRequestInfo put_request(url, header_map, http_params, const_data_ptr_cast(buffer_in), buffer_in_len,
-	                           content_type);
+                                                       const_data_ptr_t buffer_in, idx_t buffer_in_len,
+                                                       const string &content_type, HTTPSendCallback send_request) {
+	PutRequestInfo put_request(url, header_map, http_params, buffer_in, buffer_in_len, content_type);
 	return send_request(put_request);
 }
 
@@ -133,11 +132,128 @@ static void SetRangeRequestNotSupported(HTTPResponse &response) {
 	}
 }
 
+struct HTTPRangeRequestContext {
+	HTTPRangeRequestContext(HTTPFileHandle &handle_p, const HTTPReadConfig &read_config_p, string url_p,
+	                        string range_expression_p, data_ptr_t buffer_out_p, idx_t buffer_out_len_p,
+	                        RangeRequestState::Guard range_request_p,
+	                        std::function<HTTPException(const HTTPResponse &)> get_error_p,
+	                        std::function<void(const HTTPResponse &)> validate_response_p)
+	    : handle(handle_p), read_config(read_config_p), url(std::move(url_p)),
+	      range_expression(std::move(range_expression_p)), buffer_out(buffer_out_p), buffer_out_len(buffer_out_len_p),
+	      range_request(std::move(range_request_p)), get_error(std::move(get_error_p)),
+	      validate_response(std::move(validate_response_p)) {
+	}
+
+	bool HandleResponse(const HTTPResponse &response) {
+		if (response.status == HTTPStatusCode::PreconditionFailed_412 &&
+		    read_config.condition.type == HTTPReadConditionType::ETAG) {
+			return false;
+		}
+		if (static_cast<int>(response.status) >= 400) {
+			throw get_error(response);
+		}
+		if (static_cast<int>(response.status) >= 300) {
+			return true;
+		}
+
+		out_offset = 0;
+		validate_response(response);
+		if (!ValidateContentLength(response)) {
+			return false;
+		}
+		if (response.status == HTTPStatusCode::PartialContent_206) {
+			range_request.MarkSupported();
+		}
+		return true;
+	}
+
+	bool HandleContent(const_data_ptr_t data, idx_t data_length) {
+		if (!buffer_out) {
+			return true;
+		}
+		if (out_offset > buffer_out_len || data_length > buffer_out_len - out_offset) {
+			throw HTTPException("Server sent back more data than expected, `SET force_download=true` might "
+			                    "help in this case");
+		}
+		memcpy(buffer_out + out_offset, data, data_length);
+		out_offset += data_length;
+		return true;
+	}
+
+	unique_ptr<HTTPResponse> Finalize(unique_ptr<HTTPResponse> response, const GetRequestInfo &request) {
+		if (range_request_not_supported) {
+			D_ASSERT(response);
+			SetRangeRequestNotSupported(*response);
+			return response;
+		}
+		ValidateReadLength(response);
+		if (IsSuccessfulResponse(response)) {
+			range_request.MarkSupported();
+			RecordNetworkSample(request);
+		}
+		return response;
+	}
+
+private:
+	bool ValidateContentLength(const HTTPResponse &response) {
+		if (!response.HasHeader("Content-Length")) {
+			return true;
+		}
+		try {
+			auto content_length = NumericCast<idx_t>(stoull(response.GetHeaderValue("Content-Length")));
+			if (content_length == buffer_out_len) {
+				return true;
+			}
+			range_request_not_supported = true;
+			range_request.MarkNotSupported();
+			return false;
+		} catch (const std::exception &) {
+			// A malformed Content-Length cannot be used to validate range support.
+			return true;
+		}
+	}
+
+	void ValidateReadLength(const unique_ptr<HTTPResponse> &response) const {
+		if (!response || response->HasRequestError() || !response->Success() || !buffer_out ||
+		    out_offset == buffer_out_len) {
+			return;
+		}
+		throw IOException("Short read for HTTP GET to '%s': requested range %s (%llu bytes), but received %llu bytes",
+		                  url, range_expression, static_cast<unsigned long long>(buffer_out_len),
+		                  static_cast<unsigned long long>(out_offset));
+	}
+
+	static bool IsSuccessfulResponse(const unique_ptr<HTTPResponse> &response) {
+		return response && (response->Success() || response->status == HTTPStatusCode::PartialContent_206 ||
+		                    response->status == HTTPStatusCode::Accepted_202);
+	}
+
+	void RecordNetworkSample(const GetRequestInfo &request) {
+		const auto elapsed_nanos =
+		    TimePoint::ElapsedNanos(request.request_monotonic_start, request.request_monotonic_end);
+		const double total_seconds = elapsed_nanos > 0 ? static_cast<double>(elapsed_nanos) / 1e9 : 0;
+		const idx_t bytes = request.bytes_received != 0 ? request.bytes_received : buffer_out_len;
+		handle.RecordNetworkSample(total_seconds, bytes, request.have_time_to_fst_byte, request.time_to_fst_byte_sec);
+	}
+
+	HTTPFileHandle &handle;
+	const HTTPReadConfig &read_config;
+	const string url;
+	const string range_expression;
+	data_ptr_t buffer_out;
+	const idx_t buffer_out_len;
+	RangeRequestState::Guard range_request;
+	std::function<HTTPException(const HTTPResponse &)> get_error;
+	std::function<void(const HTTPResponse &)> validate_response;
+	idx_t out_offset = 0;
+	bool range_request_not_supported = false;
+};
+
 unique_ptr<HTTPResponse>
 HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh, string url, HTTPHeaders header_map, HTTPFSParams &http_params,
-                                   const HTTPReadConfig &read_config, idx_t file_offset, char *buffer_out,
+                                   const HTTPReadConfig &read_config, idx_t file_offset, data_ptr_t buffer_out,
                                    idx_t buffer_out_len, HTTPErrorCallback get_error, HTTPSendCallback send_request) {
-	string range_expr = "bytes=" + to_string(file_offset) + "-" + to_string(file_offset + buffer_out_len - 1);
+	auto range_expr = "bytes=" + to_string(file_offset) + "-" + to_string(file_offset + buffer_out_len - 1);
 	header_map["Range"] = range_expr;
 	ApplyReadCondition(header_map, read_config);
 
@@ -149,79 +265,15 @@ HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh, string url, HTTPHeaders 
 		return response;
 	}
 
-	idx_t out_offset = 0;
-	bool range_request_not_supported = false;
+	HTTPRangeRequestContext context(
+	    hfh, read_config, url, range_expr, buffer_out, buffer_out_len, std::move(range_request), std::move(get_error),
+	    [&](const HTTPResponse &response) { ValidateResponseETag(hfh, read_config, response); });
 	GetRequestInfo get_request(
-	    url, header_map, http_params,
-	    [&](const HTTPResponse &response) {
-		    if (response.status == HTTPStatusCode::PreconditionFailed_412 &&
-		        read_config.condition.type == HTTPReadConditionType::ETAG) {
-			    return false;
-		    }
-		    if (static_cast<int>(response.status) >= 400) {
-			    throw get_error(response);
-		    }
-		    if (static_cast<int>(response.status) < 300) {
-			    out_offset = 0;
-			    ValidateResponseETag(hfh, read_config, response);
-
-			    if (response.HasHeader("Content-Length")) {
-				    unsigned long long content_length;
-				    bool parsed = false;
-				    try {
-					    content_length = stoull(response.GetHeaderValue("Content-Length"));
-					    parsed = true;
-				    } catch (const std::exception &) {
-					    // Content-Length header contains a non-numeric value, so skip validation.
-				    }
-				    if (parsed && (idx_t)content_length != buffer_out_len) {
-					    range_request_not_supported = true;
-					    range_request.MarkNotSupported();
-					    return false;
-				    }
-			    }
-			    if (response.status == HTTPStatusCode::PartialContent_206) {
-				    range_request.MarkSupported();
-			    }
-		    }
-		    return true;
-	    },
-	    [&](const_data_ptr_t data, idx_t data_length) {
-		    if (buffer_out != nullptr) {
-			    if (data_length + out_offset > buffer_out_len) {
-				    throw HTTPException("Server sent back more data than expected, `SET force_download=true` might "
-				                        "help in this case");
-			    }
-			    memcpy(buffer_out + out_offset, data, data_length);
-			    out_offset += data_length;
-		    }
-		    return true;
-	    });
+	    url, header_map, http_params, [&](const HTTPResponse &response) { return context.HandleResponse(response); },
+	    [&](const_data_ptr_t data, idx_t data_length) { return context.HandleContent(data, data_length); });
 
 	get_request.try_request = read_config.auto_fallback_to_full_download;
-	auto response = send_request(get_request);
-	if (range_request_not_supported) {
-		SetRangeRequestNotSupported(*response);
-		return response;
-	}
-	if (response && !response->HasRequestError() && response->Success() && buffer_out != nullptr &&
-	    out_offset != buffer_out_len) {
-		throw IOException("Short read for HTTP GET to '%s': requested range %s (%llu bytes), but received %llu bytes",
-		                  url, range_expr, static_cast<unsigned long long>(buffer_out_len),
-		                  static_cast<unsigned long long>(out_offset));
-	}
-
-	if (response && (response->Success() || response->status == HTTPStatusCode::PartialContent_206 ||
-	                 response->status == HTTPStatusCode::Accepted_202)) {
-		range_request.MarkSupported();
-		const auto elapsed_nanos =
-		    TimePoint::ElapsedNanos(get_request.request_monotonic_start, get_request.request_monotonic_end);
-		const double total_seconds = elapsed_nanos > 0 ? static_cast<double>(elapsed_nanos) / 1e9 : 0;
-		const idx_t bytes = get_request.bytes_received != 0 ? get_request.bytes_received : buffer_out_len;
-		hfh.RecordNetworkSample(total_seconds, bytes, get_request.have_time_to_fst_byte,
-		                        get_request.time_to_fst_byte_sec);
-	}
-	return response;
+	return context.Finalize(send_request(get_request), get_request);
 }
 
 unique_ptr<HTTPResponse> HTTPFileSystem::HeadRequest(FileHandle &handle, string url, HTTPHeaders header_map) {
@@ -301,7 +353,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRequest(FileHandle &handle, string u
 
 unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, string url, HTTPHeaders header_map,
                                                          const HTTPReadConfig &read_config, idx_t file_offset,
-                                                         char *buffer_out, idx_t buffer_out_len) {
+                                                         data_ptr_t buffer_out, idx_t buffer_out_len) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
 	auto captured = hfh.request_session->Capture();
 	captured.snapshot->AddConfiguredHeaders(header_map);

--- a/src/http/http_settings.cpp
+++ b/src/http/http_settings.cpp
@@ -1,0 +1,114 @@
+#include "http/http_settings.hpp"
+
+#include "http/httpfs_client.hpp"
+#include "duckdb/common/local_file_system.hpp"
+#include "duckdb/main/client_context_file_opener.hpp"
+#include "duckdb/main/config.hpp"
+
+#ifndef EMSCRIPTEN
+#include "http/httpfs_curl_client.hpp"
+#endif
+
+namespace duckdb {
+
+static void SetCACertFile(ClientContext &context, SetScope, Value &parameter) {
+	if (parameter.IsNull()) {
+		throw InvalidInputException("NULL is not a valid option for ca_cert_file");
+	}
+	auto value = StringValue::Get(parameter);
+	if (value.empty()) {
+		parameter = Value("");
+		return;
+	}
+	LocalFileSystem fs;
+	ClientContextFileOpener opener(context);
+	parameter = Value(fs.CanonicalizePath(value, opener));
+}
+
+static void SetHTTPClientImplementation(ClientContext &context, SetScope, Value &parameter) {
+	auto &config = DBConfig::GetConfig(context);
+	auto value = StringValue::Get(parameter);
+	auto &http_util = config.GetHTTPUtil();
+	if (http_util.GetName() == "WasmHTTPUtils") {
+		if (value == "wasm" || value == "default") {
+			return;
+		}
+		throw InvalidInputException("Unsupported option for httpfs_client_implementation, only `wasm` and "
+		                            "`default` are currently supported for duckdb-wasm");
+	}
+#ifndef EMSCRIPTEN
+	if (value == "curl" || value == "default") {
+		config.SetHTTPUtil(make_shared_ptr<HTTPFSCurlUtil>());
+		return;
+	}
+	if (value == "httplib") {
+		config.SetHTTPUtil(make_shared_ptr<HTTPFSUtil>());
+		return;
+	}
+#endif
+	throw InvalidInputException("Unsupported option for httpfs_client_implementation, only `curl`, `httplib` "
+	                            "and `default` are currently supported");
+}
+
+static void SetHTTPConnectionCaching(ClientContext &context, SetScope, Value &parameter) {
+#ifndef EMSCRIPTEN
+	auto &http_util = DBConfig::GetConfig(context).GetHTTPUtil();
+	if (http_util.GetName() == "HTTPFS-Curl") {
+		auto &curl_util = static_cast<HTTPFSCurlUtil &>(http_util);
+		curl_util.connection_caching_enabled = BooleanValue::Get(parameter);
+	}
+#endif
+}
+
+void HTTPSettings::Register(DBConfig &config) {
+	config.AddExtensionOption("http_timeout", "HTTP timeout read/write/connection/retry (in seconds)",
+	                          LogicalType::UBIGINT, Value::UBIGINT(HTTPParams::DEFAULT_TIMEOUT_SECONDS));
+	config.AddExtensionOption("http_retries", "HTTP retries on I/O error", LogicalType::UBIGINT,
+	                          Value::UBIGINT(HTTPParams::DEFAULT_RETRIES));
+	config.AddExtensionOption("http_retry_wait_ms", "Time between retries", LogicalType::UBIGINT,
+	                          Value::UBIGINT(HTTPParams::DEFAULT_RETRY_WAIT_MS));
+	config.AddExtensionOption("http_retry_backoff", "Backoff factor for exponentially increasing retry wait time",
+	                          LogicalType::FLOAT, Value(HTTPParams::DEFAULT_RETRY_BACKOFF));
+	config.AddExtensionOption(
+	    "http_keep_alive",
+	    "Keep alive connections. Setting this to false can help when running into connection failures",
+	    LogicalType::BOOLEAN, Value(HTTPParams::DEFAULT_KEEP_ALIVE));
+	config.AddExtensionOption("force_download", "Forces upfront download of file", LogicalType::BOOLEAN, Value(false));
+	config.AddExtensionOption("force_download_threshold",
+	                          "Forces upfront download of files smaller than the given size in bytes",
+	                          LogicalType::UBIGINT, Value::UBIGINT(0));
+	config.AddExtensionOption("auto_fallback_to_full_download",
+	                          "Allows automatically falling back to full file downloads when possible.",
+	                          LogicalType::BOOLEAN, Value(true));
+	config.AddExtensionOption("allow_asterisks_in_http_paths", "Allow '*' character in URLs users can query",
+	                          LogicalType::BOOLEAN, Value(false));
+	config.AddExtensionOption("enable_curl_server_cert_verification",
+	                          "Enable server side certificate verification for CURL backend.", LogicalType::BOOLEAN,
+	                          Value(true));
+	config.AddExtensionOption("enable_server_cert_verification", "Enable server side certificate verification.",
+	                          LogicalType::BOOLEAN, Value(false));
+	config.AddExtensionOption("ca_cert_file", "Path to a custom certificate file for self-signed certificates.",
+	                          LogicalType::VARCHAR, Value(""), SetCACertFile);
+	config.AddExtensionOption("unsafe_disable_etag_checks", "Disable checks on ETag consistency", LogicalType::BOOLEAN,
+	                          Value(false));
+	config.AddExtensionOption("hf_max_per_page", "Debug option to limit number of items returned in list requests",
+	                          LogicalType::UBIGINT, Value::UBIGINT(0));
+	config.AddExtensionOption("httpfs_client_implementation", "Select which HTTP client implementation is used",
+	                          LogicalType::VARCHAR, "default", SetHTTPClientImplementation);
+	config.AddExtensionOption("httpfs_connection_caching", "Enable connection caching for HTTP requests",
+	                          LogicalType::BOOLEAN, Value::BOOLEAN(true), SetHTTPConnectionCaching);
+}
+
+void HTTPSettings::Initialize(DBConfig &config) {
+	auto &http_util = config.GetHTTPUtil();
+	if (http_util.GetName() == "WasmHTTPUtils") {
+		return;
+	}
+#ifndef EMSCRIPTEN
+	config.SetHTTPUtil(make_shared_ptr<HTTPFSCurlUtil>());
+#else
+	config.SetHTTPUtil(make_shared_ptr<HTTPFSUtil>());
+#endif
+}
+
+} // namespace duckdb

--- a/src/http/httpfs.cpp
+++ b/src/http/httpfs.cpp
@@ -31,92 +31,111 @@ HTTPUtil &HTTPFSUtil::GetHTTPUtil(optional_ptr<FileOpener> opener) {
 	throw InternalException("FileOpener not provided, can't get HTTPUtil");
 }
 
-unique_ptr<HTTPParams> HTTPFSUtil::InitializeParameters(optional_ptr<FileOpener> opener,
-                                                        optional_ptr<FileOpenerInfo> info) {
-	auto result = make_uniq<HTTPFSParams>(*this);
-	result->Initialize(opener);
-	result->state = HTTPState::TryGetState(opener);
-	result->client_reuse_mode = GetClientReuseMode();
-	result->httpfs_util = this;
+struct HTTPParametersInitializer {
+	static unique_ptr<HTTPParams> Create(HTTPFSUtil &httpfs_util, optional_ptr<FileOpener> opener,
+	                                     optional_ptr<FileOpenerInfo> info) {
+		HTTPParametersInitializer initializer(httpfs_util, opener, info);
+		return initializer.Initialize();
+	}
 
-	// No point in continuing without an opener
-	if (!opener) {
+private:
+	HTTPParametersInitializer(HTTPFSUtil &httpfs_util_p, optional_ptr<FileOpener> opener_p,
+	                          optional_ptr<FileOpenerInfo> info_p)
+	    : httpfs_util(httpfs_util_p), opener(opener_p), info(info_p), result(make_uniq<HTTPFSParams>(httpfs_util)) {
+	}
+
+	unique_ptr<HTTPParams> Initialize() {
+		result->Initialize(opener);
+		result->state = HTTPState::TryGetState(opener);
+		result->client_reuse_mode = httpfs_util.GetClientReuseMode();
+		result->httpfs_util = httpfs_util;
+		if (!opener) {
+			return std::move(result);
+		}
+		ReadSettings();
+		SetUserAgent();
+		auto settings_reader = CreateSettingsReader();
+		ReadSecrets(*settings_reader);
 		return std::move(result);
 	}
 
-	Value value;
+	void ReadSettings() {
+		FileOpener::TryGetCurrentSetting(opener, "http_timeout", result->timeout, info);
+		FileOpener::TryGetCurrentSetting(opener, "force_download", result->force_download, info);
+		FileOpener::TryGetCurrentSetting(opener, "force_download_threshold", result->force_download_threshold, info);
+		FileOpener::TryGetCurrentSetting(opener, "auto_fallback_to_full_download",
+		                                 result->auto_fallback_to_full_download, info);
+		FileOpener::TryGetCurrentSetting(opener, "http_retries", result->retries, info);
+		FileOpener::TryGetCurrentSetting(opener, "http_retry_wait_ms", result->retry_wait_ms, info);
+		FileOpener::TryGetCurrentSetting(opener, "http_retry_backoff", result->retry_backoff, info);
+		FileOpener::TryGetCurrentSetting(opener, "http_keep_alive", result->keep_alive, info);
+		FileOpener::TryGetCurrentSetting(opener, "enable_curl_server_cert_verification",
+		                                 result->enable_curl_server_cert_verification, info);
+		FileOpener::TryGetCurrentSetting(opener, "enable_server_cert_verification",
+		                                 result->enable_server_cert_verification, info);
+		FileOpener::TryGetCurrentSetting(opener, "ca_cert_file", result->ca_cert_file, info);
+		FileOpener::TryGetCurrentSetting(opener, "hf_max_per_page", result->hf_max_per_page, info);
+		FileOpener::TryGetCurrentSetting(opener, "unsafe_disable_etag_checks", result->unsafe_disable_etag_checks,
+		                                 info);
+		FileOpener::TryGetCurrentSetting(opener, "s3_version_id_pinning", result->s3_version_id_pinning, info);
+	}
 
-	// Setting lookups
-	FileOpener::TryGetCurrentSetting(opener, "http_timeout", result->timeout, info);
-	FileOpener::TryGetCurrentSetting(opener, "force_download", result->force_download, info);
-	FileOpener::TryGetCurrentSetting(opener, "force_download_threshold", result->force_download_threshold, info);
-	FileOpener::TryGetCurrentSetting(opener, "auto_fallback_to_full_download", result->auto_fallback_to_full_download,
-	                                 info);
-	FileOpener::TryGetCurrentSetting(opener, "http_retries", result->retries, info);
-	FileOpener::TryGetCurrentSetting(opener, "http_retry_wait_ms", result->retry_wait_ms, info);
-	FileOpener::TryGetCurrentSetting(opener, "http_retry_backoff", result->retry_backoff, info);
-	FileOpener::TryGetCurrentSetting(opener, "http_keep_alive", result->keep_alive, info);
-	FileOpener::TryGetCurrentSetting(opener, "enable_curl_server_cert_verification",
-	                                 result->enable_curl_server_cert_verification, info);
-	FileOpener::TryGetCurrentSetting(opener, "enable_server_cert_verification", result->enable_server_cert_verification,
-	                                 info);
-	FileOpener::TryGetCurrentSetting(opener, "ca_cert_file", result->ca_cert_file, info);
-	FileOpener::TryGetCurrentSetting(opener, "hf_max_per_page", result->hf_max_per_page, info);
-	FileOpener::TryGetCurrentSetting(opener, "unsafe_disable_etag_checks", result->unsafe_disable_etag_checks, info);
-	FileOpener::TryGetCurrentSetting(opener, "s3_version_id_pinning", result->s3_version_id_pinning, info);
-
-	{
+	void SetUserAgent() {
 		auto db = FileOpener::TryGetDatabase(opener);
 		if (db) {
 			result->user_agent = StringUtil::Format("%s %s", db->config.UserAgent(), DuckDB::SourceID());
 		}
 	}
 
-	unique_ptr<KeyValueSecretReader> settings_reader;
-	if (info && !S3Url::TryGetPrefix(info->file_path).empty()) {
-		// This is an S3-type url, we should
-		const char *s3_secret_types[] = {"s3", "r2", "gcs", "aws", "http"};
-
-		idx_t secret_type_count = 5;
-		Value merge_http_secret_into_s3_request;
-		FileOpener::TryGetCurrentSetting(opener, "merge_http_secret_into_s3_request",
-		                                 merge_http_secret_into_s3_request);
-
-		if (!merge_http_secret_into_s3_request.IsNull() && !merge_http_secret_into_s3_request.GetValue<bool>()) {
-			// Drop the http secret from the lookup
-			secret_type_count = 4;
+	unique_ptr<KeyValueSecretReader> CreateSettingsReader() {
+		if (info && !S3Url::TryGetPrefix(info->file_path).empty()) {
+			const char *s3_secret_types[] = {"s3", "r2", "gcs", "aws", "http"};
+			idx_t secret_type_count = 5;
+			Value merge_http_secret_into_s3_request;
+			FileOpener::TryGetCurrentSetting(opener, "merge_http_secret_into_s3_request",
+			                                 merge_http_secret_into_s3_request);
+			if (!merge_http_secret_into_s3_request.IsNull() && !merge_http_secret_into_s3_request.GetValue<bool>()) {
+				secret_type_count = 4;
+			}
+			return make_uniq<KeyValueSecretReader>(*opener, info, s3_secret_types, secret_type_count);
 		}
-		settings_reader = make_uniq<KeyValueSecretReader>(*opener, info, s3_secret_types, secret_type_count);
-	} else {
-		settings_reader = make_uniq<KeyValueSecretReader>(*opener, info, "http");
+		return make_uniq<KeyValueSecretReader>(*opener, info, "http");
 	}
 
-	// HTTP Secret lookups
+	void ReadSecrets(KeyValueSecretReader &settings_reader) {
+		string proxy_setting;
+		if (settings_reader.TryGetSecretKey<string>("http_proxy", proxy_setting) && !proxy_setting.empty()) {
+			idx_t port;
+			string host;
+			HTTPUtil::ParseHTTPProxyHost(proxy_setting, host, port);
+			result->http_proxy = host;
+			result->http_proxy_port = port;
+		}
+		result->override_verify_ssl = settings_reader.TryGetSecretKey<bool>("verify_ssl", result->verify_ssl);
+		settings_reader.TryGetSecretKey<string>("http_proxy_username", result->http_proxy_username);
+		settings_reader.TryGetSecretKey<string>("http_proxy_password", result->http_proxy_password);
+		settings_reader.TryGetSecretKey<string>("bearer_token", result->bearer_token);
 
-	string proxy_setting;
-	if (settings_reader->TryGetSecretKey<string>("http_proxy", proxy_setting) && !proxy_setting.empty()) {
-		idx_t port;
-		string host;
-		HTTPUtil::ParseHTTPProxyHost(proxy_setting, host, port);
-		result->http_proxy = host;
-		result->http_proxy_port = port;
-	}
-	result->override_verify_ssl = settings_reader->TryGetSecretKey<bool>("verify_ssl", result->verify_ssl);
-	settings_reader->TryGetSecretKey<string>("http_proxy_username", result->http_proxy_username);
-	settings_reader->TryGetSecretKey<string>("http_proxy_password", result->http_proxy_password);
-	settings_reader->TryGetSecretKey<string>("bearer_token", result->bearer_token);
-
-	Value extra_headers;
-	if (settings_reader->TryGetSecretKey("extra_http_headers", extra_headers)) {
-		auto children = MapValue::GetChildren(extra_headers);
-		for (const auto &child : children) {
-			auto kv = StructValue::GetChildren(child);
-			D_ASSERT(kv.size() == 2);
-			result->extra_headers[kv[0].GetValue<string>()] = kv[1].GetValue<string>();
+		Value extra_headers;
+		if (settings_reader.TryGetSecretKey("extra_http_headers", extra_headers)) {
+			auto children = MapValue::GetChildren(extra_headers);
+			for (const auto &child : children) {
+				auto key_value = StructValue::GetChildren(child);
+				D_ASSERT(key_value.size() == 2);
+				result->extra_headers[key_value[0].GetValue<string>()] = key_value[1].GetValue<string>();
+			}
 		}
 	}
 
-	return std::move(result);
+	HTTPFSUtil &httpfs_util;
+	optional_ptr<FileOpener> opener;
+	optional_ptr<FileOpenerInfo> info;
+	unique_ptr<HTTPFSParams> result;
+};
+
+unique_ptr<HTTPParams> HTTPFSUtil::InitializeParameters(optional_ptr<FileOpener> opener,
+                                                        optional_ptr<FileOpenerInfo> info) {
+	return HTTPParametersInitializer::Create(*this, opener, info);
 }
 
 unique_ptr<HTTPParams> HTTPFSParams::Clone() const {
@@ -298,7 +317,7 @@ static bool RespondedWithRangeRequestNotSupported(const HTTPResponse &res) {
 }
 
 bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders header_map,
-                                     const HTTPReadConfig &read_config, idx_t file_offset, char *buffer_out,
+                                     const HTTPReadConfig &read_config, idx_t file_offset, data_ptr_t buffer_out,
                                      idx_t buffer_out_len) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
 
@@ -328,7 +347,7 @@ bool HTTPFileSystem::TryRangeRequest(FileHandle &handle, string url, HTTPHeaders
 	throw IOException("Unknown error for HTTP %s to '%s'", EnumUtil::ToString(RequestType::GET_REQUEST), url);
 }
 
-bool HTTPFileSystem::ReadAt(FileHandle &handle, void *buffer, idx_t read_size, idx_t location,
+bool HTTPFileSystem::ReadAt(FileHandle &handle, data_ptr_t buffer, idx_t read_size, idx_t location,
                             const HTTPReadConfig &read_config) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
 	if (read_size > NumericLimits<idx_t>::Maximum() - location) {
@@ -347,7 +366,7 @@ bool HTTPFileSystem::ReadAt(FileHandle &handle, void *buffer, idx_t read_size, i
 			memcpy(buffer, cached_file->GetData() + location, read_size);
 		}
 	} else if (read_size > 0) {
-		if (!TryRangeRequest(hfh, hfh.path, {}, read_config, location, static_cast<char *>(buffer), read_size)) {
+		if (!TryRangeRequest(hfh, hfh.path, {}, read_config, location, buffer, read_size)) {
 			return false;
 		}
 	}
@@ -356,7 +375,7 @@ bool HTTPFileSystem::ReadAt(FileHandle &handle, void *buffer, idx_t read_size, i
 	return true;
 }
 
-void HTTPFileSystem::ReadAtWithFallback(FileHandle &handle, void *buffer, idx_t read_size, idx_t location,
+void HTTPFileSystem::ReadAtWithFallback(FileHandle &handle, data_ptr_t buffer, idx_t read_size, idx_t location,
                                         const HTTPReadConfig &read_config) {
 	auto success = ReadAt(handle, buffer, read_size, location, read_config);
 	if (success) {
@@ -402,7 +421,7 @@ void HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, id
 		return;
 	}
 	auto read_config = hfh.GetReadConfig();
-	ReadAtWithFallback(handle, buffer, read_size, location, read_config);
+	ReadAtWithFallback(handle, data_ptr_cast(buffer), read_size, location, read_config);
 }
 
 int64_t HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
@@ -415,7 +434,7 @@ int64_t HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes)
 	read_size = MinValue<idx_t>(hfh.length - hfh.file_offset, read_size);
 	const auto location = hfh.file_offset;
 	auto read_config = hfh.GetReadConfig();
-	ReadAtWithFallback(handle, buffer, read_size, location, read_config);
+	ReadAtWithFallback(handle, data_ptr_cast(buffer), read_size, location, read_config);
 	hfh.file_offset += read_size;
 	return NumericCast<int64_t>(read_size);
 }
@@ -485,7 +504,7 @@ optional_ptr<HTTPMetadataCache> HTTPFileSystem::GetGlobalCache() {
 	if (!global_metadata_cache) {
 		global_metadata_cache = make_uniq<HTTPMetadataCache>(false, true);
 	}
-	return global_metadata_cache.get();
+	return global_metadata_cache;
 }
 
 void HTTPFileSystem::EraseGlobalCacheEntry(const string &path) {
@@ -513,7 +532,7 @@ static optional_ptr<HTTPMetadataCache> TryGetMetadataCache(optional_ptr<FileOpen
 	if (use_shared_cache) {
 		return httpfs.GetGlobalCache();
 	} else if (client_context) {
-		return client_context->registered_state->GetOrCreate<HTTPMetadataCache>("http_cache", true, true).get();
+		return client_context->registered_state->GetOrCreate<HTTPMetadataCache>("http_cache", true, true);
 	}
 	return nullptr;
 }
@@ -555,119 +574,130 @@ bool HTTPFileSystem::TryParseLastModifiedTime(const string &timestamp, timestamp
 	return true;
 }
 
-optional_idx TryParseContentRange(const HTTPHeaders &headers) {
-	if (!headers.HasHeader("Content-Range")) {
-		return optional_idx();
+struct HTTPFileInfoParser {
+	static optional_idx TryParseContentRange(const HTTPHeaders &headers) {
+		if (!headers.HasHeader("Content-Range")) {
+			return optional_idx();
+		}
+		auto content_range = headers.GetHeaderValue("Content-Range");
+		auto range_find = content_range.find("/");
+		if (range_find == string::npos || content_range.size() < range_find + 1) {
+			return optional_idx();
+		}
+		auto range_length = content_range.substr(range_find + 1);
+		if (range_length == "*") {
+			return optional_idx();
+		}
+		return TryParseLength(range_length);
 	}
-	string content_range = headers.GetHeaderValue("Content-Range");
-	auto range_find = content_range.find("/");
-	if (range_find == std::string::npos || content_range.size() < range_find + 1) {
-		return optional_idx();
-	}
-	string range_length = content_range.substr(range_find + 1);
-	if (range_length == "*") {
-		return optional_idx();
-	}
-	try {
-		return std::stoull(range_length);
-	} catch (...) {
-		return optional_idx();
-	}
-}
 
-optional_idx TryParseContentLength(const HTTPHeaders &headers) {
-	if (!headers.HasHeader("Content-Length")) {
-		return optional_idx();
+	static optional_idx TryParseContentLength(const HTTPHeaders &headers) {
+		if (!headers.HasHeader("Content-Length")) {
+			return optional_idx();
+		}
+		return TryParseLength(headers.GetHeaderValue("Content-Length"));
 	}
-	string content_length = headers.GetHeaderValue("Content-Length");
-	try {
-		return std::stoull(content_length);
-	} catch (...) {
-		return optional_idx();
+
+private:
+	static optional_idx TryParseLength(const string &input) {
+		try {
+			return NumericCast<idx_t>(std::stoull(input));
+		} catch (...) {
+			return optional_idx();
+		}
 	}
-}
+};
 
-void HTTPFileHandle::LoadFileInfo() {
-
-	// Check if file is already fully cached (e.g., from a prior force_download_threshold open)
+bool HTTPFileHandle::TryLoadFileInfoWithoutRequest() {
 	D_ASSERT(file_state);
 	if (auto cached_file = file_state->TryGetCachedFileHandle()) {
 		length = cached_file->GetSize();
 		initialized = true;
-		return;
+		return true;
 	}
-
 	if (initialized || force_full_download) {
-		// already initialized or we specifically do not want to perform a head request and just run a direct download
-		return;
+		return true;
 	}
-
-	// In write_overwrite_mode we dgaf about the size, so no head request is needed
 	if (write_overwrite_mode) {
 		length = 0;
 		initialized = true;
-		return;
+		return true;
 	}
+	return false;
+}
 
-	auto &hfs = file_system.Cast<HTTPFileSystem>();
-	auto res = hfs.HeadRequest(*this, path, {});
-	if (res->status != HTTPStatusCode::OK_200) {
-		if (flags.OpenForWriting() && res->status == HTTPStatusCode::NotFound_404) {
-			if (!flags.CreateFileIfNotExists() && !flags.OverwriteExistingFile()) {
-				throw IOException(
-				    "Unable to open URL \"%s\" for writing: file does not exist and CREATE flag is not set", path);
-			}
-			length = 0;
-			return;
-		} else {
-			// HEAD request fail, use Range request for another try (read only one byte)
-			if (flags.OpenForReading() && res->status != HTTPStatusCode::NotFound_404 &&
-			    res->status != HTTPStatusCode::MovedPermanently_301) {
-				auto read_config = BuildReadConfig();
-				auto range_res = hfs.GetRangeRequest(*this, path, {}, read_config, 0, nullptr, 2);
-				if (range_res->status != HTTPStatusCode::PartialContent_206 &&
-				    range_res->status != HTTPStatusCode::Accepted_202 && range_res->status != HTTPStatusCode::OK_200) {
-					// It failed again, check whether we can fall back to full download
-					if (RespondedWithRangeRequestNotSupported(*range_res) &&
-					    read_config.auto_fallback_to_full_download) {
-						force_full_download = true;
-					} else {
-						throw hfs.GetHTTPError(*this, *range_res, path);
-					}
-				}
-				res = std::move(range_res);
-			} else {
-				throw hfs.GetHTTPError(*this, *res, path);
-			}
-		}
+unique_ptr<HTTPResponse> HTTPFileHandle::RequestFileInfo(HTTPFileSystem &hfs) {
+	auto response = hfs.HeadRequest(*this, path, {});
+	if (response->status == HTTPStatusCode::OK_200) {
+		return response;
 	}
+	if (flags.OpenForWriting() && response->status == HTTPStatusCode::NotFound_404) {
+		if (!flags.CreateFileIfNotExists() && !flags.OverwriteExistingFile()) {
+			throw IOException("Unable to open URL \"%s\" for writing: file does not exist and CREATE flag is not set",
+			                  path);
+		}
+		length = 0;
+		return nullptr;
+	}
+	if (flags.OpenForReading() && response->status != HTTPStatusCode::NotFound_404 &&
+	    response->status != HTTPStatusCode::MovedPermanently_301) {
+		return RetryFileInfoWithRange(hfs);
+	}
+	throw hfs.GetHTTPError(*this, *response, path);
+}
+
+unique_ptr<HTTPResponse> HTTPFileHandle::RetryFileInfoWithRange(HTTPFileSystem &hfs) {
+	auto config = BuildReadConfig();
+	auto response = hfs.GetRangeRequest(*this, path, {}, config, 0, nullptr, 2);
+	if (response->status == HTTPStatusCode::PartialContent_206 || response->status == HTTPStatusCode::Accepted_202 ||
+	    response->status == HTTPStatusCode::OK_200) {
+		return response;
+	}
+	if (RespondedWithRangeRequestNotSupported(*response) && config.auto_fallback_to_full_download) {
+		force_full_download = true;
+		return response;
+	}
+	throw hfs.GetHTTPError(*this, *response, path);
+}
+
+void HTTPFileHandle::ApplyFileInfo(const HTTPResponse &response) {
 	length = 0;
-	optional_idx content_size;
-	content_size = TryParseContentRange(res->headers);
+	auto content_size = HTTPFileInfoParser::TryParseContentRange(response.headers);
 	if (!content_size.IsValid()) {
-		content_size = TryParseContentLength(res->headers);
+		content_size = HTTPFileInfoParser::TryParseContentLength(response.headers);
 	}
 	if (content_size.IsValid()) {
 		length = content_size.GetIndex();
 	}
-	if (res->headers.HasHeader("Last-Modified")) {
-		HTTPFileSystem::TryParseLastModifiedTime(res->headers.GetHeaderValue("Last-Modified"), last_modified);
+	if (response.headers.HasHeader("Last-Modified")) {
+		HTTPFileSystem::TryParseLastModifiedTime(response.headers.GetHeaderValue("Last-Modified"), last_modified);
 	}
-	if (res->headers.HasHeader("ETag")) {
-		etag = res->headers.GetHeaderValue("ETag");
+	if (response.headers.HasHeader("ETag")) {
+		etag = response.headers.GetHeaderValue("ETag");
 	}
 	if (request_session->Capture().snapshot->Params().s3_version_id_pinning &&
-	    res->headers.HasHeader("x-amz-version-id")) {
-		SetVersionId(res->headers.GetHeaderValue("x-amz-version-id"));
+	    response.headers.HasHeader("x-amz-version-id")) {
+		SetVersionId(response.headers.GetHeaderValue("x-amz-version-id"));
 	}
-	if (res->headers.HasHeader("Accept-Ranges")) {
-		auto accept_ranges = res->headers.GetHeaderValue("Accept-Ranges");
+	if (response.headers.HasHeader("Accept-Ranges")) {
+		auto accept_ranges = response.headers.GetHeaderValue("Accept-Ranges");
 		StringUtil::Trim(accept_ranges);
 		if (StringUtil::CIEquals(accept_ranges, "bytes")) {
 			file_state->MarkRangeRequestsSupported();
 		}
 	}
 	initialized = true;
+}
+
+void HTTPFileHandle::LoadFileInfo() {
+	if (TryLoadFileInfoWithoutRequest()) {
+		return;
+	}
+	auto &hfs = file_system.Cast<HTTPFileSystem>();
+	auto response = RequestFileInfo(hfs);
+	if (response) {
+		ApplyFileInfo(*response);
+	}
 }
 
 void HTTPFileHandle::TryAddLogger(FileOpener &opener) {
@@ -701,8 +731,7 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
 	return result;
 }
 
-void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
-	auto &hfs = file_system.Cast<HTTPFileSystem>();
+void HTTPFileHandle::InitializeRequestState(optional_ptr<FileOpener> opener) {
 	auto client_context = FileOpener::TryGetClientContext(opener);
 	if (client_context) {
 		buffer_allocator = BufferAllocator::Get(*client_context);
@@ -723,48 +752,62 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 	if (opener) {
 		TryAddLogger(*opener);
 	}
+}
 
-	auto current_cache = TryGetMetadataCache(opener, hfs);
-
-	bool should_write_cache = false;
-	if (flags.OpenForReading()) {
-		if (request_snapshot->Params().force_download) {
-			FinalizeReadConfig();
-			length = hfs.FullDownload(*this, GetReadConfig(), should_write_cache)->GetSize();
-			return;
-		}
-
-		if (current_cache) {
-			HTTPMetadataCacheEntry value;
-			bool found = current_cache->Find(path, value);
-
-			if (found) {
-				InitializeFromCacheEntry(value);
-				FinalizeReadConfig();
-				return;
-			}
-
-			should_write_cache = true;
-		}
+bool HTTPFileHandle::TryInitializeRead(HTTPFileSystem &hfs, optional_ptr<HTTPMetadataCache> cache,
+                                       bool &should_write_cache) {
+	if (!flags.OpenForReading()) {
+		return false;
 	}
+	auto request_snapshot = request_session->Capture().snapshot;
+	if (request_snapshot->Params().force_download) {
+		FinalizeReadConfig();
+		length = hfs.FullDownload(*this, GetReadConfig(), should_write_cache)->GetSize();
+		return true;
+	}
+
+	if (cache) {
+		HTTPMetadataCacheEntry value;
+		if (cache->Find(path, value)) {
+			InitializeFromCacheEntry(value);
+			FinalizeReadConfig();
+			return true;
+		}
+		should_write_cache = true;
+	}
+	return false;
+}
+
+void HTTPFileHandle::InitializeFileInfo(HTTPFileSystem &hfs, optional_ptr<HTTPMetadataCache> cache,
+                                        bool should_write_cache) {
 	LoadFileInfo();
 	FinalizeReadConfig();
 
 	if (flags.OpenForReading()) {
-
+		auto request_snapshot = request_session->Capture().snapshot;
 		const auto has_cache_state = (request_snapshot->Params().state != nullptr) && (length == 0);
 		const auto always_download = force_full_download;
 		const auto meets_threshold = (length < request_snapshot->Params().force_download_threshold) && (length != 0);
-
 		const auto should_full_download = has_cache_state || meets_threshold || always_download;
 
 		if (should_full_download) {
 			length = hfs.FullDownload(*this, GetReadConfig(), should_write_cache)->GetSize();
 		}
 		if (should_write_cache) {
-			current_cache->Insert(path, GetCacheEntry());
+			cache->Insert(path, GetCacheEntry());
 		}
 	}
+}
+
+void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
+	auto &hfs = file_system.Cast<HTTPFileSystem>();
+	InitializeRequestState(opener);
+	auto current_cache = TryGetMetadataCache(opener, hfs);
+	bool should_write_cache = false;
+	if (TryInitializeRead(hfs, current_cache, should_write_cache)) {
+		return;
+	}
+	InitializeFileInfo(hfs, current_cache, should_write_cache);
 
 	// If we're writing to a file, we might as well remove it from the cache
 	if (current_cache && flags.OpenForWriting()) {

--- a/src/http/httpfs_curl_client.cpp
+++ b/src/http/httpfs_curl_client.cpp
@@ -41,16 +41,16 @@ static std::string SelectCURLCertPath() {
 }
 
 static size_t RequestWriteCallback(void *contents, size_t size, size_t nmemb, void *userp) {
-	size_t totalSize = size * nmemb;
-	std::string *str = static_cast<std::string *>(userp);
-	str->append(static_cast<char *>(contents), totalSize);
-	return totalSize;
+	auto total_size = size * nmemb;
+	auto &result = *static_cast<string *>(userp);
+	result.append(char_ptr_cast(contents), total_size);
+	return total_size;
 }
 
 static size_t RequestHeaderCallback(void *contents, size_t size, size_t nmemb, void *userp) {
-	size_t totalSize = size * nmemb;
-	std::string header(static_cast<char *>(contents), totalSize);
-	HeaderCollector *header_collection = static_cast<HeaderCollector *>(userp);
+	auto total_size = size * nmemb;
+	string header(char_ptr_cast(contents), total_size);
+	auto &header_collection = *static_cast<HeaderCollector *>(userp);
 
 	// Trim trailing \r\n
 	if (!header.empty() && header.back() == '\n') {
@@ -63,8 +63,8 @@ static size_t RequestHeaderCallback(void *contents, size_t size, size_t nmemb, v
 	// If header starts with HTTP/... curl has followed a redirect and we have a new Header,
 	// so we push back a new header_collection and store headers from the redirect there.
 	if (header.rfind("HTTP/", 0) == 0) {
-		header_collection->header_collection.push_back(HTTPHeaders());
-		header_collection->header_collection.back().Insert("__RESPONSE_STATUS__", header);
+		header_collection.header_collection.push_back(HTTPHeaders());
+		header_collection.header_collection.back().Insert("__RESPONSE_STATUS__", header);
 	}
 
 	size_t colonPos = header.find(':');
@@ -77,11 +77,11 @@ static size_t RequestHeaderCallback(void *contents, size_t size, size_t nmemb, v
 			part2.erase(0, 1);
 		}
 
-		header_collection->header_collection.back().Insert(part1, part2);
+		header_collection.header_collection.back().Insert(part1, part2);
 	}
 	// TODO: log headers that don't follow the header format
 
-	return totalSize;
+	return total_size;
 }
 
 CURLHandle::CURLHandle(const string &token, const string &cert_path) {
@@ -103,6 +103,22 @@ CURLHandle::~CURLHandle() {
 	curl_easy_cleanup(curl);
 }
 
+CURLURLHandle::CURLURLHandle() : CURLURLHandle(curl_url()) {
+}
+
+CURLURLHandle::CURLURLHandle(CURLU *handle_p) : handle(handle_p) {
+	if (!handle) {
+		throw InternalException("Failed to initialize CURL URL");
+	}
+}
+
+CURLURLHandle::CURLURLHandle(const CURLURLHandle &other) : CURLURLHandle(curl_url_dup(other.handle)) {
+}
+
+CURLURLHandle::~CURLURLHandle() {
+	curl_url_cleanup(handle);
+}
+
 struct RequestInfo {
 	string url = "";
 	string body = "";
@@ -110,10 +126,81 @@ struct RequestInfo {
 	std::vector<HTTPHeaders> header_collection;
 };
 
-static idx_t httpfs_client_count = 0;
+struct CURLGlobalState {
+	annotated_mutex lock;
+	idx_t client_count DUCKDB_GUARDED_BY(lock) = 0;
+};
+
+static CURLGlobalState &GetCURLGlobalState() {
+	static CURLGlobalState state;
+	return state;
+}
 
 class HTTPFSCurlClient : public HTTPClient {
 public:
+	struct ClientConfigurator {
+		static void Configure(HTTPFSCurlClient &client, HTTPFSParams &params) {
+			client.state = params.state;
+			InitializeHandle(client, params);
+			client.request_info = make_uniq<RequestInfo>();
+			ConfigureConnection(client, params);
+			ConfigureTimeoutsAndCallbacks(client, params);
+			ConfigureProxy(client, params);
+		}
+
+	private:
+		static void InitializeHandle(HTTPFSCurlClient &client, const HTTPFSParams &params) {
+			auto cert_file_path = params.ca_cert_file;
+			if (client.curl && client.stored_bearer_token == params.bearer_token &&
+			    client.stored_cert_file_path == cert_file_path) {
+				return;
+			}
+			HTTPFSCurlClient::InitCurlGlobal();
+			client.stored_cert_file_path = cert_file_path;
+			if (cert_file_path.empty()) {
+				cert_file_path = SelectCURLCertPath();
+			}
+			client.curl = make_uniq<CURLHandle>(params.bearer_token, cert_file_path);
+			client.stored_bearer_token = params.bearer_token;
+		}
+
+		static void ConfigureConnection(HTTPFSCurlClient &client, const HTTPFSParams &params) {
+			curl_easy_setopt(*client.curl, CURLOPT_FORBID_REUSE, params.keep_alive ? 0L : 1L);
+			const bool verify_ssl =
+			    params.override_verify_ssl ? params.verify_ssl : params.enable_curl_server_cert_verification;
+			curl_easy_setopt(*client.curl, CURLOPT_SSL_VERIFYPEER, verify_ssl ? 1L : 0L);
+			curl_easy_setopt(*client.curl, CURLOPT_SSL_VERIFYHOST, verify_ssl ? 2L : 0L);
+		}
+
+		static void ConfigureTimeoutsAndCallbacks(HTTPFSCurlClient &client, const HTTPFSParams &params) {
+			curl_easy_setopt(*client.curl, CURLOPT_CONNECTTIMEOUT, params.timeout);
+			curl_easy_setopt(*client.curl, CURLOPT_TIMEOUT, 0L);
+			curl_easy_setopt(*client.curl, CURLOPT_LOW_SPEED_LIMIT, 1024L);
+			curl_easy_setopt(*client.curl, CURLOPT_LOW_SPEED_TIME, params.timeout);
+			curl_easy_setopt(*client.curl, CURLOPT_ACCEPT_ENCODING, nullptr);
+			curl_easy_setopt(*client.curl, CURLOPT_FOLLOWLOCATION, params.follow_location ? 1L : 0L);
+			curl_easy_setopt(*client.curl, CURLOPT_HEADERFUNCTION, RequestHeaderCallback);
+			curl_easy_setopt(*client.curl, CURLOPT_HEADERDATA, &client.request_info->header_collection);
+			curl_easy_setopt(*client.curl, CURLOPT_WRITEFUNCTION, RequestWriteCallback);
+			curl_easy_setopt(*client.curl, CURLOPT_WRITEDATA, &client.request_info->body);
+		}
+
+		static void ConfigureProxy(HTTPFSCurlClient &client, const HTTPFSParams &params) {
+			curl_easy_setopt(*client.curl, CURLOPT_PROXY, nullptr);
+			curl_easy_setopt(*client.curl, CURLOPT_PROXYUSERNAME, nullptr);
+			curl_easy_setopt(*client.curl, CURLOPT_PROXYPASSWORD, nullptr);
+			if (params.http_proxy.empty()) {
+				return;
+			}
+			curl_easy_setopt(*client.curl, CURLOPT_PROXY,
+			                 StringUtil::Format("%s:%d", params.http_proxy, params.http_proxy_port).c_str());
+			if (!params.http_proxy_username.empty()) {
+				curl_easy_setopt(*client.curl, CURLOPT_PROXYUSERNAME, params.http_proxy_username.c_str());
+				curl_easy_setopt(*client.curl, CURLOPT_PROXYPASSWORD, params.http_proxy_password.c_str());
+			}
+		}
+	};
+
 	static string NormalizePathToBeAdded(string added_path) {
 		while (added_path.size() > 2) {
 			if (StringUtil::StartsWith(added_path, "//"))
@@ -127,98 +214,18 @@ public:
 		return added_path;
 	}
 	HTTPFSCurlClient(HTTPFSParams &http_params, const string &proto_host_port) : HTTPClient(proto_host_port) {
-		curl_base_url = curl_url();
 		string normalized_path = NormalizePathToBeAdded(proto_host_port);
-		curl_url_set(curl_base_url, CURLUPART_URL, normalized_path.c_str(), 0);
+		curl_url_set(curl_base_url.Get(), CURLUPART_URL, normalized_path.c_str(), 0);
 		stored_bearer_token = "";
 		stored_cert_file_path = "";
 		Initialize(http_params);
 	}
 	void Initialize(HTTPParams &http_p) override {
-		HTTPFSParams &http_params = (HTTPFSParams &)http_p;
-		auto bearer_token = "";
-		if (!http_params.bearer_token.empty()) {
-			bearer_token = http_params.bearer_token.c_str();
-		}
-
-		state = http_params.state;
-
-		std::string cert_file_path;
-		if (!http_params.ca_cert_file.empty()) {
-			cert_file_path = http_params.ca_cert_file;
-		}
-
-		if (!curl || (stored_bearer_token != bearer_token) || (stored_cert_file_path != cert_file_path)) {
-			// call curl_global_init if not already done by another HTTPFS Client
-			InitCurlGlobal();
-
-			stored_cert_file_path = cert_file_path;
-
-			if (cert_file_path.empty()) {
-				cert_file_path = SelectCURLCertPath();
-			}
-			curl = make_uniq<CURLHandle>(bearer_token, cert_file_path);
-			stored_bearer_token = bearer_token;
-		}
-		request_info = make_uniq<RequestInfo>();
-
-		// set curl options
-
-		// Curl re-uses connections by default
-		if (!http_params.keep_alive) {
-			curl_easy_setopt(*curl, CURLOPT_FORBID_REUSE, 1L);
-		} else {
-			curl_easy_setopt(*curl, CURLOPT_FORBID_REUSE, 0L);
-		}
-
-		const bool verify_ssl =
-		    http_params.override_verify_ssl ? http_params.verify_ssl : http_params.enable_curl_server_cert_verification;
-		if (verify_ssl) {
-			curl_easy_setopt(*curl, CURLOPT_SSL_VERIFYPEER, 1L); // Verify the cert
-			curl_easy_setopt(*curl, CURLOPT_SSL_VERIFYHOST, 2L); // Verify that the cert matches the hostname
-		} else {
-			curl_easy_setopt(*curl, CURLOPT_SSL_VERIFYPEER, 0L); // Override default, don't verify the cert
-			curl_easy_setopt(*curl, CURLOPT_SSL_VERIFYHOST,
-			                 0L); // Override default, don't verify that the cert matches the hostname
-		}
-
-		// set connection timeout
-		curl_easy_setopt(*curl, CURLOPT_CONNECTTIMEOUT, http_params.timeout);
-		// Do NOT impose a hard timeout on the whole transfer
-		curl_easy_setopt(*curl, CURLOPT_TIMEOUT, 0L);                         // no hard timeout for uploads
-		curl_easy_setopt(*curl, CURLOPT_LOW_SPEED_LIMIT, 1024L);              // abort if < 1 KB/s...
-		curl_easy_setopt(*curl, CURLOPT_LOW_SPEED_TIME, http_params.timeout); // ...for 'timeout' consecutive seconds
-
-		// accept content as-is (i.e no decompressing)
-		curl_easy_setopt(*curl, CURLOPT_ACCEPT_ENCODING, NULL);
-		// follow redirects
-		curl_easy_setopt(*curl, CURLOPT_FOLLOWLOCATION, http_params.follow_location ? 1L : 0L);
-
-		// define the header callback
-		curl_easy_setopt(*curl, CURLOPT_HEADERFUNCTION, RequestHeaderCallback);
-		curl_easy_setopt(*curl, CURLOPT_HEADERDATA, &request_info->header_collection);
-		// define the write data callback (for get requests)
-		curl_easy_setopt(*curl, CURLOPT_WRITEFUNCTION, RequestWriteCallback);
-		curl_easy_setopt(*curl, CURLOPT_WRITEDATA, &request_info->body);
-
-		// Reset PROXY-related settings, so they are set only on proxy actually being there
-		curl_easy_setopt(*curl, CURLOPT_PROXY, NULL);
-		curl_easy_setopt(*curl, CURLOPT_PROXYUSERNAME, NULL);
-		curl_easy_setopt(*curl, CURLOPT_PROXYPASSWORD, NULL);
-
-		if (!http_params.http_proxy.empty()) {
-			curl_easy_setopt(*curl, CURLOPT_PROXY,
-			                 StringUtil::Format("%s:%d", http_params.http_proxy, http_params.http_proxy_port).c_str());
-
-			if (!http_params.http_proxy_username.empty()) {
-				curl_easy_setopt(*curl, CURLOPT_PROXYUSERNAME, http_params.http_proxy_username.c_str());
-				curl_easy_setopt(*curl, CURLOPT_PROXYPASSWORD, http_params.http_proxy_password.c_str());
-			}
-		}
+		auto &http_params = http_p.Cast<HTTPFSParams>();
+		ClientConfigurator::Configure(*this, http_params);
 	}
 
 	~HTTPFSCurlClient() {
-		curl_url_cleanup(curl_base_url);
 		DestroyCurlGlobal();
 	}
 	static void AddUserAgentIfAvailable(HTTPFSParams &http_params, HTTPHeaders &header_map) {
@@ -305,7 +312,7 @@ public:
 		}
 
 		bool IsEndOfHeaders(void *contents, idx_t size) const {
-			auto header = static_cast<const char *>(contents);
+			auto header = const_char_ptr_cast(contents);
 			return (size == 2 && header[0] == '\r' && header[1] == '\n') || (size == 1 && header[0] == '\n');
 		}
 
@@ -326,7 +333,7 @@ public:
 				return stopped ? 0 : size;
 			}
 			if (!stream_content || client.request_info->response_code >= 400) {
-				client.request_info->body.append(static_cast<char *>(contents), size);
+				client.request_info->body.append(char_ptr_cast(contents), size);
 			} else if (!request.content_handler(const_data_ptr_cast(contents), size)) {
 				stopped = true;
 				return 0;
@@ -385,7 +392,7 @@ public:
 	};
 
 	unique_ptr<HTTPResponse> Get(GetRequestInfo &info) override {
-		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
+		AddUserAgentIfAvailable(info.params.Cast<HTTPFSParams>(), info.headers);
 		ResetRequestInfo();
 		if (state) {
 			state->get_count++;
@@ -398,23 +405,22 @@ public:
 		{
 			curl_easy_setopt(*curl, CURLOPT_NOBODY, 0L);
 			curl_easy_setopt(*curl, CURLOPT_HTTPGET, 1L);
-			CURLU *url = curl_url_dup(curl_base_url);
+			CURLURLHandle url(curl_base_url);
 
 			string normalized_path = NormalizePathToBeAdded(info.path);
-			curl_url_set(url, CURLUPART_URL, normalized_path.c_str(), 0);
+			curl_url_set(url.Get(), CURLUPART_URL, normalized_path.c_str(), 0);
 
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
-			curl_easy_setopt(*curl, CURLOPT_CURLU, url);
+			curl_easy_setopt(*curl, CURLOPT_CURLU, url.Get());
 			curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers ? curl_headers.headers : nullptr);
 			GetTransferState transfer(*this, info);
 			res = curl->Execute();
-			curl_url_cleanup(url);
 			return transfer.Finish(res);
 		}
 	}
 
 	unique_ptr<HTTPResponse> Put(PutRequestInfo &info) override {
-		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
+		AddUserAgentIfAvailable(info.params.Cast<HTTPFSParams>(), info.headers);
 		ResetRequestInfo();
 		if (state) {
 			state->put_count++;
@@ -429,13 +435,13 @@ public:
 
 		CURLcode res;
 		{
-			CURLU *url = curl_url_dup(curl_base_url);
+			CURLURLHandle url(curl_base_url);
 
 			string normalized_path = NormalizePathToBeAdded(info.path);
-			curl_url_set(url, CURLUPART_URL, normalized_path.c_str(), 0);
+			curl_url_set(url.Get(), CURLUPART_URL, normalized_path.c_str(), 0);
 
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
-			curl_easy_setopt(*curl, CURLOPT_CURLU, url);
+			curl_easy_setopt(*curl, CURLOPT_CURLU, url.Get());
 
 			// Perform PUT
 			curl_easy_setopt(*curl, CURLOPT_CUSTOMREQUEST, "PUT");
@@ -450,7 +456,6 @@ public:
 			curl_easy_setopt(*curl, CURLOPT_CUSTOMREQUEST, nullptr);
 			curl_easy_setopt(*curl, CURLOPT_POSTFIELDS, nullptr);
 			curl_easy_setopt(*curl, CURLOPT_POSTFIELDSIZE, 0);
-			curl_url_cleanup(url);
 		}
 
 		curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, &request_info->response_code);
@@ -459,7 +464,7 @@ public:
 	}
 
 	unique_ptr<HTTPResponse> Head(HeadRequestInfo &info) override {
-		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
+		AddUserAgentIfAvailable(info.params.Cast<HTTPFSParams>(), info.headers);
 		ResetRequestInfo();
 		if (state) {
 			state->head_count++;
@@ -475,13 +480,13 @@ public:
 			curl_easy_setopt(*curl, CURLOPT_NOBODY, 1L);
 			curl_easy_setopt(*curl, CURLOPT_HTTPGET, 0L);
 
-			CURLU *url = curl_url_dup(curl_base_url);
+			CURLURLHandle url(curl_base_url);
 
 			string normalized_path = NormalizePathToBeAdded(info.path);
-			curl_url_set(url, CURLUPART_URL, normalized_path.c_str(), 0);
+			curl_url_set(url.Get(), CURLUPART_URL, normalized_path.c_str(), 0);
 
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
-			curl_easy_setopt(*curl, CURLOPT_CURLU, url);
+			curl_easy_setopt(*curl, CURLOPT_CURLU, url.Get());
 
 			// Add headers if any
 			curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers ? curl_headers.headers : nullptr);
@@ -490,7 +495,6 @@ public:
 			res = curl->Execute();
 			curl_easy_setopt(*curl, CURLOPT_NOBODY, 0L);
 			curl_easy_setopt(*curl, CURLOPT_HTTPGET, 1L);
-			curl_url_cleanup(url);
 		}
 
 		curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, &request_info->response_code);
@@ -498,7 +502,7 @@ public:
 	}
 
 	unique_ptr<HTTPResponse> Delete(DeleteRequestInfo &info) override {
-		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
+		AddUserAgentIfAvailable(info.params.Cast<HTTPFSParams>(), info.headers);
 		ResetRequestInfo();
 		if (state) {
 			state->delete_count++;
@@ -509,13 +513,13 @@ public:
 
 		CURLcode res;
 		{
-			CURLU *url = curl_url_dup(curl_base_url);
+			CURLURLHandle url(curl_base_url);
 
 			string normalized_path = NormalizePathToBeAdded(info.path);
-			curl_url_set(url, CURLUPART_URL, normalized_path.c_str(), 0);
+			curl_url_set(url.Get(), CURLUPART_URL, normalized_path.c_str(), 0);
 
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
-			curl_easy_setopt(*curl, CURLOPT_CURLU, url);
+			curl_easy_setopt(*curl, CURLOPT_CURLU, url.Get());
 
 			// Set DELETE request method
 			curl_easy_setopt(*curl, CURLOPT_CUSTOMREQUEST, "DELETE");
@@ -526,7 +530,6 @@ public:
 			// Execute DELETE request
 			res = curl->Execute();
 			curl_easy_setopt(*curl, CURLOPT_CUSTOMREQUEST, nullptr);
-			curl_url_cleanup(url);
 		}
 
 		// Get HTTP response status code
@@ -541,13 +544,13 @@ public:
 
 		CURLcode res;
 		{
-			CURLU *url = curl_url_dup(curl_base_url);
+			CURLURLHandle url(curl_base_url);
 
 			string normalized_path = NormalizePathToBeAdded(info.path);
-			curl_url_set(url, CURLUPART_URL, normalized_path.c_str(), 0);
+			curl_url_set(url.Get(), CURLUPART_URL, normalized_path.c_str(), 0);
 
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
-			curl_easy_setopt(*curl, CURLOPT_CURLU, url);
+			curl_easy_setopt(*curl, CURLOPT_CURLU, url.Get());
 
 			curl_easy_setopt(*curl, CURLOPT_CUSTOMREQUEST, "OPTIONS");
 
@@ -555,7 +558,6 @@ public:
 
 			res = curl->Execute();
 			curl_easy_setopt(*curl, CURLOPT_CUSTOMREQUEST, nullptr);
-			curl_url_cleanup(url);
 		}
 
 		curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, &request_info->response_code);
@@ -563,7 +565,7 @@ public:
 	}
 
 	unique_ptr<HTTPResponse> Post(PostRequestInfo &info) override {
-		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
+		AddUserAgentIfAvailable(info.params.Cast<HTTPFSParams>(), info.headers);
 		ResetRequestInfo();
 		if (state) {
 			state->post_count++;
@@ -580,13 +582,13 @@ public:
 
 		CURLcode res;
 		{
-			CURLU *url = curl_url_dup(curl_base_url);
+			CURLURLHandle url(curl_base_url);
 
 			string normalized_path = NormalizePathToBeAdded(info.path);
-			curl_url_set(url, CURLUPART_URL, normalized_path.c_str(), 0);
+			curl_url_set(url.Get(), CURLUPART_URL, normalized_path.c_str(), 0);
 
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
-			curl_easy_setopt(*curl, CURLOPT_CURLU, url);
+			curl_easy_setopt(*curl, CURLOPT_CURLU, url.Get());
 			if (info.send_post_as_get_request) {
 				curl_easy_setopt(*curl, CURLOPT_CUSTOMREQUEST, "GET");
 			} else {
@@ -605,7 +607,6 @@ public:
 			curl_easy_setopt(*curl, CURLOPT_POSTFIELDS, nullptr);
 			curl_easy_setopt(*curl, CURLOPT_POSTFIELDSIZE, 0);
 			curl_easy_setopt(*curl, CURLOPT_POST, 0L);
-			curl_url_cleanup(url);
 		}
 
 		curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, &request_info->response_code);
@@ -643,7 +644,7 @@ private:
 				curl_headers.Add(entry.first + ": " + entry.second);
 			}
 		}
-		return std::move(curl_headers);
+		return curl_headers;
 	}
 
 	void ResetRequestInfo() {
@@ -684,32 +685,27 @@ private:
 	unique_ptr<CURLHandle> curl;
 	optional_ptr<HTTPState> state;
 	unique_ptr<RequestInfo> request_info;
-	CURLU *curl_base_url = nullptr;
+	CURLURLHandle curl_base_url;
 	string stored_bearer_token;
 	string stored_cert_file_path;
 
-	static mutex &GetRefLock() {
-		static mutex mtx;
-		return mtx;
-	}
-
 	static void InitCurlGlobal() {
-		const std::lock_guard<std::mutex> lock(GetRefLock());
-		if (httpfs_client_count == 0) {
+		auto &state = GetCURLGlobalState();
+		annotated_lock_guard<annotated_mutex> lock(state.lock);
+		if (state.client_count == 0) {
 			curl_global_init(CURL_GLOBAL_DEFAULT);
 		}
-		++httpfs_client_count;
+		++state.client_count;
 	}
 
 	static void DestroyCurlGlobal() {
 		// TODO: when to call curl_global_cleanup()
 		// calling it on client destruction causes SSL errors when verification is on (due to many requests).
-		// GetRefLock();
-		// if (httpfs_client_count == 0) {
+		// if (state.client_count == 0) {
 		// 	throw InternalException("Destroying Httpfs client that did not initialize CURL");
 		// }
-		// --httpfs_client_count;
-		// if (httpfs_client_count == 0) {
+		// --state.client_count;
+		// if (state.client_count == 0) {
 		// 	curl_global_cleanup();
 		// }
 	}

--- a/src/http/httpfs_httplib_client.cpp
+++ b/src/http/httpfs_httplib_client.cpp
@@ -12,7 +12,7 @@ public:
 		Initialize(http_params);
 	}
 	void Initialize(HTTPParams &http_p) override {
-		HTTPFSParams &http_params = (HTTPFSParams &)http_p;
+		auto &http_params = http_p.Cast<HTTPFSParams>();
 		client->set_follow_location(http_params.follow_location);
 		client->set_keep_alive(http_params.keep_alive);
 		if (!http_params.ca_cert_file.empty()) {
@@ -54,8 +54,75 @@ public:
 		}
 	}
 
+	class GetTransferState {
+	public:
+		GetTransferState(HTTPFSClient &client_p, GetRequestInfo &request_p)
+		    : client(client_p), request(request_p), request_monotonic_start(TimePoint::Tick()) {
+		}
+
+		bool HandleResponse(const duckdb_httplib_openssl::Response &response) {
+			auto http_response = client.TransformResponse(response);
+			if (static_cast<int>(http_response->status) >= 400) {
+				deferred_response = std::move(http_response);
+				return true;
+			}
+			if (request.response_handler && !request.response_handler(*http_response)) {
+				stopped_response = std::move(http_response);
+				return false;
+			}
+			return true;
+		}
+
+		bool HandleContent(const char *data, size_t data_length) {
+			RecordFirstByte();
+			auto chunk_size = NumericCast<idx_t>(data_length);
+			total_bytes += chunk_size;
+			if (client.state) {
+				client.state->total_bytes_received += chunk_size;
+			}
+			if (deferred_response) {
+				deferred_response->body.append(data, data_length);
+				return true;
+			}
+			return !request.content_handler || request.content_handler(const_data_ptr_cast(data), chunk_size);
+		}
+
+		unique_ptr<HTTPResponse> Finish(duckdb_httplib_openssl::Result result) {
+			request.bytes_received = total_bytes;
+			if (deferred_response) {
+				if (request.response_handler) {
+					request.response_handler(*deferred_response);
+				}
+				return std::move(deferred_response);
+			}
+			if (stopped_response) {
+				return std::move(stopped_response);
+			}
+			return client.TransformResult(std::move(result));
+		}
+
+	private:
+		void RecordFirstByte() {
+			if (!first_chunk) {
+				return;
+			}
+			first_chunk = false;
+			request.have_time_to_fst_byte = true;
+			const auto elapsed_nanos = TimePoint::ElapsedNanos(request_monotonic_start, TimePoint::Tick());
+			request.time_to_fst_byte_sec = elapsed_nanos > 0 ? static_cast<double>(elapsed_nanos) / 1e9 : 0;
+		}
+
+		HTTPFSClient &client;
+		GetRequestInfo &request;
+		const TimePoint request_monotonic_start;
+		idx_t total_bytes = 0;
+		bool first_chunk = true;
+		unique_ptr<HTTPResponse> deferred_response;
+		unique_ptr<HTTPResponse> stopped_response;
+	};
+
 	unique_ptr<HTTPResponse> Get(GetRequestInfo &info) override {
-		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
+		AddUserAgentIfAvailable(info.params.Cast<HTTPFSParams>(), info.headers);
 		if (state) {
 			state->get_count++;
 		}
@@ -66,61 +133,16 @@ public:
 				state->total_bytes_received += result->body.size();
 			}
 			return result;
-		} else {
-			// The httplib client streams per chunk, so the first chunk gives us TTFB, used by the prefetch cost model
-			// as the latency estimate.
-			const auto request_monotonic_start = TimePoint::Tick();
-			idx_t total_bytes = 0;
-			bool first_chunk = true;
-			unique_ptr<HTTPResponse> deferred_response;
-			unique_ptr<HTTPResponse> stopped_response;
-			auto client_result = client->Get(
-			    info.path.c_str(), headers,
-			    [&](const duckdb_httplib_openssl::Response &response) {
-				    auto http_response = TransformResponse(response);
-				    if (static_cast<int>(http_response->status) >= 400) {
-					    deferred_response = std::move(http_response);
-					    return true;
-				    }
-				    if (info.response_handler && !info.response_handler(*http_response)) {
-					    stopped_response = std::move(http_response);
-					    return false;
-				    }
-				    return true;
-			    },
-			    [&](const char *data, size_t data_length) {
-				    if (first_chunk) {
-					    first_chunk = false;
-					    info.have_time_to_fst_byte = true;
-					    // Time to first byte is the duration from issuing the request until the first chunk arrives.
-					    const auto elapsed_nanos = TimePoint::ElapsedNanos(request_monotonic_start, TimePoint::Tick());
-					    info.time_to_fst_byte_sec = elapsed_nanos > 0 ? static_cast<double>(elapsed_nanos) / 1e9 : 0;
-				    }
-				    total_bytes += data_length;
-				    if (state) {
-					    state->total_bytes_received += data_length;
-				    }
-				    if (deferred_response) {
-					    deferred_response->body.append(data, data_length);
-					    return true;
-				    }
-				    return !info.content_handler || info.content_handler(const_data_ptr_cast(data), data_length);
-			    });
-			info.bytes_received = total_bytes;
-			if (deferred_response) {
-				if (info.response_handler) {
-					info.response_handler(*deferred_response);
-				}
-				return deferred_response;
-			}
-			if (stopped_response) {
-				return stopped_response;
-			}
-			return TransformResult(std::move(client_result));
 		}
+		GetTransferState transfer(*this, info);
+		auto result = client->Get(
+		    info.path.c_str(), headers,
+		    [&](const duckdb_httplib_openssl::Response &response) { return transfer.HandleResponse(response); },
+		    [&](const char *data, size_t data_length) { return transfer.HandleContent(data, data_length); });
+		return transfer.Finish(std::move(result));
 	}
 	unique_ptr<HTTPResponse> Put(PutRequestInfo &info) override {
-		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
+		AddUserAgentIfAvailable(info.params.Cast<HTTPFSParams>(), info.headers);
 		if (state) {
 			state->put_count++;
 			state->total_bytes_sent += info.buffer_in_len;
@@ -131,7 +153,7 @@ public:
 	}
 
 	unique_ptr<HTTPResponse> Head(HeadRequestInfo &info) override {
-		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
+		AddUserAgentIfAvailable(info.params.Cast<HTTPFSParams>(), info.headers);
 		if (state) {
 			state->head_count++;
 		}
@@ -140,7 +162,7 @@ public:
 	}
 
 	unique_ptr<HTTPResponse> Delete(DeleteRequestInfo &info) override {
-		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
+		AddUserAgentIfAvailable(info.params.Cast<HTTPFSParams>(), info.headers);
 		if (state) {
 			state->delete_count++;
 		}
@@ -154,7 +176,7 @@ public:
 	}
 
 	unique_ptr<HTTPResponse> Post(PostRequestInfo &info) override {
-		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
+		AddUserAgentIfAvailable(info.params.Cast<HTTPFSParams>(), info.headers);
 		if (state) {
 			state->post_count++;
 			state->total_bytes_sent += info.buffer_in_len;

--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -1,211 +1,66 @@
 #include "httpfs_extension.hpp"
-#include "duckdb/logging/logger.hpp"
-
 #include "http/httpfs_client.hpp"
+#include "http/http_settings.hpp"
 #include "create_secret_functions.hpp"
 #include "duckdb.hpp"
+#include "s3/s3_settings.hpp"
 #include "s3/s3fs.hpp"
 #include "hffs.hpp"
-#include "duckdb/common/local_file_system.hpp"
 #include "duckdb/logging/log_manager.hpp"
-#include "duckdb/main/client_context_file_opener.hpp"
 #ifdef OVERRIDE_ENCRYPTION_UTILS
 #include "crypto.hpp"
 #elif defined(EMSCRIPTEN)
 #include "mbedtls_wrapper.hpp"
 #endif // OVERRIDE_ENCRYPTION_UTILS
 
-#ifndef EMSCRIPTEN
-#include "http/httpfs_curl_client.hpp"
-#endif
-
 namespace duckdb {
 
-static void ClearHTTPFSConnectionCacheFunction(ClientContext &context, TableFunctionInput &, DataChunk &) {
-	auto &config = DBConfig::GetConfig(context);
-	auto &httpfs_util = static_cast<HTTPFSUtil &>(config.GetHTTPUtil());
-	httpfs_util.ClearCachedConnections();
-}
+struct HTTPFSExtensionLoader {
+	static void RegisterFileSystems(DatabaseInstance &instance) {
+		auto &fs = instance.GetFileSystem();
+		fs.RegisterSubSystem(make_uniq<HTTPFileSystem>());
+		fs.RegisterSubSystem(make_uniq<HuggingFaceFileSystem>());
+		fs.RegisterSubSystem(make_uniq<S3FileSystem>(BufferManager::GetBufferManager(instance)));
+	}
 
-static unique_ptr<FunctionData> ClearHTTPFSConnectionCacheBind(ClientContext &, TableFunctionBindInput &,
-                                                               vector<LogicalType> &return_types,
-                                                               vector<string> &names) {
-	return_types.emplace_back(LogicalType::BOOLEAN);
-	names.emplace_back("success");
-	return nullptr;
-}
+	static void RegisterSettings(DBConfig &config) {
+		HTTPSettings::Register(config);
+		S3Settings::Register(config);
+		HTTPSettings::Initialize(config);
+		S3Settings::Initialize(config);
+	}
+
+	static void RegisterSecrets(ExtensionLoader &loader) {
+		CreateS3SecretFunctions::Register(loader);
+		CreateBearerTokenFunctions::Register(loader);
+	}
+
+	static void ConfigureEncryption(DBConfig &config) {
+#ifdef OVERRIDE_ENCRYPTION_UTILS
+		config.encryption_util = make_shared_ptr<AESStateSSLFactory>();
+#elif defined(EMSCRIPTEN)
+		if (!config.encryption_util) {
+			config.encryption_util = make_shared_ptr<duckdb_mbedtls::MbedTlsWrapper::AESStateMBEDTLSFactory>();
+		}
+#endif
+	}
+
+	static void Load(ExtensionLoader &loader) {
+		auto &instance = loader.GetDatabaseInstance();
+		RegisterFileSystems(instance);
+		instance.GetLogManager().RegisterLogType(make_uniq<HTTPFSInfoLogType>());
+
+		auto &config = DBConfig::GetConfig(instance);
+		RegisterSettings(config);
+		RegisterSecrets(loader);
+		ConfigureEncryption(config);
+	}
+};
 
 static void LoadInternal(ExtensionLoader &loader) {
-	auto &instance = loader.GetDatabaseInstance();
-	auto &fs = instance.GetFileSystem();
-
-	fs.RegisterSubSystem(make_uniq<HTTPFileSystem>());
-	fs.RegisterSubSystem(make_uniq<HuggingFaceFileSystem>());
-	fs.RegisterSubSystem(make_uniq<S3FileSystem>(BufferManager::GetBufferManager(instance)));
-
-	instance.GetLogManager().RegisterLogType(make_uniq<HTTPFSInfoLogType>());
-
-	auto &config = DBConfig::GetConfig(instance);
-
-	// Global HTTP config
-	// Single timeout value is used for all 4 types of timeouts, we could split it into 4 if users need that
-	config.AddExtensionOption("http_timeout", "HTTP timeout read/write/connection/retry (in seconds)",
-	                          LogicalType::UBIGINT, Value::UBIGINT(HTTPParams::DEFAULT_TIMEOUT_SECONDS));
-	config.AddExtensionOption("http_retries", "HTTP retries on I/O error", LogicalType::UBIGINT, Value(3));
-	config.AddExtensionOption("http_retry_wait_ms", "Time between retries", LogicalType::UBIGINT, Value(100));
-	config.AddExtensionOption("force_download", "Forces upfront download of file", LogicalType::BOOLEAN, Value(false));
-	config.AddExtensionOption("force_download_threshold",
-	                          "Forces upfront download of files smaller than the given size in bytes",
-	                          LogicalType::UBIGINT, Value::UBIGINT(0));
-	config.AddExtensionOption("auto_fallback_to_full_download",
-	                          "Allows automatically falling back to full file downloads when possible.",
-	                          LogicalType::BOOLEAN, Value(true));
-	// Reduces the number of requests made while waiting, for example retry_wait_ms of 50 and backoff factor of 2 will
-	// result in wait times of  0 50 100 200 400...etc.
-	config.AddExtensionOption("http_retry_backoff", "Backoff factor for exponentially increasing retry wait time",
-	                          LogicalType::FLOAT, Value(4));
-	config.AddExtensionOption(
-	    "http_keep_alive",
-	    "Keep alive connections. Setting this to false can help when running into connection failures",
-	    LogicalType::BOOLEAN, Value(true));
-	config.AddExtensionOption("allow_asterisks_in_http_paths", "Allow '*' character in URLs users can query",
-	                          LogicalType::BOOLEAN, Value(false));
-	config.AddExtensionOption("enable_curl_server_cert_verification",
-	                          "Enable server side certificate verification for CURL backend.", LogicalType::BOOLEAN,
-	                          Value(true));
-	config.AddExtensionOption("enable_server_cert_verification", "Enable server side certificate verification.",
-	                          LogicalType::BOOLEAN, Value(false));
-	auto callback_ca_cert_file = [](ClientContext &context, SetScope scope, Value &parameter) {
-		if (parameter.IsNull()) {
-			throw InvalidInputException("NULL it's not a valid option for ca_cert_file");
-		}
-		string value = StringValue::Get(parameter);
-		if (value.empty()) {
-			parameter = Value("");
-			return;
-		}
-		LocalFileSystem fs;
-		ClientContextFileOpener opener(context);
-		// Normalize ca_cert_file to absolute path
-		parameter = Value(fs.CanonicalizePath(value, opener));
-	};
-	config.AddExtensionOption("ca_cert_file", "Path to a custom certificate file for self-signed certificates.",
-	                          LogicalType::VARCHAR, Value(""), callback_ca_cert_file);
-	// Global S3 config
-	config.AddExtensionOption("s3_region", "S3 Region", LogicalType::VARCHAR);
-	config.AddExtensionOption("s3_access_key_id", "S3 Access Key ID", LogicalType::VARCHAR);
-	config.AddExtensionOption("s3_secret_access_key", "S3 Access Key", LogicalType::VARCHAR);
-	config.AddExtensionOption("s3_session_token", "S3 Session Token", LogicalType::VARCHAR);
-	config.AddExtensionOption("s3_endpoint", "S3 Endpoint", LogicalType::VARCHAR);
-	config.AddExtensionOption("s3_url_style", "S3 URL style", LogicalType::VARCHAR, Value("vhost"));
-	config.AddExtensionOption("s3_use_ssl", "S3 use SSL", LogicalType::BOOLEAN, Value(true));
-	config.AddExtensionOption("s3_kms_key_id", "S3 KMS Key ID", LogicalType::VARCHAR);
-	config.AddExtensionOption("s3_url_compatibility_mode", "Disable Globs and Query Parameters on S3 URLs",
-	                          LogicalType::BOOLEAN, Value(false));
-	config.AddExtensionOption("s3_requester_pays", "S3 use requester pays mode", LogicalType::BOOLEAN, Value(false));
-	config.AddExtensionOption(
-	    "s3_allow_recursive_globbing",
-	    "Whether globs on S3-like storage are optimized with recursive strategy (alterative is listing)",
-	    LogicalType::BOOLEAN, Value(true));
-
-	// S3 Uploader config
-	config.AddExtensionOption("s3_uploader_max_filesize", "S3 Uploader max filesize (between 50GB and 5TB)",
-	                          LogicalType::VARCHAR, "800GB");
-	config.AddExtensionOption("s3_uploader_max_parts_per_file", "S3 Uploader max parts per file (between 1 and 10000)",
-	                          LogicalType::UBIGINT, Value(10000));
-	config.AddExtensionOption("s3_uploader_thread_limit", "S3 Uploader global thread limit", LogicalType::UBIGINT,
-	                          Value(50));
-	config.AddExtensionOption("unsafe_disable_etag_checks", "Disable checks on ETag consistency", LogicalType::BOOLEAN,
-	                          Value(false));
-	config.AddExtensionOption("s3_version_id_pinning", "Pin S3 reads to a specific object version for consistency",
-	                          LogicalType::BOOLEAN, Value(false));
-
-	// HuggingFace options
-	config.AddExtensionOption("hf_max_per_page", "Debug option to limit number of items returned in list requests",
-	                          LogicalType::UBIGINT, Value::UBIGINT(0));
-
-	config.AddExtensionOption("merge_http_secret_into_s3_request", "Merges http secret params into S3 requests",
-	                          LogicalType::BOOLEAN, Value(true));
-	config.AddExtensionOption("httpfs_enable_credential_refresh", "Enable credential refresh for HTTPFS S3 secrets",
-	                          LogicalType::BOOLEAN, Value(true));
-
-	auto callback_httpfs_client_implementation = [](ClientContext &context, SetScope scope, Value &parameter) {
-		auto &config = DBConfig::GetConfig(context);
-		string value = StringValue::Get(parameter);
-		auto &http_util = config.GetHTTPUtil();
-		if (http_util.GetName() == "WasmHTTPUtils") {
-			if (value == "wasm" || value == "default") {
-				return;
-			}
-			throw InvalidInputException("Unsupported option for httpfs_client_implementation, only `wasm` and "
-			                            "`default` are currently supported for duckdb-wasm");
-		}
-#ifndef EMSCRIPTEN
-		// HTTP util classes are supposed to be cheap, which provides acces to the HTTP client, and generally don't
-		// store resources (i.e., connection pool).
-		if (value == "curl" || value == "default") {
-			config.SetHTTPUtil(make_shared_ptr<HTTPFSCurlUtil>());
-			return;
-		}
-		if (value == "httplib") {
-			config.SetHTTPUtil(make_shared_ptr<HTTPFSUtil>());
-			return;
-		}
-#endif
-		throw InvalidInputException("Unsupported option for httpfs_client_implementation, only `curl`, `httplib` "
-		                            "and `default` are currently supported");
-	};
-	config.AddExtensionOption("httpfs_client_implementation", "Select which is the HTTPUtil implementation to be used",
-	                          LogicalType::VARCHAR, "default", callback_httpfs_client_implementation);
-
-	auto callback_httpfs_connection_caching = [](ClientContext &context, SetScope scope, Value &parameter) {
-		auto &config = DBConfig::GetConfig(context);
-		auto &http_util = config.GetHTTPUtil();
-#ifndef EMSCRIPTEN
-		if (http_util.GetName() == "HTTPFS-Curl") {
-			auto *curl_util = static_cast<HTTPFSCurlUtil *>(&http_util);
-			curl_util->connection_caching_enabled = BooleanValue::Get(parameter);
-		}
-#endif
-	};
-	config.AddExtensionOption("httpfs_connection_caching", "Enable connection caching for HTTP requests",
-	                          LogicalType::BOOLEAN, Value::BOOLEAN(true), callback_httpfs_connection_caching);
-
-	config.AddExtensionOption("enable_global_s3_configuration",
-	                          "Automatically fetch AWS credentials from environment variables.", LogicalType::BOOLEAN,
-	                          Value::BOOLEAN(true));
-
-	auto &http_util = config.GetHTTPUtil();
-	if (http_util.GetName() == "WasmHTTPUtils") {
-		// Already handled, do not override
-	} else {
-#ifndef EMSCRIPTEN
-		config.SetHTTPUtil(make_shared_ptr<HTTPFSCurlUtil>());
-#else
-		config.SetHTTPUtil(make_shared_ptr<HTTPFSUtil>());
-#endif
-	}
-
-	auto provider = make_uniq<AWSEnvironmentCredentialsProvider>(config);
-	provider->SetAll();
-
-	auto clear_httpfs_connection_cache = TableFunction(
-	    "clear_httpfs_connection_cache", {}, ClearHTTPFSConnectionCacheFunction, ClearHTTPFSConnectionCacheBind);
-	// No registration (for now), due to issues with loading httpfs with partially intialized duckdb
-	// loader.RegisterFunction(clear_httpfs_connection_cache);
-
-	CreateS3SecretFunctions::Register(loader);
-	CreateBearerTokenFunctions::Register(loader);
-
-#ifdef OVERRIDE_ENCRYPTION_UTILS
-	// set pointer to OpenSSL encryption state
-	config.encryption_util = make_shared_ptr<AESStateSSLFactory>();
-#elif defined(EMSCRIPTEN)
-	if (!config.encryption_util) {
-		config.encryption_util = make_shared_ptr<duckdb_mbedtls::MbedTlsWrapper::AESStateMBEDTLSFactory>();
-	}
-#endif // OVERRIDE_ENCRYPTION_UTILS
+	HTTPFSExtensionLoader::Load(loader);
 }
+
 void HttpfsExtension::Load(ExtensionLoader &loader) {
 	LoadInternal(loader);
 }

--- a/src/include/hash_functions.hpp
+++ b/src/include/hash_functions.hpp
@@ -10,9 +10,9 @@ namespace duckdb {
 typedef unsigned char hash_bytes[32];
 typedef unsigned char hash_str[64];
 
-void sha256(EncryptionUtil &encryption_util, const char *in, size_t in_len, hash_bytes &out);
+void sha256(EncryptionUtil &encryption_util, const_data_ptr_t in, idx_t in_len, hash_bytes &out);
 
-void hmac256(EncryptionUtil &encryption_util, const std::string &message, const char *secret, size_t secret_len,
+void hmac256(EncryptionUtil &encryption_util, const std::string &message, const_data_ptr_t secret, idx_t secret_len,
              hash_bytes &out);
 
 void hmac256(EncryptionUtil &encryption_util, std::string message, hash_bytes secret, hash_bytes &out);

--- a/src/include/hffs.hpp
+++ b/src/include/hffs.hpp
@@ -30,7 +30,7 @@ public:
 	                                            CachedFileDownload &download) override;
 	duckdb::unique_ptr<HTTPResponse> GetRangeRequest(FileHandle &handle, string hf_url, HTTPHeaders header_map,
 	                                                 const HTTPReadConfig &read_config, idx_t file_offset,
-	                                                 char *buffer_out, idx_t buffer_out_len) override;
+	                                                 data_ptr_t buffer_out, idx_t buffer_out_len) override;
 
 	bool CanHandleFile(const string &fpath) override {
 		return fpath.rfind("hf://", 0) == 0;
@@ -40,6 +40,7 @@ public:
 		return "HuggingFaceFileSystem";
 	}
 	static ParsedHFUrl HFUrlParse(const string &url);
+	static void ParseListResult(const string &input, vector<string> &files, vector<string> &directories);
 	string GetHFUrl(const ParsedHFUrl &url);
 	string GetTreeUrl(const ParsedHFUrl &url, idx_t limit);
 	string GetFileUrl(const ParsedHFUrl &url);

--- a/src/include/http/http_settings.hpp
+++ b/src/include/http/http_settings.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace duckdb {
+
+class DBConfig;
+
+struct HTTPSettings {
+	static void Register(DBConfig &config);
+	static void Initialize(DBConfig &config);
+};
+
+} // namespace duckdb

--- a/src/include/http/httpfs.hpp
+++ b/src/include/http/httpfs.hpp
@@ -119,6 +119,15 @@ protected:
 
 private:
 	void FinalizeReadConfig();
+	bool TryLoadFileInfoWithoutRequest();
+	unique_ptr<HTTPResponse> RequestFileInfo(HTTPFileSystem &file_system);
+	unique_ptr<HTTPResponse> RetryFileInfoWithRange(HTTPFileSystem &file_system);
+	void ApplyFileInfo(const HTTPResponse &response);
+	void InitializeRequestState(optional_ptr<FileOpener> opener);
+	bool TryInitializeRead(HTTPFileSystem &file_system, optional_ptr<HTTPMetadataCache> cache,
+	                       bool &should_write_cache);
+	void InitializeFileInfo(HTTPFileSystem &file_system, optional_ptr<HTTPMetadataCache> cache,
+	                        bool should_write_cache);
 };
 
 class HTTPFileSystem : public FileSystem {
@@ -178,7 +187,7 @@ public:
 	// Get Request with range parameter that GETs exactly buffer_out_len bytes from the url
 	virtual unique_ptr<HTTPResponse> GetRangeRequest(FileHandle &handle, string url, HTTPHeaders header_map,
 	                                                 const HTTPReadConfig &read_config, idx_t file_offset,
-	                                                 char *buffer_out, idx_t buffer_out_len);
+	                                                 data_ptr_t buffer_out, idx_t buffer_out_len);
 	// Get Request without a range (i.e., downloads full file)
 	virtual unique_ptr<HTTPResponse> GetRequest(FileHandle &handle, string url, HTTPHeaders header_map,
 	                                            const HTTPReadConfig &read_config, CachedFileDownload &download);
@@ -199,9 +208,10 @@ protected:
 
 	//! Internal read helpers.
 	bool TryRangeRequest(FileHandle &handle, string url, HTTPHeaders header_map, const HTTPReadConfig &read_config,
-	                     idx_t file_offset, char *buffer_out, idx_t buffer_out_len);
-	bool ReadAt(FileHandle &handle, void *buffer, idx_t read_size, idx_t location, const HTTPReadConfig &read_config);
-	void ReadAtWithFallback(FileHandle &handle, void *buffer, idx_t read_size, idx_t location,
+	                     idx_t file_offset, data_ptr_t buffer_out, idx_t buffer_out_len);
+	bool ReadAt(FileHandle &handle, data_ptr_t buffer, idx_t read_size, idx_t location,
+	            const HTTPReadConfig &read_config);
+	void ReadAtWithFallback(FileHandle &handle, data_ptr_t buffer, idx_t read_size, idx_t location,
 	                        const HTTPReadConfig &read_config);
 
 	//! Shared request runners used by subclasses that need custom request setup/retry behavior.
@@ -213,10 +223,10 @@ protected:
 	unique_ptr<HTTPResponse> RunDeleteRequest(string url, HTTPHeaders header_map, HTTPFSParams &http_params,
 	                                          HTTPSendCallback send_request);
 	unique_ptr<HTTPResponse> RunPostRequest(string url, HTTPHeaders header_map, HTTPFSParams &http_params,
-	                                        string &result, char *buffer_in, idx_t buffer_in_len,
+	                                        string &result, const_data_ptr_t buffer_in, idx_t buffer_in_len,
 	                                        HTTPSendCallback send_request);
 	unique_ptr<HTTPResponse> RunPutRequest(string url, HTTPHeaders header_map, HTTPFSParams &http_params,
-	                                       char *buffer_in, idx_t buffer_in_len, const string &content_type,
+	                                       const_data_ptr_t buffer_in, idx_t buffer_in_len, const string &content_type,
 	                                       HTTPSendCallback send_request);
 	unique_ptr<HTTPResponse> RunGetRequest(HTTPFileHandle &handle, string url, HTTPHeaders header_map,
 	                                       HTTPFSParams &http_params, const HTTPReadConfig &read_config,
@@ -224,7 +234,7 @@ protected:
 	                                       HTTPSendCallback send_request);
 	unique_ptr<HTTPResponse> RunGetRangeRequest(HTTPFileHandle &handle, string url, HTTPHeaders header_map,
 	                                            HTTPFSParams &http_params, const HTTPReadConfig &read_config,
-	                                            idx_t file_offset, char *buffer_out, idx_t buffer_out_len,
+	                                            idx_t file_offset, data_ptr_t buffer_out, idx_t buffer_out_len,
 	                                            HTTPErrorCallback get_error, HTTPSendCallback send_request);
 
 private:

--- a/src/include/http/httpfs_curl_client.hpp
+++ b/src/include/http/httpfs_curl_client.hpp
@@ -11,6 +11,24 @@ class FileOpener;
 struct FileOpenerInfo;
 class HTTPState;
 
+class CURLURLHandle {
+public:
+	CURLURLHandle();
+	CURLURLHandle(const CURLURLHandle &other);
+	~CURLURLHandle();
+
+	CURLURLHandle &operator=(const CURLURLHandle &) = delete;
+
+	CURLU *Get() {
+		return handle;
+	}
+
+private:
+	explicit CURLURLHandle(CURLU *handle_p);
+
+	CURLU *handle;
+};
+
 class CURLHandle {
 public:
 	CURLHandle(const string &token, const string &cert_path);
@@ -25,7 +43,7 @@ public:
 	}
 
 private:
-	CURL *curl = NULL;
+	CURL *curl = nullptr;
 };
 
 class CURLRequestHeaders {
@@ -52,10 +70,10 @@ public:
 		if (headers) {
 			curl_slist_free_all(headers);
 		}
-		headers = NULL;
+		headers = nullptr;
 	}
 	operator bool() const {
-		return headers != NULL;
+		return headers != nullptr;
 	}
 
 public:
@@ -64,7 +82,7 @@ public:
 	}
 
 public:
-	curl_slist *headers = NULL;
+	curl_slist *headers = nullptr;
 };
 
 } // namespace duckdb

--- a/src/include/s3/s3_multi_part_upload.hpp
+++ b/src/include/s3/s3_multi_part_upload.hpp
@@ -15,7 +15,7 @@ public:
 		uploading = false;
 	}
 
-	void *Ptr() {
+	data_ptr_t Ptr() {
 		return buffer.GetDataMutable();
 	}
 
@@ -64,18 +64,18 @@ public:
 	size_t part_size;
 
 	//! Write buffers for this file
-	mutex write_buffers_lock;
-	unordered_map<uint16_t, shared_ptr<S3WriteBuffer>> write_buffers;
+	annotated_mutex write_buffers_lock;
+	unordered_map<uint16_t, shared_ptr<S3WriteBuffer>> write_buffers DUCKDB_GUARDED_BY(write_buffers_lock);
 
 	//! Synchronization for upload threads
-	mutex uploads_in_progress_lock;
+	annotated_mutex uploads_in_progress_lock;
 	std::condition_variable uploads_in_progress_cv;
 	std::condition_variable final_flush_cv;
-	uint16_t uploads_in_progress;
+	uint16_t uploads_in_progress DUCKDB_GUARDED_BY(uploads_in_progress_lock);
 
 	//! Etags are stored for each part
-	mutex part_etags_lock;
-	unordered_map<uint16_t, string> part_etags;
+	annotated_mutex part_etags_lock;
+	unordered_map<uint16_t, string> part_etags DUCKDB_GUARDED_BY(part_etags_lock);
 
 	//! Info for upload
 	atomic<uint16_t> parts_uploaded;

--- a/src/include/s3/s3_request.hpp
+++ b/src/include/s3/s3_request.hpp
@@ -53,7 +53,7 @@ struct S3RequestUtil {
 	                                string service, string method, const S3AuthParams &auth_params,
 	                                string date_now = "", string datetime_now = "", string payload_hash = "",
 	                                string content_type = "", string content_md5 = "");
-	static string GetPayloadHash(EncryptionUtil &encryption_util, char *buffer, idx_t buffer_len);
+	static string GetPayloadHash(EncryptionUtil &encryption_util, const_data_ptr_t buffer, idx_t buffer_len);
 	static bool IsRequestTimeout(const HTTPResponse &response);
 
 	static optional_idx TryFindTagContents(const string &response, const string &tag, idx_t cur_pos, string &result);

--- a/src/include/s3/s3_settings.hpp
+++ b/src/include/s3/s3_settings.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace duckdb {
+
+class DBConfig;
+
+struct S3Settings {
+	static void Register(DBConfig &config);
+	static void Initialize(DBConfig &config);
+};
+
+} // namespace duckdb

--- a/src/include/s3/s3fs.hpp
+++ b/src/include/s3/s3fs.hpp
@@ -93,11 +93,11 @@ public:
 	unique_ptr<HTTPResponse> GetRequest(FileHandle &handle, string url, HTTPHeaders header_map,
 	                                    const HTTPReadConfig &read_config, CachedFileDownload &download) override;
 	unique_ptr<HTTPResponse> GetRangeRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
-	                                         const HTTPReadConfig &read_config, idx_t file_offset, char *buffer_out,
-	                                         idx_t buffer_out_len) override;
+	                                         const HTTPReadConfig &read_config, idx_t file_offset,
+	                                         data_ptr_t buffer_out, idx_t buffer_out_len) override;
 	unique_ptr<HTTPResponse> PostRequest(HTTPRequestSession &session, string s3_url, string &buffer_out,
-	                                     char *buffer_in, idx_t buffer_in_len, string http_params = "");
-	unique_ptr<HTTPResponse> PutRequest(HTTPRequestSession &session, string s3_url, char *buffer_in,
+	                                     const_data_ptr_t buffer_in, idx_t buffer_in_len, string http_params = "");
+	unique_ptr<HTTPResponse> PutRequest(HTTPRequestSession &session, string s3_url, const_data_ptr_t buffer_in,
 	                                    idx_t buffer_in_len, string http_params = "");
 	unique_ptr<HTTPResponse> DeleteRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map) override;
 	HTTPException GetHTTPError(FileHandle &, const HTTPResponse &response, const string &url) override;

--- a/src/s3/CMakeLists.txt
+++ b/src/s3/CMakeLists.txt
@@ -5,5 +5,6 @@ target_sources(
           s3_list.cpp
           s3_multi_part_upload.cpp
           s3_request.cpp
+          s3_settings.cpp
           s3_url.cpp
           s3fs.cpp)

--- a/src/s3/s3_auth.cpp
+++ b/src/s3/s3_auth.cpp
@@ -7,15 +7,14 @@
 namespace duckdb {
 
 void AWSEnvironmentCredentialsProvider::SetExtensionOptionValue(string key, const char *env_var_name) {
-	char *evar;
-
-	if ((evar = std::getenv(env_var_name)) != NULL) {
-		if (StringUtil::Lower(evar) == "false") {
+	const auto env_value = std::getenv(env_var_name);
+	if (env_value) {
+		if (StringUtil::Lower(env_value) == "false") {
 			this->config.SetOption(key, Value(false));
-		} else if (StringUtil::Lower(evar) == "true") {
+		} else if (StringUtil::Lower(env_value) == "true") {
 			this->config.SetOption(key, Value(true));
 		} else {
-			this->config.SetOption(key, Value(evar));
+			this->config.SetOption(key, Value(env_value));
 		}
 	}
 }

--- a/src/s3/s3_delete.cpp
+++ b/src/s3/s3_delete.cpp
@@ -134,7 +134,7 @@ static void AddDeleteBatchSelectedSecretKeyParts(S3DeleteBatchKeyBuilder &key_bu
 			key_builder.AddString("");
 			continue;
 		}
-		key_builder.AddIndex(static_cast<idx_t>(match.score));
+		key_builder.AddIndex(NumericCast<idx_t>(match.score));
 		AddDeleteBatchSecretKeyParts(key_builder, *match.secret_entry);
 	}
 }
@@ -229,7 +229,7 @@ unique_ptr<HTTPResponse> S3FileSystem::RunS3BulkDeleteRequest(HTTPRequestSession
                                                               const string &secret_lookup_url, const string &body,
                                                               string &result) {
 	auto payload_hash =
-	    S3RequestUtil::GetPayloadHash(GetEncryptionUtil(), const_cast<char *>(body.data()), body.length());
+	    S3RequestUtil::GetPayloadHash(GetEncryptionUtil(), const_data_ptr_cast(body.data()), body.length());
 	auto content_md5 = GetS3DeleteContentMD5(body);
 	return S3RequestExecutor::Run(
 	    secret_lookup_url,
@@ -242,7 +242,7 @@ unique_ptr<HTTPResponse> S3FileSystem::RunS3BulkDeleteRequest(HTTPRequestSession
 		    result.clear();
 		    auto &params = request_data.http_params->Cast<HTTPFSParams>();
 		    return RunPostRequest(request_data.http_url, request_data.headers, params, result,
-		                          const_cast<char *>(body.data()), body.length(), [&](BaseRequest &request) {
+		                          const_data_ptr_cast(body.data()), body.length(), [&](BaseRequest &request) {
 			                          return S3RequestExecutor::SendSessionRequest(session, request_data.captured,
 			                                                                       params, request);
 		                          });

--- a/src/s3/s3_list.cpp
+++ b/src/s3/s3_list.cpp
@@ -57,6 +57,14 @@ protected:
 	bool ExpandNextPath() const override;
 
 private:
+	void ScanCurrentCommonPrefix(vector<OpenFileInfo> &s3_keys) const;
+	void ScanTopLevel(vector<OpenFileInfo> &s3_keys) const;
+	bool ShouldInvestigateRecursiveGlob() const;
+	void SelectGlobType(string &response, string &continuation_token) const;
+	bool ContainsDenseDirectories(const vector<OpenFileInfo> &s3_keys) const;
+	void SelectNextCommonPrefix() const;
+	void AppendMatchingFiles(vector<OpenFileInfo> &s3_keys) const;
+
 	S3FileSystem &fs;
 	string glob_pattern;
 	optional_ptr<FileOpener> opener;
@@ -111,127 +119,109 @@ bool S3GlobResult::ExpandNextPath() const {
 		return false;
 	}
 
-	const vector<string> pattern_splits = StringUtil::Split(parsed_s3_url.key, "/");
-
 	vector<OpenFileInfo> s3_keys;
 	if (!current_common_prefix.empty()) {
-		// we have common prefixes left to scan - perform the request
-		auto prefix_path = parsed_s3_url.prefix + parsed_s3_url.bucket + '/' + current_common_prefix;
-
-		current_common_prefix = S3Url::Decode(current_common_prefix);
-		vector<string> key_splits = StringUtil::Split(current_common_prefix, "/");
-		const bool is_match =
-		    Match(key_splits.begin(), key_splits.end(), pattern_splits.begin(), pattern_splits.end(), false);
-		if (is_match) {
-			prefix_path = S3Url::Decode(prefix_path);
-			auto prefix_res = AWSListObjectV2::Request(fs.GetEncryptionUtil(), *request_session, prefix_path,
-			                                           common_prefix_continuation_token, true);
-
-			AWSListObjectV2::ParseFileList(prefix_res, s3_keys);
-			auto more_prefixes = AWSListObjectV2::ParseCommonPrefix(prefix_res);
-			common_prefixes.insert(common_prefixes.end(), more_prefixes.begin(), more_prefixes.end());
-
-			common_prefix_continuation_token = AWSListObjectV2::ParseContinuationToken(prefix_res);
-		}
-
-		if (common_prefix_continuation_token.empty()) {
-			// we are done with the current common prefix
-			// either move on to the next one, or finish up
-			if (common_prefixes.empty()) {
-				// done - we need to do a top-level request again next
-				current_common_prefix = string();
-			} else {
-				// process the next prefix
-				current_common_prefix = common_prefixes.back();
-				common_prefixes.pop_back();
-			}
-		}
+		ScanCurrentCommonPrefix(s3_keys);
 	} else {
-		if (!common_prefixes.empty()) {
-			throw InternalException("We have common prefixes but we are doing a top-level request");
-		}
-
-		Value value;
-		bool allow_s3_recursive_globbing = true;
-		if (FileOpener::TryGetCurrentSetting(opener, "s3_allow_recursive_globbing", value)) {
-			allow_s3_recursive_globbing = value.GetValue<bool>();
-		}
-
-		const bool investigate_use_recursive_glob = !StringUtil::Contains(parsed_s3_url.key, "**") &&
-		                                            allow_s3_recursive_globbing && glob_type == GlobType::UNKNOWN;
-		// issue the main request
-
-		bool perform_listing = (glob_type != GlobType::HIERARCHICAL);
-
-		// First perform listing once (default will get back up to 1000 elements)
-		string response_str = AWSListObjectV2::Request(fs.GetEncryptionUtil(), *request_session, shared_path,
-		                                               main_continuation_token, !perform_listing);
-
-		string next_continuation_token = AWSListObjectV2::ParseContinuationToken(response_str);
-
-		// If we could have used recursive globbing AND there are more files, check average number of files per folder
-		if (investigate_use_recursive_glob && !next_continuation_token.empty()) {
-			vector<OpenFileInfo> s3_keys_tmp;
-			AWSListObjectV2::ParseFileList(response_str, s3_keys_tmp);
-			idx_t found = 0;
-			unordered_set<string> my_set;
-			for (auto &s3_key : s3_keys_tmp) {
-				vector<string> key_splits = StringUtil::Split(s3_key.path, "/");
-
-				found++;
-				string x = "";
-				key_splits.pop_back();
-				for (string y : key_splits) {
-					x += y + "/";
-				}
-				my_set.insert(x);
-			}
-
-			if (my_set.size() * 100 < found) {
-				// We have at least 100 files per folder, this should make so that hierarchical listing price is
-				// amortized folder of hierarchical glob
-
-				// Start from scratch:
-				// 1. clear keys
-				s3_keys_tmp.clear();
-				// 2. do request again, now passing true
-				response_str = AWSListObjectV2::Request(fs.GetEncryptionUtil(), *request_session, shared_path,
-				                                        main_continuation_token, true);
-
-				// 3. now set next_continuation_token
-				next_continuation_token = AWSListObjectV2::ParseContinuationToken(response_str);
-
-				glob_type = GlobType::HIERARCHICAL;
-			} else {
-				glob_type = GlobType::LISTING;
-			}
-		}
-
-		main_continuation_token = next_continuation_token;
-		AWSListObjectV2::ParseFileList(response_str, s3_keys);
-
-		// parse the list of common prefixes
-		common_prefixes = AWSListObjectV2::ParseCommonPrefix(response_str);
-		if (!common_prefixes.empty()) {
-			// we have common prefixes - set one up for the next request
-			current_common_prefix = common_prefixes.back();
-			common_prefixes.pop_back();
-		}
+		ScanTopLevel(s3_keys);
 	}
 
 	if (main_continuation_token.empty() && current_common_prefix.empty()) {
-		// we are done
 		finished = true;
 	}
+	AppendMatchingFiles(s3_keys);
+	return true;
+}
 
+void S3GlobResult::ScanCurrentCommonPrefix(vector<OpenFileInfo> &s3_keys) const {
+	auto prefix_path = parsed_s3_url.prefix + parsed_s3_url.bucket + '/' + current_common_prefix;
+	current_common_prefix = S3Url::Decode(current_common_prefix);
+	auto key_splits = StringUtil::Split(current_common_prefix, "/");
+	auto pattern_splits = StringUtil::Split(parsed_s3_url.key, "/");
+	if (Match(key_splits.begin(), key_splits.end(), pattern_splits.begin(), pattern_splits.end(), false)) {
+		prefix_path = S3Url::Decode(prefix_path);
+		auto response = AWSListObjectV2::Request(fs.GetEncryptionUtil(), *request_session, prefix_path,
+		                                         common_prefix_continuation_token, true);
+		AWSListObjectV2::ParseFileList(response, s3_keys);
+		auto more_prefixes = AWSListObjectV2::ParseCommonPrefix(response);
+		common_prefixes.insert(common_prefixes.end(), more_prefixes.begin(), more_prefixes.end());
+		common_prefix_continuation_token = AWSListObjectV2::ParseContinuationToken(response);
+	}
+	if (common_prefix_continuation_token.empty()) {
+		SelectNextCommonPrefix();
+	}
+}
+
+void S3GlobResult::ScanTopLevel(vector<OpenFileInfo> &s3_keys) const {
+	if (!common_prefixes.empty()) {
+		throw InternalException("We have common prefixes but we are doing a top-level request");
+	}
+	const bool hierarchical = glob_type == GlobType::HIERARCHICAL;
+	auto response = AWSListObjectV2::Request(fs.GetEncryptionUtil(), *request_session, shared_path,
+	                                         main_continuation_token, hierarchical);
+	auto continuation_token = AWSListObjectV2::ParseContinuationToken(response);
+	if (ShouldInvestigateRecursiveGlob() && !continuation_token.empty()) {
+		SelectGlobType(response, continuation_token);
+	}
+	main_continuation_token = continuation_token;
+	AWSListObjectV2::ParseFileList(response, s3_keys);
+	common_prefixes = AWSListObjectV2::ParseCommonPrefix(response);
+	SelectNextCommonPrefix();
+}
+
+bool S3GlobResult::ShouldInvestigateRecursiveGlob() const {
+	if (glob_type != GlobType::UNKNOWN || StringUtil::Contains(parsed_s3_url.key, "**")) {
+		return false;
+	}
+	Value value;
+	if (!FileOpener::TryGetCurrentSetting(opener, "s3_allow_recursive_globbing", value)) {
+		return true;
+	}
+	return value.GetValue<bool>();
+}
+
+void S3GlobResult::SelectGlobType(string &response, string &continuation_token) const {
+	vector<OpenFileInfo> s3_keys;
+	AWSListObjectV2::ParseFileList(response, s3_keys);
+	if (!ContainsDenseDirectories(s3_keys)) {
+		glob_type = GlobType::LISTING;
+		return;
+	}
+	response =
+	    AWSListObjectV2::Request(fs.GetEncryptionUtil(), *request_session, shared_path, main_continuation_token, true);
+	continuation_token = AWSListObjectV2::ParseContinuationToken(response);
+	glob_type = GlobType::HIERARCHICAL;
+}
+
+bool S3GlobResult::ContainsDenseDirectories(const vector<OpenFileInfo> &s3_keys) const {
+	unordered_set<string> directories;
+	for (const auto &s3_key : s3_keys) {
+		auto key_splits = StringUtil::Split(s3_key.path, "/");
+		key_splits.pop_back();
+		string directory;
+		for (const auto &split : key_splits) {
+			directory += split + "/";
+		}
+		directories.insert(std::move(directory));
+	}
+	return directories.size() * 100 < s3_keys.size();
+}
+
+void S3GlobResult::SelectNextCommonPrefix() const {
+	if (common_prefixes.empty()) {
+		current_common_prefix.clear();
+		return;
+	}
+	current_common_prefix = common_prefixes.back();
+	common_prefixes.pop_back();
+}
+
+void S3GlobResult::AppendMatchingFiles(vector<OpenFileInfo> &s3_keys) const {
+	auto pattern_splits = StringUtil::Split(parsed_s3_url.key, "/");
 	for (auto &s3_key : s3_keys) {
-
-		vector<string> key_splits = StringUtil::Split(s3_key.path, "/");
-		bool is_match = Match(key_splits.begin(), key_splits.end(), pattern_splits.begin(), pattern_splits.end(), true);
-
-		if (is_match) {
+		auto key_splits = StringUtil::Split(s3_key.path, "/");
+		if (Match(key_splits.begin(), key_splits.end(), pattern_splits.begin(), pattern_splits.end(), true)) {
 			auto result_full_url = parsed_s3_url.prefix + parsed_s3_url.bucket + "/" + s3_key.path;
-			// if a ? char was present, we re-add it here as the url parsing will have trimmed it.
 			if (!parsed_s3_url.query_param.empty()) {
 				result_full_url += '?' + parsed_s3_url.query_param;
 			}
@@ -244,7 +234,6 @@ bool S3GlobResult::ExpandNextPath() const {
 			expanded_files.push_back(std::move(s3_key));
 		}
 	}
-	return true;
 }
 
 unique_ptr<MultiFileList> S3FileSystem::GlobFilesExtended(const string &path, const FileGlobInput &input,
@@ -277,36 +266,14 @@ bool S3FileSystem::ListFilesExtended(const string &directory, const std::functio
 	return true;
 }
 
-// Tolerant variant for error bodies: a truncated/malformed body must not escalate to a DB-invalidating
-// InternalException, so an unmatched open tag is "not found".
-
-string AWSListObjectV2::Request(EncryptionUtil &encryption_util, HTTPRequestSession &session, const string &path,
-                                const string &continuation_token, bool use_delimiter, optional_idx max_keys) {
-	auto create_request_data = [&]() {
+struct S3ListRequest {
+	static S3RequestData Create(EncryptionUtil &encryption_util, HTTPRequestSession &session, const string &path,
+	                            const string &continuation_token, bool use_delimiter, optional_idx max_keys) {
 		auto captured = session.Capture();
 		auto &snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
 		auto auth_params = snapshot.auth_params;
 		auto parsed_url = S3Url::Parse(path, auth_params);
-
-		map<string, string> request_params;
-		if (!continuation_token.empty()) {
-			request_params["continuation-token"] = S3Url::Encode(continuation_token, true);
-		}
-		if (use_delimiter) {
-			request_params["delimiter"] = "%2F";
-		}
-		request_params["encoding-type"] = "url";
-		request_params["list-type"] = "2";
-		if (max_keys.IsValid()) {
-			request_params["max-keys"] = to_string(max_keys.GetIndex());
-		}
-		request_params["prefix"] = S3Url::Encode(parsed_url.key, true);
-
-		string encoded_params;
-		for (const auto &param : request_params) {
-			encoded_params += param.first + "=" + param.second + "&";
-		}
-		encoded_params.pop_back();
+		auto encoded_params = BuildParameters(parsed_url, continuation_token, use_delimiter, max_keys);
 
 		S3RequestData result;
 		result.captured = captured;
@@ -324,10 +291,56 @@ string AWSListObjectV2::Request(EncryptionUtil &encryption_util, HTTPRequestSess
 		}
 		snapshot.AddConfiguredHeaders(result.headers);
 		return result;
-	};
+	}
 
+	static string Finish(HTTPRequestSession &session, const string &path, unique_ptr<HTTPResponse> response) {
+		if (response->HasRequestError()) {
+			throw IOException("%s error for HTTP GET to '%s'", response->GetRequestError(), path);
+		}
+		if (static_cast<int>(response->status) >= 400) {
+			auto captured = session.Capture();
+			auto &snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
+			auto trimmed_path = path;
+			StringUtil::RTrim(trimmed_path, "/");
+			throw S3RequestUtil::GetError(snapshot.auth_params, *response, trimmed_path);
+		}
+		return std::move(response->body);
+	}
+
+private:
+	static string BuildParameters(const ParsedS3Url &parsed_url, const string &continuation_token, bool use_delimiter,
+	                              optional_idx max_keys) {
+		map<string, string> request_params;
+		if (!continuation_token.empty()) {
+			request_params["continuation-token"] = S3Url::Encode(continuation_token, true);
+		}
+		if (use_delimiter) {
+			request_params["delimiter"] = "%2F";
+		}
+		request_params["encoding-type"] = "url";
+		request_params["list-type"] = "2";
+		if (max_keys.IsValid()) {
+			request_params["max-keys"] = to_string(max_keys.GetIndex());
+		}
+		request_params["prefix"] = S3Url::Encode(parsed_url.key, true);
+
+		string result;
+		for (const auto &param : request_params) {
+			result += param.first + "=" + param.second + "&";
+		}
+		result.pop_back();
+		return result;
+	}
+};
+
+string AWSListObjectV2::Request(EncryptionUtil &encryption_util, HTTPRequestSession &session, const string &path,
+                                const string &continuation_token, bool use_delimiter, optional_idx max_keys) {
 	auto response = S3RequestExecutor::Run(
-	    path, create_request_data, true,
+	    path,
+	    [&]() {
+		    return S3ListRequest::Create(encryption_util, session, path, continuation_token, use_delimiter, max_keys);
+	    },
+	    true,
 	    [&](S3RequestData &request_data) {
 		    auto &params = request_data.http_params->Cast<HTTPFSParams>();
 		    GetRequestInfo get_request(request_data.http_url, request_data.headers, params, nullptr, nullptr);
@@ -345,17 +358,7 @@ string AWSListObjectV2::Request(EncryptionUtil &encryption_util, HTTPRequestSess
 			        path, previous_region, correct_region);
 		    }
 	    });
-	if (response->HasRequestError()) {
-		throw IOException("%s error for HTTP GET to '%s'", response->GetRequestError(), path);
-	}
-	if (static_cast<int>(response->status) >= 400) {
-		auto captured = session.Capture();
-		auto &snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
-		string trimmed_path = path;
-		StringUtil::RTrim(trimmed_path, "/");
-		throw S3RequestUtil::GetError(snapshot.auth_params, *response, trimmed_path);
-	}
-	return std::move(response->body);
+	return S3ListRequest::Finish(session, path, std::move(response));
 }
 
 void AWSListObjectV2::ParseFileList(string &aws_response, vector<OpenFileInfo> &result) {

--- a/src/s3/s3_multi_part_upload.cpp
+++ b/src/s3/s3_multi_part_upload.cpp
@@ -28,7 +28,7 @@ void S3MultiPartUpload::Finalize() {
 shared_ptr<S3WriteBuffer> S3MultiPartUpload::GetBuffer(uint16_t write_buffer_idx) {
 	// Check if write buffer already exists
 	{
-		unique_lock<mutex> lck(write_buffers_lock);
+		annotated_lock_guard<annotated_mutex> lck(write_buffers_lock);
 		auto lookup_result = write_buffers.find(write_buffer_idx);
 		if (lookup_result != write_buffers.end()) {
 			shared_ptr<S3WriteBuffer> buffer = lookup_result->second;
@@ -40,7 +40,7 @@ shared_ptr<S3WriteBuffer> S3MultiPartUpload::GetBuffer(uint16_t write_buffer_idx
 	auto new_write_buffer =
 	    make_shared_ptr<S3WriteBuffer>(write_buffer_idx * part_size, part_size, std::move(buffer_handle));
 	{
-		unique_lock<mutex> lck(write_buffers_lock);
+		annotated_lock_guard<annotated_mutex> lck(write_buffers_lock);
 		auto lookup_result = write_buffers.find(write_buffer_idx);
 
 		// Check if other thread has created the same buffer, if so we return theirs and drop ours.
@@ -92,12 +92,15 @@ void S3MultiPartUpload::FinalizeMultipartUpload() {
 	ss << "<CompleteMultipartUpload xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">";
 
 	auto parts = parts_uploaded.load();
-	for (auto i = 0; i < parts; i++) {
-		auto etag_lookup = part_etags.find(i);
-		if (etag_lookup == part_etags.end()) {
-			throw IOException("Unknown part number");
+	{
+		annotated_lock_guard<annotated_mutex> part_etags_guard(part_etags_lock);
+		for (auto i = 0; i < parts; i++) {
+			auto etag_lookup = part_etags.find(i);
+			if (etag_lookup == part_etags.end()) {
+				throw IOException("Unknown part number");
+			}
+			ss << "<Part><ETag>" << etag_lookup->second << "</ETag><PartNumber>" << i + 1 << "</PartNumber></Part>";
 		}
-		ss << "<Part><ETag>" << etag_lookup->second << "</ETag><PartNumber>" << i + 1 << "</PartNumber></Part>";
 	}
 	ss << "</CompleteMultipartUpload>";
 	string body = ss.str();
@@ -106,7 +109,8 @@ void S3MultiPartUpload::FinalizeMultipartUpload() {
 	string result;
 
 	string query_param = "uploadId=" + S3Url::Encode(multipart_upload_id, true);
-	auto res = s3fs.PostRequest(*request_session, path, result, (char *)body.c_str(), body.length(), query_param);
+	auto res =
+	    s3fs.PostRequest(*request_session, path, result, const_data_ptr_cast(body.data()), body.length(), query_param);
 	auto open_tag_pos = result.find("<CompleteMultipartUploadResult", 0);
 	if (open_tag_pos == string::npos) {
 		throw HTTPException(*res, "Unexpected response during S3 multipart upload finalization: %d\n\n%s",
@@ -134,7 +138,7 @@ void S3MultiPartUpload::UploadBufferImplementation(shared_ptr<S3WriteBuffer> wri
 
 	try {
 		// Transient S3 errors are retried inside PutRequest; a non-OK status here is already final.
-		res = s3fs.PutRequest(*request_session, path, (char *)write_buffer->Ptr(), write_buffer->idx, query_param);
+		res = s3fs.PutRequest(*request_session, path, write_buffer->Ptr(), write_buffer->idx, query_param);
 
 		if (res->status != HTTPStatusCode::OK_200) {
 			throw HTTPException(*res, "Unable to connect to URL %s: %s (HTTP code %d)%s", path, res->GetError(),
@@ -161,8 +165,8 @@ void S3MultiPartUpload::UploadBufferImplementation(shared_ptr<S3WriteBuffer> wri
 
 	// Insert etag
 	{
-		unique_lock<mutex> lck(part_etags_lock);
-		part_etags.insert(std::pair<uint16_t, string>(write_buffer->part_no, etag));
+		annotated_lock_guard<annotated_mutex> lck(part_etags_lock);
+		part_etags.insert(std::pair<uint16_t, string>(NumericCast<uint16_t>(write_buffer->part_no), etag));
 	}
 
 	parts_uploaded++;
@@ -173,7 +177,7 @@ void S3MultiPartUpload::UploadBufferImplementation(shared_ptr<S3WriteBuffer> wri
 
 void S3MultiPartUpload::NotifyUploadsInProgress() {
 	{
-		unique_lock<mutex> lck(uploads_in_progress_lock);
+		annotated_lock_guard<annotated_mutex> lck(uploads_in_progress_lock);
 		if (uploads_in_progress == 0) {
 			throw InternalException(
 			    "S3MultiPartUpload: uploads_in_progress decremented but no uploads are supposed to be active");
@@ -205,17 +209,19 @@ void S3MultiPartUpload::FlushBuffer(shared_ptr<S3WriteBuffer> write_buffer) {
 	RethrowIOError();
 
 	{
-		unique_lock<mutex> lck(write_buffers_lock);
+		annotated_lock_guard<annotated_mutex> lck(write_buffers_lock);
 		write_buffers.erase(write_buffer->part_no);
 	}
 
 	{
-		unique_lock<mutex> lck(uploads_in_progress_lock);
+		annotated_unique_lock<annotated_mutex> lck(uploads_in_progress_lock);
 		// check if there are upload threads available
 #ifndef SAME_THREAD_UPLOAD
 		if (uploads_in_progress >= config_params.max_upload_threads) {
 			// there are not - wait for one to become available
-			uploads_in_progress_cv.wait(lck, [&] { return uploads_in_progress < config_params.max_upload_threads; });
+			uploads_in_progress_cv.wait(lck, [&]() DUCKDB_REQUIRES(uploads_in_progress_lock) {
+				return uploads_in_progress < config_params.max_upload_threads;
+			});
 		}
 #endif
 		uploads_in_progress++;
@@ -239,11 +245,12 @@ void S3MultiPartUpload::FlushBuffer(shared_ptr<S3WriteBuffer> write_buffer) {
 void S3MultiPartUpload::FlushAllBuffers() {
 	//  Collect references to all buffers to check
 	vector<shared_ptr<S3WriteBuffer>> to_flush;
-	write_buffers_lock.lock();
-	for (auto &item : write_buffers) {
-		to_flush.push_back(item.second);
+	{
+		annotated_lock_guard<annotated_mutex> lck(write_buffers_lock);
+		for (auto &item : write_buffers) {
+			to_flush.push_back(item.second);
+		}
 	}
-	write_buffers_lock.unlock();
 
 	if (!initialized_multipart_upload) {
 		// TODO (carlo): unclear how to handle kms_key_id, but given currently they are custom, leave the multiupload
@@ -264,9 +271,9 @@ void S3MultiPartUpload::FlushAllBuffers() {
 			FlushBuffer(write_buffer);
 		}
 	}
-	unique_lock<mutex> lck(uploads_in_progress_lock);
+	annotated_unique_lock<annotated_mutex> lck(uploads_in_progress_lock);
 #ifndef SAME_THREAD_UPLOAD
-	final_flush_cv.wait(lck, [&] { return uploads_in_progress == 0; });
+	final_flush_cv.wait(lck, [&]() DUCKDB_REQUIRES(uploads_in_progress_lock) { return uploads_in_progress == 0; });
 #endif
 
 	RethrowIOError();

--- a/src/s3/s3_request.cpp
+++ b/src/s3/s3_request.cpp
@@ -18,114 +18,161 @@
 
 namespace duckdb {
 
+struct S3HeaderBuilder {
+	S3HeaderBuilder(EncryptionUtil &encryption_util_p, string url_p, string query_p, string host_p, string service_p,
+	                string method_p, const S3AuthParams &auth_params_p, string date_now_p, string datetime_now_p,
+	                string payload_hash_p, string content_type_p, string content_md5_p)
+	    : encryption_util(encryption_util_p), url(std::move(url_p)), query(std::move(query_p)), host(std::move(host_p)),
+	      service(std::move(service_p)), method(std::move(method_p)), auth_params(auth_params_p),
+	      date_now(std::move(date_now_p)), datetime_now(std::move(datetime_now_p)),
+	      payload_hash(std::move(payload_hash_p)), content_type(std::move(content_type_p)),
+	      content_md5(std::move(content_md5_p)),
+	      use_sse_kms(!auth_params.kms_key_id.empty() && (method == "POST" || method == "PUT") &&
+	                  query.find("uploadId") == string::npos) {
+	}
+
+	HTTPHeaders Create() {
+		headers["Host"] = host;
+		if (auth_params.secret_access_key.empty() && auth_params.access_key_id.empty()) {
+			return headers;
+		}
+
+		InitializeDefaults();
+		AddRequestHeaders();
+		auto signed_headers = BuildSignedHeaders();
+		auto canonical_request = BuildCanonicalRequest(signed_headers);
+		auto signature = CreateSignature(canonical_request);
+		headers["Authorization"] = "AWS4-HMAC-SHA256 Credential=" + auth_params.access_key_id + "/" +
+		                           CredentialScope() + ", SignedHeaders=" + signed_headers + ", Signature=" + signature;
+		return headers;
+	}
+
+private:
+	void InitializeDefaults() {
+		if (payload_hash.empty()) {
+			payload_hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+		}
+		if (datetime_now.empty()) {
+			auto timestamp = Timestamp::GetCurrentTimestamp();
+			date_now = StrfTimeFormat::Format(timestamp, "%Y%m%d");
+			datetime_now = StrfTimeFormat::Format(timestamp, "%Y%m%dT%H%M%SZ");
+		}
+	}
+
+	void AddRequestHeaders() {
+		headers["x-amz-date"] = datetime_now;
+		headers["x-amz-content-sha256"] = payload_hash;
+		if (!auth_params.session_token.empty()) {
+			headers["x-amz-security-token"] = auth_params.session_token;
+		}
+		if (use_sse_kms) {
+			headers["x-amz-server-side-encryption"] = "aws:kms";
+			headers["x-amz-server-side-encryption-aws-kms-key-id"] = auth_params.kms_key_id;
+		}
+		if (auth_params.requester_pays) {
+			headers["x-amz-request-payer"] = "requester";
+		}
+		if (!content_md5.empty()) {
+			headers["content-md5"] = content_md5;
+		}
+		if (!content_type.empty() && content_type != "application/octet-stream") {
+			headers["content-type"] = content_type;
+		}
+	}
+
+	string BuildSignedHeaders() const {
+		string result;
+		if (!content_md5.empty()) {
+			result += "content-md5;";
+		}
+		if (!content_type.empty()) {
+			result += "content-type;";
+		}
+		result += "host;x-amz-content-sha256;x-amz-date";
+		if (auth_params.requester_pays) {
+			result += ";x-amz-request-payer";
+		}
+		if (!auth_params.session_token.empty()) {
+			result += ";x-amz-security-token";
+		}
+		if (use_sse_kms) {
+			result += ";x-amz-server-side-encryption;x-amz-server-side-encryption-aws-kms-key-id";
+		}
+		return result;
+	}
+
+	string BuildCanonicalRequest(const string &signed_headers) const {
+		auto result = method + "\n" + S3Url::Encode(url) + "\n" + query;
+		if (!content_md5.empty()) {
+			result += "\ncontent-md5:" + content_md5;
+		}
+		if (!content_type.empty()) {
+			result += "\ncontent-type:" + content_type;
+		}
+		result += "\nhost:" + host + "\nx-amz-content-sha256:" + payload_hash + "\nx-amz-date:" + datetime_now;
+		if (auth_params.requester_pays) {
+			result += "\nx-amz-request-payer:requester";
+		}
+		if (!auth_params.session_token.empty()) {
+			result += "\nx-amz-security-token:" + auth_params.session_token;
+		}
+		if (use_sse_kms) {
+			result += "\nx-amz-server-side-encryption:aws:kms";
+			result += "\nx-amz-server-side-encryption-aws-kms-key-id:" + auth_params.kms_key_id;
+		}
+		return result + "\n\n" + signed_headers + "\n" + payload_hash;
+	}
+
+	string CreateSignature(const string &canonical_request) const {
+		hash_bytes canonical_request_hash;
+		hash_str canonical_request_hash_str;
+		sha256(encryption_util, const_data_ptr_cast(canonical_request.data()), canonical_request.length(),
+		       canonical_request_hash);
+		hex256(canonical_request_hash, canonical_request_hash_str);
+
+		auto string_to_sign = "AWS4-HMAC-SHA256\n" + datetime_now + "\n" + CredentialScope() + "\n" +
+		                      string(const_char_ptr_cast(canonical_request_hash_str), sizeof(hash_str));
+		hash_bytes k_date, k_region, k_service, signing_key, signature;
+		auto sign_key = "AWS4" + auth_params.secret_access_key;
+		hmac256(encryption_util, date_now, const_data_ptr_cast(sign_key.data()), sign_key.length(), k_date);
+		hmac256(encryption_util, auth_params.region, k_date, k_region);
+		hmac256(encryption_util, service, k_region, k_service);
+		hmac256(encryption_util, "aws4_request", k_service, signing_key);
+		hmac256(encryption_util, string_to_sign, signing_key, signature);
+
+		hash_str signature_str;
+		hex256(signature, signature_str);
+		return string(const_char_ptr_cast(signature_str), sizeof(hash_str));
+	}
+
+	string CredentialScope() const {
+		return date_now + "/" + auth_params.region + "/" + service + "/aws4_request";
+	}
+
+	EncryptionUtil &encryption_util;
+	const string url;
+	const string query;
+	const string host;
+	const string service;
+	const string method;
+	const S3AuthParams &auth_params;
+	string date_now;
+	string datetime_now;
+	string payload_hash;
+	const string content_type;
+	const string content_md5;
+	const bool use_sse_kms;
+	HTTPHeaders headers;
+};
+
 HTTPHeaders S3RequestUtil::CreateHeader(EncryptionUtil &encryption_util, string url, string query, string host,
                                         string service, string method, const S3AuthParams &auth_params, string date_now,
                                         string datetime_now, string payload_hash, string content_type,
                                         string content_md5) {
-
-	HTTPHeaders res;
-	res["Host"] = host;
-	// If access key is not set, we don't set the headers at all to allow accessing public files through s3 urls
-	if (auth_params.secret_access_key.empty() && auth_params.access_key_id.empty()) {
-		return res;
-	}
-
-	if (payload_hash == "") {
-		payload_hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"; // Empty payload hash
-	}
-
-	// we can pass date/time but this is mostly useful in testing. normally we just get the current datetime here.
-	if (datetime_now.empty()) {
-		auto timestamp = Timestamp::GetCurrentTimestamp();
-		date_now = StrfTimeFormat::Format(timestamp, "%Y%m%d");
-		datetime_now = StrfTimeFormat::Format(timestamp, "%Y%m%dT%H%M%SZ");
-	}
-
-	// Only some S3 operations supports SSE-KMS, which this "heuristic" attempts to detect.
-	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/specifying-kms-encryption.html#sse-request-headers-kms
-	bool use_sse_kms = auth_params.kms_key_id.length() > 0 && (method == "POST" || method == "PUT") &&
-	                   query.find("uploadId") == std::string::npos;
-
-	res["x-amz-date"] = datetime_now;
-	res["x-amz-content-sha256"] = payload_hash;
-	if (auth_params.session_token.length() > 0) {
-		res["x-amz-security-token"] = auth_params.session_token;
-	}
-	if (use_sse_kms) {
-		res["x-amz-server-side-encryption"] = "aws:kms";
-		res["x-amz-server-side-encryption-aws-kms-key-id"] = auth_params.kms_key_id;
-	}
-
-	bool use_requester_pays = auth_params.requester_pays;
-	if (use_requester_pays) {
-		res["x-amz-request-payer"] = "requester";
-	}
-
-	string signed_headers = "";
-	hash_bytes canonical_request_hash;
-	hash_str canonical_request_hash_str;
-	if (content_md5.length() > 0) {
-		signed_headers += "content-md5;";
-		res["content-md5"] = content_md5;
-	}
-	if (content_type.length() > 0) {
-		signed_headers += "content-type;";
-		if (content_type != "application/octet-stream") {
-			res["content-type"] = content_type;
-		}
-	}
-	signed_headers += "host;x-amz-content-sha256;x-amz-date";
-	if (use_requester_pays) {
-		signed_headers += ";x-amz-request-payer";
-	}
-	if (auth_params.session_token.length() > 0) {
-		signed_headers += ";x-amz-security-token";
-	}
-	if (use_sse_kms) {
-		signed_headers += ";x-amz-server-side-encryption;x-amz-server-side-encryption-aws-kms-key-id";
-	}
-	auto canonical_request = method + "\n" + S3Url::Encode(url) + "\n" + query;
-	if (content_md5.length() > 0) {
-		canonical_request += "\ncontent-md5:" + content_md5;
-	}
-	if (content_type.length() > 0) {
-		canonical_request += "\ncontent-type:" + content_type;
-	}
-	canonical_request += "\nhost:" + host + "\nx-amz-content-sha256:" + payload_hash + "\nx-amz-date:" + datetime_now;
-	if (use_requester_pays) {
-		canonical_request += "\nx-amz-request-payer:requester";
-	}
-	if (auth_params.session_token.length() > 0) {
-		canonical_request += "\nx-amz-security-token:" + auth_params.session_token;
-	}
-	if (use_sse_kms) {
-		canonical_request += "\nx-amz-server-side-encryption:aws:kms";
-		canonical_request += "\nx-amz-server-side-encryption-aws-kms-key-id:" + auth_params.kms_key_id;
-	}
-
-	canonical_request += "\n\n" + signed_headers + "\n" + payload_hash;
-
-	sha256(encryption_util, canonical_request.c_str(), canonical_request.length(), canonical_request_hash);
-
-	hex256(canonical_request_hash, canonical_request_hash_str);
-	auto string_to_sign = "AWS4-HMAC-SHA256\n" + datetime_now + "\n" + date_now + "/" + auth_params.region + "/" +
-	                      service + "/aws4_request\n" + string((char *)canonical_request_hash_str, sizeof(hash_str));
-	// compute signature
-	hash_bytes k_date, k_region, k_service, signing_key, signature;
-	hash_str signature_str;
-	auto sign_key = "AWS4" + auth_params.secret_access_key;
-	hmac256(encryption_util, date_now, sign_key.c_str(), sign_key.length(), k_date);
-	hmac256(encryption_util, auth_params.region, k_date, k_region);
-	hmac256(encryption_util, service, k_region, k_service);
-	hmac256(encryption_util, "aws4_request", k_service, signing_key);
-	hmac256(encryption_util, string_to_sign, signing_key, signature);
-	hex256(signature, signature_str);
-
-	res["Authorization"] = "AWS4-HMAC-SHA256 Credential=" + auth_params.access_key_id + "/" + date_now + "/" +
-	                       auth_params.region + "/" + service + "/aws4_request, SignedHeaders=" + signed_headers +
-	                       ", Signature=" + string((char *)signature_str, sizeof(hash_str));
-
-	return res;
+	return S3HeaderBuilder(encryption_util, std::move(url), std::move(query), std::move(host), std::move(service),
+	                       std::move(method), auth_params, std::move(date_now), std::move(datetime_now),
+	                       std::move(payload_hash), std::move(content_type), std::move(content_md5))
+	    .Create();
 }
 
 static bool IsAuthRefreshErrorBody(const string &body) {
@@ -463,7 +510,7 @@ bool S3RequestExecutor::TryRefreshSession(HTTPRequestSession &session, const S3R
 	ClientContextFileOpener opener(*context);
 	auto refreshed_auth_params = current_snapshot.auth_params;
 	auto refreshed_http_params = current_snapshot.CreateRequestParams();
-	if (!TryRefreshS3AuthMaterial(context.get(), opener, current_snapshot.refresh_path, refreshed_auth_params,
+	if (!TryRefreshS3AuthMaterial(context, opener, current_snapshot.refresh_path, refreshed_auth_params,
 	                              *refreshed_http_params, current_snapshot.credential_refresh_enabled,
 	                              current_snapshot.region_redirected)) {
 		return session.Capture().snapshot->Cast<S3RequestSnapshot>().credential_generation !=
@@ -618,20 +665,21 @@ S3RequestSnapshot::S3RequestSnapshot(const HTTPFSParams &http_params, const S3Au
       region_redirected(region_redirected_p), credential_generation(credential_generation_p) {
 }
 
-string S3RequestUtil::GetPayloadHash(EncryptionUtil &encryption_util, char *buffer, idx_t buffer_len) {
+string S3RequestUtil::GetPayloadHash(EncryptionUtil &encryption_util, const_data_ptr_t buffer, idx_t buffer_len) {
 	if (buffer_len > 0) {
 		hash_bytes payload_hash_bytes;
 		hash_str payload_hash_str;
 		sha256(encryption_util, buffer, buffer_len, payload_hash_bytes);
 		hex256(payload_hash_bytes, payload_hash_str);
-		return string((char *)payload_hash_str, sizeof(payload_hash_str));
+		return string(const_char_ptr_cast(payload_hash_str), sizeof(payload_hash_str));
 	} else {
 		return "";
 	}
 }
 
 unique_ptr<HTTPResponse> S3FileSystem::PostRequest(HTTPRequestSession &session, string url, string &result,
-                                                   char *buffer_in, idx_t buffer_in_len, string http_params) {
+                                                   const_data_ptr_t buffer_in, idx_t buffer_in_len,
+                                                   string http_params) {
 	auto payload_hash = S3RequestUtil::GetPayloadHash(GetEncryptionUtil(), buffer_in, buffer_in_len);
 	const string content_type = "application/octet-stream";
 	return S3RequestExecutor::RunSession(
@@ -647,7 +695,7 @@ unique_ptr<HTTPResponse> S3FileSystem::PostRequest(HTTPRequestSession &session, 
 	    });
 }
 
-unique_ptr<HTTPResponse> S3FileSystem::PutRequest(HTTPRequestSession &session, string url, char *buffer_in,
+unique_ptr<HTTPResponse> S3FileSystem::PutRequest(HTTPRequestSession &session, string url, const_data_ptr_t buffer_in,
                                                   idx_t buffer_in_len, string http_params) {
 	auto payload_hash = S3RequestUtil::GetPayloadHash(GetEncryptionUtil(), buffer_in, buffer_in_len);
 	const string content_type = "application/octet-stream";
@@ -693,7 +741,7 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_
 
 unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
                                                        const HTTPReadConfig &read_config, idx_t file_offset,
-                                                       char *buffer_out, idx_t buffer_out_len) {
+                                                       data_ptr_t buffer_out, idx_t buffer_out_len) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
 	const auto version_id =
 	    read_config.condition.type == HTTPReadConditionType::S3_VERSION_ID ? read_config.condition.value : string();

--- a/src/s3/s3_settings.cpp
+++ b/src/s3/s3_settings.cpp
@@ -1,0 +1,46 @@
+#include "s3/s3_settings.hpp"
+
+#include "s3/s3_auth.hpp"
+#include "duckdb/main/config.hpp"
+
+namespace duckdb {
+
+void S3Settings::Register(DBConfig &config) {
+	config.AddExtensionOption("s3_region", "S3 Region", LogicalType::VARCHAR);
+	config.AddExtensionOption("s3_access_key_id", "S3 Access Key ID", LogicalType::VARCHAR);
+	config.AddExtensionOption("s3_secret_access_key", "S3 Access Key", LogicalType::VARCHAR);
+	config.AddExtensionOption("s3_session_token", "S3 Session Token", LogicalType::VARCHAR);
+	config.AddExtensionOption("s3_endpoint", "S3 Endpoint", LogicalType::VARCHAR);
+	config.AddExtensionOption("s3_url_style", "S3 URL style", LogicalType::VARCHAR, Value("vhost"));
+	config.AddExtensionOption("s3_use_ssl", "S3 use SSL", LogicalType::BOOLEAN, Value(true));
+	config.AddExtensionOption("s3_kms_key_id", "S3 KMS Key ID", LogicalType::VARCHAR);
+	config.AddExtensionOption("s3_url_compatibility_mode", "Disable Globs and Query Parameters on S3 URLs",
+	                          LogicalType::BOOLEAN, Value(false));
+	config.AddExtensionOption("s3_requester_pays", "S3 use requester pays mode", LogicalType::BOOLEAN, Value(false));
+	config.AddExtensionOption(
+	    "s3_allow_recursive_globbing",
+	    "Whether globs on S3-like storage are optimized with recursive strategy (alternative is listing)",
+	    LogicalType::BOOLEAN, Value(true));
+	config.AddExtensionOption("s3_uploader_max_filesize", "S3 Uploader max filesize (between 50GB and 5TB)",
+	                          LogicalType::VARCHAR, "800GB");
+	config.AddExtensionOption("s3_uploader_max_parts_per_file", "S3 Uploader max parts per file (between 1 and 10000)",
+	                          LogicalType::UBIGINT, Value::UBIGINT(10000));
+	config.AddExtensionOption("s3_uploader_thread_limit", "S3 Uploader global thread limit", LogicalType::UBIGINT,
+	                          Value::UBIGINT(50));
+	config.AddExtensionOption("s3_version_id_pinning", "Pin S3 reads to a specific object version for consistency",
+	                          LogicalType::BOOLEAN, Value(false));
+	config.AddExtensionOption("merge_http_secret_into_s3_request", "Merges HTTP secret parameters into S3 requests",
+	                          LogicalType::BOOLEAN, Value(true));
+	config.AddExtensionOption("httpfs_enable_credential_refresh", "Enable credential refresh for HTTPFS S3 secrets",
+	                          LogicalType::BOOLEAN, Value(true));
+	config.AddExtensionOption("enable_global_s3_configuration",
+	                          "Automatically fetch AWS credentials from environment variables.", LogicalType::BOOLEAN,
+	                          Value::BOOLEAN(true));
+}
+
+void S3Settings::Initialize(DBConfig &config) {
+	auto provider = make_uniq<AWSEnvironmentCredentialsProvider>(config);
+	provider->SetAll();
+}
+
+} // namespace duckdb

--- a/src/s3/s3fs.cpp
+++ b/src/s3/s3fs.cpp
@@ -223,7 +223,7 @@ void S3FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx
 		// Writing to buffer
 		auto idx_to_write = curr_location - write_buffer->buffer_start;
 		auto bytes_to_write = MinValue<idx_t>(nr_bytes - bytes_written, part_size - idx_to_write);
-		memcpy((char *)write_buffer->Ptr() + idx_to_write, (char *)buffer + bytes_written, bytes_to_write);
+		memcpy(write_buffer->Ptr() + idx_to_write, data_ptr_cast(buffer) + bytes_written, bytes_to_write);
 		write_buffer->idx += bytes_to_write;
 
 		// Flush to HTTP if full

--- a/test/sql/httpfs/ca_cert_file.test
+++ b/test/sql/httpfs/ca_cert_file.test
@@ -15,7 +15,7 @@ SET enable_server_cert_verification = true;
 statement error
 SET ca_cert_file = NULL;
 ----
-Invalid Input Error: NULL it's not a valid option for ca_cert_file
+Invalid Input Error: NULL is not a valid option for ca_cert_file
 
 statement ok
 SET ca_cert_file = 'README.md';

--- a/test/unittest/http/CMakeLists.txt
+++ b/test/unittest/http/CMakeLists.txt
@@ -1,5 +1,9 @@
 target_sources(
   unittest_httpfs
-  PRIVATE connection_reuse_test.cpp http_request_session_test.cpp
-          http_test_helper.cpp positional_read_test.cpp range_read_test.cpp
+  PRIVATE connection_reuse_test.cpp
+          hffs_test.cpp
+          http_request_session_test.cpp
+          http_test_helper.cpp
+          positional_read_test.cpp
+          range_read_test.cpp
           sequential_read_test.cpp)

--- a/test/unittest/http/hffs_test.cpp
+++ b/test/unittest/http/hffs_test.cpp
@@ -1,0 +1,40 @@
+#include "catch.hpp"
+
+#include "hffs.hpp"
+
+namespace duckdb {
+
+TEST_CASE("Hugging Face list results parse files and directories", "[httpfs][hffs]") {
+	const string input = R"([
+		{"type":"file","path":"folder/file.parquet","metadata":{"size":42}},
+		{"type":"directory","path":"folder/nested"}
+	])";
+	vector<string> files;
+	vector<string> directories;
+
+	HuggingFaceFileSystem::ParseListResult(input, files, directories);
+
+	REQUIRE(files == vector<string> {"/folder/file.parquet"});
+	REQUIRE(directories == vector<string> {"/folder/nested"});
+}
+
+TEST_CASE("Hugging Face list results parse escaped path characters", "[httpfs][hffs]") {
+	const string input = R"([{"type":"file","path":"folder/a\"b\\c.parquet"}])";
+	vector<string> files;
+	vector<string> directories;
+
+	HuggingFaceFileSystem::ParseListResult(input, files, directories);
+
+	REQUIRE(files == vector<string> {"/folder/a\"b\\c.parquet"});
+	REQUIRE(directories.empty());
+}
+
+TEST_CASE("Hugging Face list results reject incomplete entries", "[httpfs][hffs]") {
+	const string input = R"([{"path":"folder/file.parquet"}])";
+	vector<string> files;
+	vector<string> directories;
+
+	REQUIRE_THROWS_AS(HuggingFaceFileSystem::ParseListResult(input, files, directories), IOException);
+}
+
+} // namespace duckdb

--- a/test/unittest/s3/mock_s3_server.cpp
+++ b/test/unittest/s3/mock_s3_server.cpp
@@ -152,14 +152,15 @@ struct MockS3Server::Impl {
 		return observations;
 	}
 
-	bool WaitForFullGet() {
-		std::unique_lock<std::mutex> lock(full_get_lock);
-		return full_get_started.wait_for(lock, std::chrono::seconds(5), [this]() { return full_get_seen; });
+	bool WaitForFullGet() DUCKDB_EXCLUDES(full_get_lock) {
+		annotated_unique_lock<annotated_mutex> lock(full_get_lock);
+		return full_get_started.wait_for(lock, std::chrono::seconds(5),
+		                                 [this]() DUCKDB_REQUIRES(full_get_lock) { return full_get_seen; });
 	}
 
-	void ReleaseFullGet() {
+	void ReleaseFullGet() DUCKDB_EXCLUDES(full_get_lock) {
 		{
-			std::lock_guard<std::mutex> lock(full_get_lock);
+			annotated_lock_guard<annotated_mutex> lock(full_get_lock);
 			full_get_released = true;
 		}
 		full_get_release.notify_all();
@@ -411,11 +412,12 @@ struct MockS3Server::Impl {
 					    config.object.data.size(), "application/octet-stream",
 					    [this](size_t offset, size_t length, httplib::DataSink &sink) {
 						    if (offset == 0) {
-							    std::unique_lock<std::mutex> lock(full_get_lock);
+							    annotated_unique_lock<annotated_mutex> lock(full_get_lock);
 							    full_get_seen = true;
 							    full_get_started.notify_all();
-							    if (!full_get_release.wait_for(lock, std::chrono::seconds(5),
-							                                   [this]() { return full_get_released; })) {
+							    if (!full_get_release.wait_for(
+							            lock, std::chrono::seconds(5),
+							            [this]() DUCKDB_REQUIRES(full_get_lock) { return full_get_released; })) {
 								    return false;
 							    }
 						    }
@@ -465,7 +467,7 @@ struct MockS3Server::Impl {
 
 			idx_t range_request_index;
 			{
-				std::lock_guard<std::mutex> lock(range_request_lock);
+				annotated_lock_guard<annotated_mutex> lock(range_request_lock);
 				range_request_index = ++range_requests_seen;
 			}
 			range_request_started.notify_all();
@@ -475,10 +477,12 @@ struct MockS3Server::Impl {
 			if (!config.range.blocked.empty() && range == config.range.blocked) {
 				response.set_content_provider(config.object.data.size(), "application/octet-stream",
 				                              [this](size_t offset, size_t length, httplib::DataSink &sink) {
-					                              std::unique_lock<std::mutex> lock(range_release_lock);
-					                              if (!range_release.wait_for(lock, std::chrono::seconds(5), [this]() {
-						                                  return release_range_completed;
-					                                  })) {
+					                              annotated_unique_lock<annotated_mutex> lock(range_release_lock);
+					                              if (!range_release.wait_for(lock, std::chrono::seconds(5),
+					                                                          [this]()
+					                                                              DUCKDB_REQUIRES(range_release_lock) {
+						                                                              return release_range_completed;
+					                                                              })) {
 						                              return false;
 					                              }
 					                              return sink.write(config.object.data.data() + offset, length);
@@ -487,19 +491,19 @@ struct MockS3Server::Impl {
 				return;
 			}
 			if (!config.range.release.empty() && range == config.range.release) {
-				response.set_content_provider(config.object.data.size(), "application/octet-stream",
-				                              [this](size_t offset, size_t length, httplib::DataSink &sink) {
-					                              const auto success =
-					                                  sink.write(config.object.data.data() + offset, length);
-					                              if (success) {
-						                              {
-							                              std::lock_guard<std::mutex> lock(range_release_lock);
-							                              release_range_completed = true;
-						                              }
-						                              range_release.notify_all();
-					                              }
-					                              return success;
-				                              });
+				response.set_content_provider(
+				    config.object.data.size(), "application/octet-stream",
+				    [this](size_t offset, size_t length, httplib::DataSink &sink) {
+					    const auto success = sink.write(config.object.data.data() + offset, length);
+					    if (success) {
+						    {
+							    annotated_lock_guard<annotated_mutex> lock(range_release_lock);
+							    release_range_completed = true;
+						    }
+						    range_release.notify_all();
+					    }
+					    return success;
+				    });
 				Record(request, response.status);
 				return;
 			}
@@ -509,9 +513,11 @@ struct MockS3Server::Impl {
 				    config.object.data.size(), "application/octet-stream",
 				    [this, wait_for_second_request](size_t offset, size_t length, httplib::DataSink &sink) {
 					    if (wait_for_second_request->exchange(false)) {
-						    std::unique_lock<std::mutex> lock(range_request_lock);
+						    annotated_unique_lock<annotated_mutex> lock(range_request_lock);
 						    if (!range_request_started.wait_for(lock, std::chrono::seconds(5),
-						                                        [this]() { return range_requests_seen >= 2; })) {
+						                                        [this]() DUCKDB_REQUIRES(range_request_lock) {
+							                                        return range_requests_seen >= 2;
+						                                        })) {
 							    return false;
 						    }
 					    }
@@ -647,17 +653,17 @@ struct MockS3Server::Impl {
 	mutable std::atomic<idx_t> remaining_complete_post_failures {0};
 	mutable annotated_mutex observation_lock;
 	mutable vector<MockS3RequestObservation> observations DUCKDB_GUARDED_BY(observation_lock);
-	std::mutex range_request_lock;
+	annotated_mutex range_request_lock;
 	std::condition_variable range_request_started;
-	idx_t range_requests_seen = 0;
-	std::mutex range_release_lock;
+	idx_t range_requests_seen DUCKDB_GUARDED_BY(range_request_lock) = 0;
+	annotated_mutex range_release_lock;
 	std::condition_variable range_release;
-	bool release_range_completed = false;
-	std::mutex full_get_lock;
+	bool release_range_completed DUCKDB_GUARDED_BY(range_release_lock) = false;
+	annotated_mutex full_get_lock;
 	std::condition_variable full_get_started;
 	std::condition_variable full_get_release;
-	bool full_get_seen = false;
-	bool full_get_released = false;
+	bool full_get_seen DUCKDB_GUARDED_BY(full_get_lock) = false;
+	bool full_get_released DUCKDB_GUARDED_BY(full_get_lock) = false;
 };
 
 MockS3Server::MockS3Server(MockS3ServerConfig config) : impl(make_uniq<Impl>(std::move(config))) {

--- a/test/unittest/s3/s3_refresh_test.cpp
+++ b/test/unittest/s3/s3_refresh_test.cpp
@@ -15,7 +15,6 @@
 #include "duckdb/main/secret/secret_manager.hpp"
 
 #include <atomic>
-#include <mutex>
 
 namespace duckdb {
 

--- a/test/unittest/s3/s3_request_test.cpp
+++ b/test/unittest/s3/s3_request_test.cpp
@@ -5,6 +5,8 @@
 
 #include "http/httpfs.hpp"
 #include "http/httpfs_client.hpp"
+#include "crypto.hpp"
+#include "s3/s3_request.hpp"
 #include "s3/s3fs.hpp"
 
 #include "duckdb.hpp"
@@ -190,6 +192,46 @@ CREATE SECRET s3_region_redirect (
 }
 
 } // namespace
+
+TEST_CASE("S3 request signing remains deterministic", "[httpfs][s3][signing]") {
+	::AESStateSSLFactory encryption_util;
+	S3AuthParams auth_params;
+	auth_params.region = "us-east-1";
+	auth_params.access_key_id = "AKIAIOSFODNN7EXAMPLE";
+	auth_params.secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+
+	auto headers = S3RequestUtil::CreateHeader(encryption_util, "/test.txt", "", "examplebucket.s3.amazonaws.com", "s3",
+	                                           "GET", auth_params, "20130524", "20130524T000000Z");
+
+	REQUIRE(headers.GetHeaderValue("Host") == "examplebucket.s3.amazonaws.com");
+	REQUIRE(headers.GetHeaderValue("x-amz-content-sha256") ==
+	        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+	REQUIRE(headers.GetHeaderValue("Authorization") ==
+	        "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, "
+	        "SignedHeaders=host;x-amz-content-sha256;x-amz-date, "
+	        "Signature=df548e2ce037944d03f3e68682813b093763996d597cf890ca3d9037fd231eb4");
+}
+
+TEST_CASE("S3 request signing includes optional headers", "[httpfs][s3][signing]") {
+	::AESStateSSLFactory encryption_util;
+	S3AuthParams auth_params;
+	auth_params.region = "eu-west-1";
+	auth_params.access_key_id = "key";
+	auth_params.secret_access_key = "secret";
+	auth_params.session_token = "token";
+	auth_params.kms_key_id = "kms-key";
+	auth_params.requester_pays = true;
+
+	auto headers =
+	    S3RequestUtil::CreateHeader(encryption_util, "/bucket/key", "", "bucket.example.com", "s3", "PUT", auth_params,
+	                                "20260730", "20260730T120000Z", "", "application/octet-stream", "content-md5");
+
+	REQUIRE(headers.GetHeaderValue("x-amz-security-token") == "token");
+	REQUIRE(headers.GetHeaderValue("x-amz-request-payer") == "requester");
+	REQUIRE(headers.GetHeaderValue("x-amz-server-side-encryption") == "aws:kms");
+	REQUIRE(headers.GetHeaderValue("x-amz-server-side-encryption-aws-kms-key-id") == "kms-key");
+	REQUIRE(headers.GetHeaderValue("Authorization").find("content-md5;content-type;host;") != string::npos);
+}
 
 TEST_CASE("HTTPFS preserves S3 error bodies for streamed GETs", "[httpfs][s3][errors]") {
 	SECTION("httplib") {


### PR DESCRIPTION
1. Use DuckDB's more modern casts
2. Use `annotated_mutex` everywhere
3. Split up large functions into helpers

And some more small cleanup chores.