### PR TITLE
Add autoload run and add missing `LOAD`

### DIFF
--- a/.github/workflows/IntegrationTests.yml
+++ b/.github/workflows/IntegrationTests.yml
@@ -93,6 +93,13 @@ jobs:
           source ./scripts/set_s3_test_server_variables.sh
           ./build/release/test/unittest "*" --test-config test/configs/httpfs_dynamic.json
 
+      - name: Run tests with extension autoloading
+        shell: bash
+        run: |
+          source ./scripts/run_s3_test_server.sh
+          source ./scripts/set_s3_test_server_variables.sh
+          ./build/release/test/unittest "*" --autoloading available --skip-compiled
+
       - name: Run tests with statically loaded extensions (curl)
         shell: bash
         run: |

--- a/.github/workflows/IntegrationTests.yml
+++ b/.github/workflows/IntegrationTests.yml
@@ -98,7 +98,7 @@ jobs:
         run: |
           source ./scripts/run_s3_test_server.sh
           source ./scripts/set_s3_test_server_variables.sh
-          ./build/release/test/unittest "*" --autoloading available --skip-compiled
+          ./build/release/test/unittest "*" --test-config test/configs/httpfs_autoloading.json
 
       - name: Run tests with statically loaded extensions (curl)
         shell: bash

--- a/src/httpfs_extension.cpp
+++ b/src/httpfs_extension.cpp
@@ -47,13 +47,13 @@ struct HTTPFSExtensionLoader {
 
 	static void Load(ExtensionLoader &loader) {
 		auto &instance = loader.GetDatabaseInstance();
-		RegisterFileSystems(instance);
-		instance.GetLogManager().RegisterLogType(make_uniq<HTTPFSInfoLogType>());
-
 		auto &config = DBConfig::GetConfig(instance);
 		RegisterSettings(config);
 		RegisterSecrets(loader);
 		ConfigureEncryption(config);
+
+		instance.GetLogManager().RegisterLogType(make_uniq<HTTPFSInfoLogType>());
+		RegisterFileSystems(instance);
 	}
 };
 

--- a/test/configs/httpfs_autoloading.json
+++ b/test/configs/httpfs_autoloading.json
@@ -1,0 +1,18 @@
+{
+  "description": "Run HTTPFS tests with extension autoloading.",
+  "autoloading": "available",
+  "skip_compiled": true,
+  "skip_error_messages": [],
+  "skip_tests": [
+    {
+      "reason": "These tests require HTTPFS to be available only from the local extension repository.",
+      "paths": [
+        "test/extension/autoloading_base.test",
+        "test/extension/autoloading_current_setting.test",
+        "test/extension/autoloading_filesystems.test",
+        "test/extension/autoloading_load_only.test",
+        "test/extension/autoloading_reset_setting.test"
+      ]
+    }
+  ]
+}

--- a/test/sql/connection_caching_default.test
+++ b/test/sql/connection_caching_default.test
@@ -6,6 +6,9 @@ require httpfs
 
 require parquet
 
+statement ok
+LOAD httpfs;
+
 # override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
 set ignore_error_messages
 

--- a/test/sql/json/table/internal_issue_6807.test_slow
+++ b/test/sql/json/table/internal_issue_6807.test_slow
@@ -7,6 +7,12 @@ require json
 require httpfs
 
 statement ok
+LOAD json;
+
+statement ok
+LOAD httpfs;
+
+statement ok
 CALL enable_logging('HTTP');
 
 statement ok

--- a/test/sql/secrets/create_secret_minio.test
+++ b/test/sql/secrets/create_secret_minio.test
@@ -83,6 +83,12 @@ loop z 0 100
 restart
 
 statement ok
+LOAD httpfs;
+
+statement ok
+LOAD parquet;
+
+statement ok
 set s3_access_key_id='';
 
 statement ok


### PR DESCRIPTION
CI can succeed here but then fail in core, this brings test parity closer to core (more work still needs to be done though)