### PR TITLE
Retry S3 `CompleteMultipartUpload` when a 200 response returns an `IntenalError`

### DIFF
--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -230,6 +230,8 @@ public:
 	BufferHandle Allocate(idx_t part_size, uint16_t max_threads);
 	static string GetS3BadRequestError(const S3AuthParams &s3_auth_params, string correct_region = "");
 	static string ParseS3Error(const string &error);
+	static bool TryGetS3ErrorCode(const string &body, string &code);
+	static void SleepForS3RequestTimeoutRetry(const HTTPFSParams &http_params, idx_t transient_retries, double &wait_ms);
 	static string GetS3AuthError(const S3AuthParams &s3_auth_params);
 	static string GetGCSAuthError(const S3AuthParams &s3_auth_params);
 	static HTTPException GetS3Error(const S3AuthParams &s3_auth_params, const HTTPResponse &response,

--- a/src/include/s3fs.hpp
+++ b/src/include/s3fs.hpp
@@ -231,7 +231,8 @@ public:
 	static string GetS3BadRequestError(const S3AuthParams &s3_auth_params, string correct_region = "");
 	static string ParseS3Error(const string &error);
 	static bool TryGetS3ErrorCode(const string &body, string &code);
-	static void SleepForS3RequestTimeoutRetry(const HTTPFSParams &http_params, idx_t transient_retries, double &wait_ms);
+	static void SleepForS3RequestTimeoutRetry(const HTTPFSParams &http_params, idx_t transient_retries,
+	                                          double &wait_ms);
 	static string GetS3AuthError(const S3AuthParams &s3_auth_params);
 	static string GetGCSAuthError(const S3AuthParams &s3_auth_params);
 	static HTTPException GetS3Error(const S3AuthParams &s3_auth_params, const HTTPResponse &response,

--- a/src/s3_multi_part_upload.cpp
+++ b/src/s3_multi_part_upload.cpp
@@ -102,7 +102,8 @@ void S3MultiPartUpload::FinalizeMultipartUpload() {
 
 	string query_param = "uploadId=" + S3FileSystem::UrlEncode(multipart_upload_id, true);
 
-	// CompleteMultipartUpload is special: after S3 sends the 200 status header it can still write an error into the body.
+	// CompleteMultipartUpload is special: after S3 sends the 200 status header it can still write an error into the
+	// body.
 	auto &http_params = http_input->params->Cast<HTTPFSParams>();
 	idx_t transient_retries = 0;
 	double transient_wait_ms = 0;
@@ -117,7 +118,8 @@ void S3MultiPartUpload::FinalizeMultipartUpload() {
 		// Response is around ~400 in AWS docs so this should be enough to not need a resize
 		string code;
 		// Only HTTP 200s with an embedded error are retried here.
-		if (res->status == HTTPStatusCode::OK_200 && S3FileSystem::TryGetS3ErrorCode(result, code) && code == "InternalError" && transient_retries < http_params.retries) {
+		if (res->status == HTTPStatusCode::OK_200 && S3FileSystem::TryGetS3ErrorCode(result, code) &&
+		    code == "InternalError" && transient_retries < http_params.retries) {
 			S3FileSystem::SleepForS3RequestTimeoutRetry(http_params, transient_retries, transient_wait_ms);
 			transient_retries++;
 			continue;

--- a/src/s3_multi_part_upload.cpp
+++ b/src/s3_multi_part_upload.cpp
@@ -100,15 +100,31 @@ void S3MultiPartUpload::FinalizeMultipartUpload() {
 	ss << "</CompleteMultipartUpload>";
 	string body = ss.str();
 
-	// Response is around ~400 in AWS docs so this should be enough to not need a resize
-	string result;
-
 	string query_param = "uploadId=" + S3FileSystem::UrlEncode(multipart_upload_id, true);
-	auto res = s3fs.PostRequest(*http_input, path, {}, result, (char *)body.c_str(), body.length(), query_param);
-	auto open_tag_pos = result.find("<CompleteMultipartUploadResult", 0);
-	if (open_tag_pos == string::npos) {
-		throw HTTPException(*res, "Unexpected response during S3 multipart upload finalization: %d\n\n%s",
-		                    static_cast<int>(res->status), result);
+
+	// CompleteMultipartUpload is special: after S3 sends the 200 status header it can still write an error into the body.
+	auto &http_params = http_input->params->Cast<HTTPFSParams>();
+	idx_t transient_retries = 0;
+	double transient_wait_ms = 0;
+	for (;;) {
+		string result;
+		auto res = s3fs.PostRequest(*http_input, path, {}, result, (char *)body.c_str(), body.length(), query_param);
+
+		if (result.find("<CompleteMultipartUploadResult", 0) != string::npos) {
+			return;
+		}
+
+		// Response is around ~400 in AWS docs so this should be enough to not need a resize
+		string code;
+		// Only HTTP 200s with an embedded error are retried here.
+		if (res->status == HTTPStatusCode::OK_200 && S3FileSystem::TryGetS3ErrorCode(result, code) && code == "InternalError" && transient_retries < http_params.retries) {
+			S3FileSystem::SleepForS3RequestTimeoutRetry(http_params, transient_retries, transient_wait_ms);
+			transient_retries++;
+			continue;
+		}
+
+		throw HTTPException(*res, "Unexpected response during S3 multipart upload finalization: %d%s\n\n%s",
+		                    static_cast<int>(res->status), S3FileSystem::ParseS3Error(result), result);
 	}
 }
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -419,6 +419,18 @@ bool IsS3RequestTimeout(const HTTPResponse &response) {
 	return TryFindTagContents(response.body, "Code", 0, code).IsValid() && code == "RequestTimeout";
 }
 
+void S3FileSystem::SleepForS3RequestTimeoutRetry(const HTTPFSParams &http_params, idx_t transient_retries,
+                                                 double &wait_ms) {
+	if (transient_retries == 0) {
+		wait_ms = static_cast<double>(http_params.retry_wait_ms);
+		return;
+	}
+#ifndef DUCKDB_NO_THREADS
+	ThreadUtil::SleepMs(static_cast<idx_t>(wait_ms));
+#endif
+	wait_ms *= http_params.retry_backoff;
+}
+
 template <class CREATE_DATA, class REQUEST, class REFRESH, class SET_REGION>
 static unique_ptr<HTTPResponse> RunS3RequestWithAuthRefreshInternal(const string &s3_url, CREATE_DATA create_data,
                                                                     REQUEST request, REFRESH refresh_auth_params,
@@ -1823,6 +1835,13 @@ string S3FileSystem::GetGCSAuthError(const S3AuthParams &s3_auth_params) {
 		extra_text += "\n* Ensure your HMAC key_id and secret are correct.";
 	}
 	return extra_text;
+}
+
+bool S3FileSystem::TryGetS3ErrorCode(const string &body, string &code) {
+	if (body.empty()) {
+		return false;
+	}
+	return TryFindTagContents(body, "Code", 0, code).IsValid();
 }
 
 string S3FileSystem::ParseS3Error(const string &error) {

--- a/test/unittest/httpfs_refresh_test.cpp
+++ b/test/unittest/httpfs_refresh_test.cpp
@@ -884,7 +884,8 @@ static void RunCompletePost200ErrorRetryScenario(const string &client_implementa
 	REQUIRE(CountObservationsTarget(observations, "POST", 200, "uploadId") == 3);
 }
 
-// A CompleteMultipartUpload that keeps returning a 200 OK with an embedded error must exhaust exactly http_retries retries
+// A CompleteMultipartUpload that keeps returning a 200 OK with an embedded error must exhaust exactly http_retries
+// retries
 static void RunCompletePost200ErrorExhaustsBudgetScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
 	config.bucket = BUCKET;

--- a/test/unittest/httpfs_refresh_test.cpp
+++ b/test/unittest/httpfs_refresh_test.cpp
@@ -856,9 +856,69 @@ static void RunMultipartCompleteNotRetriedScenario(const string &client_implemen
 	REQUIRE(CountObservationsTarget(observations, "POST", 400, "uploadId") == 1);
 }
 
+// A CompleteMultipartUpload that returns HTTP 200 with an embedded InternalError must be retried
+static void RunCompletePost200ErrorRetryScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	// Use a refresh target that writes never exercise, so credential refresh never triggers here.
+	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.transient_complete_post_200_errors = 2;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureRefreshTest(db, con, server, client_implementation, false);
+
+	RequireQueryOk(con, "SET http_retries=3");
+	RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	WriteMultipartPayload(con);
+	RequireQueryOk(con, "COMMIT");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	// The two 200-with-embedded-error completions were retried, and the third completion succeeded: 3 complete
+	// POSTs in total, all reported as HTTP 200 by S3.
+	REQUIRE(CountObservationsTarget(observations, "POST", 200, "uploadId") == 3);
+}
+
+// A CompleteMultipartUpload that keeps returning a 200 OK with an embedded error must exhaust exactly http_retries retries
+static void RunCompletePost200ErrorExhaustsBudgetScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.transient_complete_post_200_errors = 1000;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureRefreshTest(db, con, server, client_implementation, false);
+
+	RequireQueryOk(con, "SET http_retries=3");
+	RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	REQUIRE_THROWS(WriteMultipartPayload(con));
+	RequireQueryOk(con, "ROLLBACK");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	// http_retries=3 => 1 initial attempt + 3 retries = 4 complete POSTs, all HTTP 200 with the embedded error.
+	REQUIRE(CountObservationsTarget(observations, "POST", 200, "uploadId") == 4);
+}
+
 static void RunAllTransientRetryScenarios(const string &client_implementation) {
 	SECTION("multipart part upload retries and completes") {
 		RunTransientPutRetryScenario(client_implementation);
+	}
+	SECTION("a multipart-complete 200 with an embedded transient error is retried and completes") {
+		RunCompletePost200ErrorRetryScenario(client_implementation);
+	}
+	SECTION("a persistent multipart-complete 200-with-error is bounded by http_retries") {
+		RunCompletePost200ErrorExhaustsBudgetScenario(client_implementation);
 	}
 	SECTION("object read retries and completes") {
 		RunTransientGetRetryScenario(client_implementation);

--- a/test/unittest/httpfs_refresh_test.cpp
+++ b/test/unittest/httpfs_refresh_test.cpp
@@ -879,7 +879,7 @@ static void RunCompletePost200ErrorRetryScenario(const string &client_implementa
 
 	auto observations = server.Observations();
 	INFO(MockS3DescribeObservations(observations));
-	// The two 200-with-embedded-error completions were retried, and the third completion succeeded: 3 complete
+	// The two 200 with embedded error completions were retried, and the third completion succeeded: 3 complete
 	// POSTs in total, all reported as HTTP 200 by S3.
 	REQUIRE(CountObservationsTarget(observations, "POST", 200, "uploadId") == 3);
 }

--- a/test/unittest/mock_s3_server.cpp
+++ b/test/unittest/mock_s3_server.cpp
@@ -77,6 +77,7 @@ struct MockS3Server::Impl {
 		remaining_delete_failures = config.transient_delete_failures;
 		remaining_post_failures = config.transient_post_failures;
 		remaining_complete_post_failures = config.transient_complete_post_failures;
+		remaining_complete_post_200_errors = config.transient_complete_post_200_errors;
 		if (config.range_behavior == MockS3RangeBehavior::SHORT_SUCCESS && config.range_behavior_requests > 0) {
 			server.set_keep_alive_max_count(1);
 		}
@@ -217,6 +218,16 @@ struct MockS3Server::Impl {
 			                     "CompleteMultipartUploadResult>",
 			                     "application/xml");
 		}
+		Record(request, response.status);
+	}
+
+	// S3 can return HTTP 200 OK on CompleteMultipartUpload while embedding an error in the body
+	void SendComplete200Error(const httplib::Request &request, httplib::Response &response) const {
+		response.status = 200;
+		response.set_content("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+		                     "<Error><Code>InternalError</Code>"
+		                     "<Message>We encountered an internal error. Please try again.</Message></Error>",
+		                     "application/xml");
 		Record(request, response.status);
 	}
 
@@ -398,6 +409,11 @@ struct MockS3Server::Impl {
 				SendS3Error400(request, response, config.failure_is_request_timeout);
 				return;
 			}
+			if (request.target.find("uploadId") != string::npos && remaining_complete_post_200_errors.load() > 0) {
+				remaining_complete_post_200_errors--;
+				SendComplete200Error(request, response);
+				return;
+			}
 			SendMultipartPostSuccess(request, response);
 		});
 
@@ -439,6 +455,7 @@ struct MockS3Server::Impl {
 	mutable std::atomic<idx_t> remaining_delete_failures {0};
 	mutable std::atomic<idx_t> remaining_post_failures {0};
 	mutable std::atomic<idx_t> remaining_complete_post_failures {0};
+	mutable std::atomic<idx_t> remaining_complete_post_200_errors {0};
 	mutable std::mutex observation_lock;
 	mutable vector<MockS3RequestObservation> observations;
 };

--- a/test/unittest/mock_s3_server.hpp
+++ b/test/unittest/mock_s3_server.hpp
@@ -50,6 +50,8 @@ struct MockS3ServerConfig {
 	idx_t transient_post_failures = 0;
 	//! Number of multipart-complete POSTs (uploadId=) to fail with a 400 before succeeding
 	idx_t transient_complete_post_failures = 0;
+	//! Number of multipart-complete POSTs (uploadId=) to answer with an HTTP 200 whose body carries an error before succeeding
+	idx_t transient_complete_post_200_errors = 0;
 	//! Whether injected 400s carry S3's retryable RequestTimeout code or a generic (non-retryable) code
 	bool failure_is_request_timeout = true;
 	//! Whether injected 400 bodies are truncated mid-XML (an open <Code> with no closing tag)

--- a/test/unittest/mock_s3_server.hpp
+++ b/test/unittest/mock_s3_server.hpp
@@ -50,7 +50,8 @@ struct MockS3ServerConfig {
 	idx_t transient_post_failures = 0;
 	//! Number of multipart-complete POSTs (uploadId=) to fail with a 400 before succeeding
 	idx_t transient_complete_post_failures = 0;
-	//! Number of multipart-complete POSTs (uploadId=) to answer with an HTTP 200 whose body carries an error before succeeding
+	//! Number of multipart-complete POSTs (uploadId=) to answer with an HTTP 200 whose body carries an error before
+	//! succeeding
 	idx_t transient_complete_post_200_errors = 0;
 	//! Whether injected 400s carry S3's retryable RequestTimeout code or a generic (non-retryable) code
 	bool failure_is_request_timeout = true;


### PR DESCRIPTION
`CompleteMultipartUpload` is [documented](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html) to sometimes return HTTP 200 with an `InternalError` embedded in the body. S3 sends the `200` header before the upload finishes, then may write an error into the body.

Before this change, `FinalizeMultipartUpload` only checked whether the response body contained a `<CompleteMultipartUploadResult>`; if it didn't, it threw a generic `Unexpected response during S3 multipart upload finalization` error. It never inspected whether the `200` actually carried an `InternalError`, so a transient server-side error was treated as fatal and aborted the whole COPY. 

This PR adds a retry mechanism bounded by `http_retries`.