### PR TITLE
Clean up persistent HTTP secret after its test

### DIFF
--- a/test/sql/secrets/persistent_key_value_secret.test
+++ b/test/sql/secrets/persistent_key_value_secret.test
@@ -26,3 +26,6 @@ from
 	read_json('https://non.existant/endpoint');
 ----
 <REGEX>:.*IO Error.*HTTP HEAD to 'https://non.existant/endpoint'.*
+
+statement ok
+DROP PERSISTENT SECRET http;


### PR DESCRIPTION
`persistent_key_value_secret.test` leaves its fake Bearer Authorization header on disk. In out-of-tree runs, cleanup happens after the runner restores the original working directory, so it targets the wrong relative test directory.

The leaked header is merged into the public S3 request in `connection_caching_s3.test`. AWS rejects it with HTTP 400 "Unsupported Authorization Type", breaking the linux_arm64_musl extension build and preventing nightly extension publication.

Example: https://github.com/duckdb/duckdb/actions/runs/29970387347

```
================================================================================
Query unexpectedly failed! (/duckdb_build_dir/build/release/_deps/httpfs_extension_fc-src/test/sql/s3/connection_caching_s3.test:28)!
================================================================================
FROM parquet_scan('s3://overturemaps-us-west-2/bridgefiles/2025-03-19.0-beta.0/dataset=Esri Community Maps/theme=buildings/type=building/part-00000-947c2149-23db-4abc-a7ee-3a892aac90ff.c000.snappy.parquet') LIMIT 1;
================================================================================
HTTP Error: HTTP GET error reading 'https://overturemaps-us-west-2.s3.us-west-2.amazonaws.com/bridgefiles/2025-03-19.0-beta.0/dataset%3DEsri%20Community%20Maps/theme%3Dbuildings/type%3Dbuilding/part-00000-947c2149-23db-4abc-a7ee-3a892aac90ff.c000.snappy.parquet' in region 'us-west-2' (HTTP 400 Bad Request)

InvalidArgument: Unsupported Authorization Type

Bad Request - this can be caused by the S3 region being set incorrectly.
```

Drop the secret after verifying that it survives a restart. This is a narrow v1.5 quickfix for the known contaminant. It does not fix general out-of-tree test isolation. duckdb/duckdb#23574 is the broader fix on main, but is too large to backport.

Blocks testing of nightly extensions in duckdb-rs (and later duckdb-go) as part of https://github.com/duckdblabs/duckdb-internal/issues/7516