### PR TITLE
Make run_s3_test_server.sh run from absolute paths

### DIFF
--- a/scripts/run_s3_test_server.sh
+++ b/scripts/run_s3_test_server.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 #Note: DONT run as root
 
+HTTPFS_SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+
 if [ ! -f test/test_data/attach.db ]; then
     echo "File test/test_data/attach.db not found, run ./scripts/generate_presigned_url.sh to generate"
 else
-  ./scripts/cleanup_s3_test_server.sh
+  "${HTTPFS_SCRIPT_DIR}/cleanup_s3_test_server.sh"
   mkdir -p /tmp/minio_test_data
   mkdir -p /tmp/minio_root_data
-  docker compose -f scripts/minio_s3.yml -p duckdb-minio up -d
+  docker compose -f "${HTTPFS_SCRIPT_DIR}/minio_s3.yml" -p duckdb-minio up -d
 
   # for testing presigned url
   container_name=$(docker ps -a --format '{{.Names}}' | grep -m 1 "duckdb-minio")


### PR DESCRIPTION
The script [failed](https://github.com/duckdb/duckdb-delta/actions/runs/30992031924/job/92260166122?pr=332#step:10:240) in duckdb-delta:
```
/home/runner/work/duckdb-delta/duckdb-delta/build/release/_deps/httpfs_extension_fc-src/scripts/run_s3_test_server.sh: line 7: ./scripts/cleanup_s3_test_server.sh: No such file or directory
Error: Process completed with exit code 127.
```

cc @okruitho 