### PR TITLE
Add extra_http_headers setting to inject headers into every request

### DIFF
--- a/src/http/http_settings.cpp
+++ b/src/http/http_settings.cpp
@@ -25,6 +25,19 @@ static void SetCACertFile(ClientContext &context, SetScope, Value &parameter) {
 	parameter = Value(fs.CanonicalizePath(value, opener));
 }
 
+static void SetExtraHTTPHeaders(ClientContext &, SetScope, Value &parameter) {
+	if (parameter.IsNull()) {
+		throw InvalidInputException("NULL is not a valid option for extra_http_headers");
+	}
+	for (const auto &entry : MapValue::GetChildren(parameter)) {
+		auto key_value = StructValue::GetChildren(entry);
+		if (key_value[1].IsNull()) {
+			throw InvalidInputException("extra_http_headers value for \"%s\" must not be NULL",
+			                            key_value[0].GetValue<string>());
+		}
+	}
+}
+
 static void SetHTTPClientImplementation(ClientContext &context, SetScope, Value &parameter) {
 	auto &config = DBConfig::GetConfig(context);
 	auto value = StringValue::Get(parameter);
@@ -73,6 +86,10 @@ void HTTPSettings::Register(DBConfig &config) {
 	    "http_keep_alive",
 	    "Keep alive connections. Setting this to false can help when running into connection failures",
 	    LogicalType::BOOLEAN, Value(HTTPParams::DEFAULT_KEEP_ALIVE));
+	config.AddExtensionOption("extra_http_headers", "Extra HTTP headers added to every request",
+	                          LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR),
+	                          Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, {}, {}), SetExtraHTTPHeaders,
+	                          SetScope::GLOBAL);
 	config.AddExtensionOption("force_download", "Forces upfront download of file", LogicalType::BOOLEAN, Value(false));
 	config.AddExtensionOption("force_download_threshold",
 	                          "Forces upfront download of files smaller than the given size in bytes",

--- a/src/http/httpfs.cpp
+++ b/src/http/httpfs.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/http_util.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/thread.hpp"
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/types/time.hpp"
@@ -78,6 +79,37 @@ private:
 		FileOpener::TryGetCurrentSetting(opener, "unsafe_disable_etag_checks", result->unsafe_disable_etag_checks,
 		                                 info);
 		FileOpener::TryGetCurrentSetting(opener, "s3_version_id_pinning", result->s3_version_id_pinning, info);
+
+		// The base set of headers for every request - a matching secret merges over these per key
+		Value extra_http_headers;
+		if (TryGetSetting("extra_http_headers", extra_http_headers)) {
+			MergeExtraHeaders(extra_http_headers);
+		}
+	}
+
+	SettingLookupResult TryGetSetting(const string &key, Value &value) {
+		if (info) {
+			return FileOpener::TryGetCurrentSetting(opener, key, value, *info);
+		}
+		return FileOpener::TryGetCurrentSetting(opener, key, value);
+	}
+
+	void MergeExtraHeaders(const Value &headers) {
+		if (headers.IsNull()) {
+			return;
+		}
+		if (headers.type().id() != LogicalTypeId::MAP) {
+			throw InvalidInputException("extra_http_headers must be a MAP(VARCHAR, VARCHAR), got \"%s\"",
+			                            headers.type().ToString());
+		}
+		for (const auto &child : MapValue::GetChildren(headers)) {
+			auto key_value = StructValue::GetChildren(child);
+			if (key_value[1].IsNull()) {
+				throw InvalidInputException("extra_http_headers value for \"%s\" must not be NULL",
+				                            key_value[0].GetValue<string>());
+			}
+			result->extra_headers[key_value[0].GetValue<string>()] = key_value[1].GetValue<string>();
+		}
 	}
 
 	void SetUserAgent() {
@@ -118,12 +150,7 @@ private:
 
 		Value extra_headers;
 		if (settings_reader.TryGetSecretKey("extra_http_headers", extra_headers)) {
-			auto children = MapValue::GetChildren(extra_headers);
-			for (const auto &child : children) {
-				auto key_value = StructValue::GetChildren(child);
-				D_ASSERT(key_value.size() == 2);
-				result->extra_headers[key_value[0].GetValue<string>()] = key_value[1].GetValue<string>();
-			}
+			MergeExtraHeaders(extra_headers);
 		}
 	}
 

--- a/test/sql/httpfs/http_extra_headers_setting.test
+++ b/test/sql/httpfs/http_extra_headers_setting.test
@@ -1,0 +1,99 @@
+# name: test/sql/httpfs/http_extra_headers_setting.test
+# description: Test extra HTTP headers from the extra_http_headers setting
+# group: [httpfs]
+
+require httpfs
+
+require-env PYTHON_HTTP_SERVER_URL
+
+require-env PYTHON_HTTP_SERVER_DIR
+
+# FIXME: extra_http_headers is not yet in duckdb's autoload registry
+statement ok
+LOAD httpfs;
+
+statement ok
+SET enable_external_file_cache=false;
+
+query I
+SELECT current_setting('extra_http_headers');
+----
+{}
+
+statement ok
+COPY (SELECT 1 AS a) TO '{PYTHON_HTTP_SERVER_DIR}/extra_http_headers.csv';
+
+statement ok
+SET extra_http_headers = MAP {'X-Setting-One': 'one', 'X-Setting-Two': 'two'};
+
+statement ok
+CALL enable_logging('HTTP');
+
+statement ok
+SELECT * FROM read_csv_auto('{PYTHON_HTTP_SERVER_URL}/extra_http_headers.csv');
+
+query II
+SELECT DISTINCT request.headers['X-Setting-One'], request.headers['X-Setting-Two']
+FROM duckdb_logs_parsed('HTTP')
+WHERE request.type = 'GET'
+----
+one	two
+
+statement ok
+CALL truncate_duckdb_logs();
+
+statement ok
+CREATE SECRET extra_http_headers_setting_override (
+    TYPE HTTP,
+    EXTRA_HTTP_HEADERS MAP {
+        'X-Setting-One': 'secret'
+    }
+);
+
+statement ok
+SELECT * FROM read_csv_auto('{PYTHON_HTTP_SERVER_URL}/extra_http_headers.csv');
+
+query II
+SELECT DISTINCT request.headers['X-Setting-One'], request.headers['X-Setting-Two']
+FROM duckdb_logs_parsed('HTTP')
+WHERE request.type = 'GET'
+----
+secret	two
+
+statement ok
+DROP SECRET extra_http_headers_setting_override;
+
+# SET replaces the map, so compose to add a header
+statement ok
+SET extra_http_headers = map_concat(current_setting('extra_http_headers'), MAP {'X-Setting-Three': 'three'});
+
+reconnect
+
+query II
+SELECT current_setting('extra_http_headers')['X-Setting-One'], current_setting('extra_http_headers')['X-Setting-Three'];
+----
+one	three
+
+statement error
+SET extra_http_headers = NULL;
+----
+NULL is not a valid option for extra_http_headers
+
+# NULL would otherwise be sent as the literal string "NULL"
+statement error
+SET extra_http_headers = MAP {'X-Setting-Null': NULL};
+----
+extra_http_headers value for "X-Setting-Null" must not be NULL
+
+statement ok
+CREATE SECRET extra_http_headers_null (
+    TYPE HTTP,
+    EXTRA_HTTP_HEADERS MAP {
+        'X-Secret-Null': NULL
+    }
+);
+
+statement error
+SELECT * FROM read_csv_auto('{PYTHON_HTTP_SERVER_URL}/extra_http_headers.csv')
+----
+extra_http_headers value for "X-Secret-Null" must not be NULL


### PR DESCRIPTION
Headers can currently only be attached via a secret, and only one secret applies per request, so headers on an HTTP secret never reach traffic matching an S3 secret. This adds an `extra_http_headers` setting (`MAP(VARCHAR, VARCHAR)`) that supplies the base headers for every request, a matching secret still overrides them per key. 
One use case is testing: a suite routing traffic through a shared proxy can tag every request with a per-test header, regardless of which secret each test happens to use.

NOTE: `extra_http_headers` does not yet autoload `httpfs`