### PR TITLE
Fix S3 `ExpiredToken` credential refresh

### DIFF
--- a/src/httpfs.cpp
+++ b/src/httpfs.cpp
@@ -248,7 +248,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRequest(HTTPFileHandle &hfh, stri
 	    url, header_map, http_params,
 	    [&](const HTTPResponse &response) {
 		    if (static_cast<int>(response.status) >= 400) {
-			    throw get_error(response);
+			    return true;
 		    }
 		    if (http_params.s3_version_id_pinning && response.HasHeader("x-amz-version-id")) {
 			    lock_guard<mutex> lck(hfh.mu);
@@ -279,7 +279,11 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRequest(HTTPFileHandle &hfh, stri
 		    return true;
 	    });
 
-	return send_request(get_request);
+	auto response = send_request(get_request);
+	if (response && !response->HasRequestError() && static_cast<int>(response->status) >= 400) {
+		throw get_error(*response);
+	}
+	return response;
 }
 
 unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh, string url, HTTPHeaders header_map,
@@ -297,7 +301,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh,
 	    url, header_map, http_params,
 	    [&](const HTTPResponse &response) {
 		    if (static_cast<int>(response.status) >= 400) {
-			    throw get_error(response);
+			    return true;
 		    }
 		    if (static_cast<int>(response.status) < 300) { // done redirecting
 			    out_offset = 0;
@@ -358,6 +362,9 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh,
 
 	get_request.try_request = auto_fallback_to_full_file_download;
 	auto response = send_request(get_request);
+	if (response && !response->HasRequestError() && static_cast<int>(response->status) >= 400) {
+		throw get_error(*response);
+	}
 	if (response && !response->HasRequestError() && response->Success() && buffer_out != nullptr &&
 	    out_offset != buffer_out_len) {
 		throw IOException("Short read for HTTP GET to '%s': requested range %s (%llu bytes), but received %llu bytes",

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -276,19 +276,17 @@ public:
 			state->total_bytes_received += bytes_received;
 		}
 
-		if (info.response_handler) {
-			auto response = TransformResponseCurl(res);
-			if (!info.response_handler(*response)) {
-				return response;
-			}
+		auto response = TransformResponseCurl(res);
+		if (info.response_handler && !info.response_handler(*response)) {
+			return response;
 		}
 
 		const char *data = request_info->body.c_str();
-		if (info.content_handler && res == CURLcode::CURLE_OK) {
+		if (info.content_handler && res == CURLcode::CURLE_OK && static_cast<int>(response->status) < 400) {
 			info.content_handler(const_data_ptr_cast(data), bytes_received);
 		}
 
-		return TransformResponseCurl(res);
+		return response;
 	}
 
 	unique_ptr<HTTPResponse> Put(PutRequestInfo &info) override {

--- a/src/httpfs_httplib_client.cpp
+++ b/src/httpfs_httplib_client.cpp
@@ -65,18 +65,29 @@ public:
 			}
 			return result;
 		} else {
-			return TransformResult(client->Get(
+			HTTPStatusCode response_status = HTTPStatusCode::INVALID;
+			string error_body;
+			auto result = TransformResult(client->Get(
 			    info.path.c_str(), headers,
 			    [&](const duckdb_httplib_openssl::Response &response) {
 				    auto http_response = TransformResponse(response);
-				    return info.response_handler(*http_response);
+				    response_status = http_response->status;
+				    return !info.response_handler || info.response_handler(*http_response);
 			    },
 			    [&](const char *data, size_t data_length) {
 				    if (state) {
 					    state->total_bytes_received += data_length;
 				    }
-				    return info.content_handler(const_data_ptr_cast(data), data_length);
+				    if (static_cast<int>(response_status) >= 400) {
+					    error_body.append(data, data_length);
+					    return true;
+				    }
+				    return !info.content_handler || info.content_handler(const_data_ptr_cast(data), data_length);
 			    }));
+			if (result && static_cast<int>(result->status) >= 400) {
+				result->body = std::move(error_body);
+			}
+			return result;
 		}
 	}
 	unique_ptr<HTTPResponse> Put(PutRequestInfo &info) override {

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -149,17 +149,35 @@ static bool IsGCSRequest(const string &url) {
 	return StringUtil::StartsWith(url, "gcs://") || StringUtil::StartsWith(url, "gs://");
 }
 
-static bool IsAuthRefreshStatus(const ErrorData &error) {
+static bool IsAuthRefreshFailure(const ErrorData &error) {
 	auto &extra_info = error.ExtraInfo();
 	auto entry = extra_info.find("status_code");
 	if (entry == extra_info.end()) {
 		return false;
 	}
-	return entry->second == "401" || entry->second == "403";
+	if (entry->second == "401" || entry->second == "403") {
+		return true;
+	}
+	if (entry->second != "400") {
+		return false;
+	}
+	auto body_entry = extra_info.find("response_body");
+	if (body_entry == extra_info.end()) {
+		return false;
+	}
+	string code;
+	return S3FileSystem::TryGetS3ErrorCode(body_entry->second, code) && code == "ExpiredToken";
 }
 
-static bool IsAuthRefreshStatus(const HTTPResponse &response) {
-	return response.status == HTTPStatusCode::Unauthorized_401 || response.status == HTTPStatusCode::Forbidden_403;
+static bool IsAuthRefreshFailure(const HTTPResponse &response) {
+	if (response.status == HTTPStatusCode::Unauthorized_401 || response.status == HTTPStatusCode::Forbidden_403) {
+		return true;
+	}
+	if (response.status != HTTPStatusCode::BadRequest_400) {
+		return false;
+	}
+	string code;
+	return S3FileSystem::TryGetS3ErrorCode(response.body, code) && code == "ExpiredToken";
 }
 
 static bool S3AuthParamsMatch(const S3AuthParams &left, const S3AuthParams &right) {
@@ -416,7 +434,7 @@ bool IsS3RequestTimeout(const HTTPResponse &response) {
 		return false;
 	}
 	string code;
-	return TryFindTagContents(response.body, "Code", 0, code).IsValid() && code == "RequestTimeout";
+	return S3FileSystem::TryGetS3ErrorCode(response.body, code) && code == "RequestTimeout";
 }
 
 void S3FileSystem::SleepForS3RequestTimeoutRetry(const HTTPFSParams &http_params, idx_t transient_retries,
@@ -442,7 +460,7 @@ static unique_ptr<HTTPResponse> RunS3RequestWithAuthRefreshInternal(const string
 		auto request_data = create_data();
 		try {
 			auto result = request(request_data);
-			if (result && !retried_auth_refresh && IsAuthRefreshStatus(*result) &&
+			if (result && !retried_auth_refresh && IsAuthRefreshFailure(*result) &&
 			    refresh_auth_params(request_data.auth_params, request_data.refreshable_http_params)) {
 				retried_auth_refresh = true;
 				continue;
@@ -457,7 +475,7 @@ static unique_ptr<HTTPResponse> RunS3RequestWithAuthRefreshInternal(const string
 			return result;
 		} catch (std::exception &ex) {
 			ErrorData error(ex);
-			if (!retried_auth_refresh && IsAuthRefreshStatus(error) &&
+			if (!retried_auth_refresh && IsAuthRefreshFailure(error) &&
 			    refresh_auth_params(request_data.auth_params, request_data.refreshable_http_params)) {
 				retried_auth_refresh = true;
 				continue;
@@ -969,8 +987,13 @@ unique_ptr<HTTPResponse> S3FileSystem::PostRequest(HTTPInput &input, string url,
 	    s3_input, url, "POST", http_params, payload_hash, content_type, [&](S3RequestData &request_data) {
 		    result.clear();
 		    auto &params = request_data.http_params->Cast<HTTPFSParams>();
-		    return RunPostRequest(request_data.http_url, request_data.headers, params, result, buffer_in, buffer_in_len,
-		                          [&](BaseRequest &request) { return params.http_util.Request(request); });
+		    auto response =
+		        RunPostRequest(request_data.http_url, request_data.headers, params, result, buffer_in, buffer_in_len,
+		                       [&](BaseRequest &request) { return params.http_util.Request(request); });
+		    if (response) {
+			    response->body = result;
+		    }
+		    return response;
 	    });
 }
 
@@ -1089,40 +1112,32 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 		HTTPFileHandle::Initialize(opener);
 	} catch (std::exception &ex) {
 		ErrorData error(ex);
-		bool refreshed_secret = false;
-		if (error.Type() == ExceptionType::IO || error.Type() == ExceptionType::HTTP) {
-			refreshed_secret = TryRefreshAuthParams(auth_params, SnapshotRefreshableHTTPParams(http_params));
-		}
 		string correct_region;
-		if (!refreshed_secret) {
-			auto &extra_info = error.ExtraInfo();
-			auto entry = extra_info.find("status_code");
-			if (entry != extra_info.end()) {
-				if (entry->second == "301" || entry->second == "400") {
-					auto new_region = extra_info.find("header_x-amz-bucket-region");
-					if (new_region != extra_info.end()) {
-						correct_region = new_region->second;
-					}
-				}
-				if (entry->second == "403") {
-					// 403: FORBIDDEN
-					string extra_text;
-					if (IsGCSRequest(path)) {
-						extra_text = S3FileSystem::GetGCSAuthError(auth_params);
-					} else {
-						extra_text = S3FileSystem::GetS3AuthError(auth_params);
-					}
-					throw Exception(extra_info, error.Type(), error.RawMessage() + extra_text);
+		auto &extra_info = error.ExtraInfo();
+		auto entry = extra_info.find("status_code");
+		if (entry != extra_info.end()) {
+			if (entry->second == "301" || entry->second == "400") {
+				auto new_region = extra_info.find("header_x-amz-bucket-region");
+				if (new_region != extra_info.end()) {
+					correct_region = new_region->second;
 				}
 			}
-			if (correct_region.empty()) {
-				throw;
+			if (entry->second == "403") {
+				// 403: FORBIDDEN
+				string extra_text;
+				if (IsGCSRequest(path)) {
+					extra_text = S3FileSystem::GetGCSAuthError(auth_params);
+				} else {
+					extra_text = S3FileSystem::GetS3AuthError(auth_params);
+				}
+				throw Exception(extra_info, error.Type(), error.RawMessage() + extra_text);
 			}
 		}
-		if (!refreshed_secret) {
-			FileOpenerInfo info = {path};
-			auth_params = S3AuthParams::ReadFrom(opener, info);
+		if (correct_region.empty()) {
+			throw;
 		}
+		FileOpenerInfo info = {path};
+		auth_params = S3AuthParams::ReadFrom(opener, info);
 		if (!correct_region.empty()) {
 			DUCKDB_LOG_WARNING(
 			    logger,
@@ -1419,7 +1434,10 @@ void S3FileSystem::RemoveFiles(const vector<string> &paths, optional_ptr<FileOpe
 				result.clear();
 				res = HTTPFileSystem::PostRequest(http_input, http_url, headers, result,
 				                                  const_cast<char *>(body.data()), body.length());
-				if (!retried_auth_refresh && res && IsAuthRefreshStatus(*res) &&
+				if (res) {
+					res->body = result;
+				}
+				if (!retried_auth_refresh && res && IsAuthRefreshFailure(*res) &&
 				    TryRefreshS3AuthParams(opener, secret_lookup_url, http_input.http_params, url_info.auth_params,
 				                           request_auth_params, request_http_params)) {
 					retried_auth_refresh = true;
@@ -1841,7 +1859,11 @@ bool S3FileSystem::TryGetS3ErrorCode(const string &body, string &code) {
 	if (body.empty()) {
 		return false;
 	}
-	return TryFindTagContents(body, "Code", 0, code).IsValid();
+	string error_xml;
+	if (!TryFindTagContents(body, "Error", 0, error_xml).IsValid()) {
+		return false;
+	}
+	return TryFindTagContents(error_xml, "Code", 0, code).IsValid();
 }
 
 string S3FileSystem::ParseS3Error(const string &error) {
@@ -1979,6 +2001,12 @@ string AWSListObjectV2::Request(const string &path, HTTPParams &http_params, S3A
 		if (result->HasRequestError()) {
 			throw IOException("%s error for HTTP GET to '%s'", result->GetRequestError(), listobjectv2_url);
 		}
+		if (!retried_auth_refresh && IsAuthRefreshFailure(*result) &&
+		    TryRefreshS3AuthParams(opener, path, http_params, s3_auth_params, request_auth_params, request_http_params,
+		                           retried_region)) {
+			retried_auth_refresh = true;
+			continue;
+		}
 		ErrorData error;
 		if (static_cast<int>(result->status) >= 400) {
 			string trimmed_path = path;
@@ -2005,12 +2033,6 @@ string AWSListObjectV2::Request(const string &path, HTTPParams &http_params, S3A
 			}
 		}
 		if (error.HasError()) {
-			if (!retried_auth_refresh && IsAuthRefreshStatus(error) &&
-			    TryRefreshS3AuthParams(opener, path, http_params, s3_auth_params, request_auth_params,
-			                           request_http_params, retried_region)) {
-				retried_auth_refresh = true;
-				continue;
-			}
 			if (!retried_region && result->HasHeader("x-amz-bucket-region")) {
 				auto response_region = result->GetHeaderValue("x-amz-bucket-region");
 				if (response_region != s3_auth_params.region) {

--- a/test/sql/copy/s3/glob_s3_paging.test_slow
+++ b/test/sql/copy/s3/glob_s3_paging.test_slow
@@ -102,12 +102,12 @@ statement ok
 SET s3_allow_recursive_globbing = ${s3_allow_recursive_globs}
 
 query I
-SELECT count(*) FROM glob('s3://test-bucket/parquet_glob*/some-non-existent-folder/*');
+SELECT count(*) FROM glob('s3://test-bucket/parquet_glob_s3_paging*/some-non-existent-folder/*');
 ----
 0
 
 query I
-SELECT count(*) FROM glob('s3://test-bucket/parquet_glob*/paging/*');
+SELECT count(*) FROM glob('s3://test-bucket/parquet_glob_s3_paging*/paging/*');
 ----
 8000
 
@@ -128,4 +128,3 @@ FROM (FROM duckdb_logs_parsed('HTTP') SELECT count(*), sum(request.type == 'HEAD
 11	0	11	0	0
 9	0	9	0	0
 9	0	9	0	0
-

--- a/test/unittest/httpfs_refresh_test.cpp
+++ b/test/unittest/httpfs_refresh_test.cpp
@@ -15,8 +15,10 @@
 
 #include <array>
 #include <atomic>
+#include <condition_variable>
 #include <mutex>
 #include <new>
+#include <thread>
 #include <unordered_map>
 
 namespace duckdb {
@@ -237,24 +239,43 @@ static idx_t CountObservations(const vector<MockS3RequestObservation> &observati
 	return result;
 }
 
+static idx_t CountExactObservations(const vector<MockS3RequestObservation> &observations, const string &method,
+                                    const string &key_id, int status, const string &range = string(),
+                                    const string &target_contains = string()) {
+	idx_t result = 0;
+	for (auto &observation : observations) {
+		if (observation.method == method && observation.key_id == key_id && observation.status == status &&
+		    observation.range == range &&
+		    (target_contains.empty() || observation.target.find(target_contains) != string::npos)) {
+			result++;
+		}
+	}
+	return result;
+}
+
+static int AuthFailureStatus(MockS3AuthFailure auth_failure) {
+	return auth_failure == MockS3AuthFailure::EXPIRED_TOKEN_400 ? 400 : 403;
+}
+
 template <class OPERATION>
-static vector<MockS3RequestObservation> RunRefreshScenario(MockS3RefreshTarget refresh_target,
-                                                           const string &client_implementation, bool connection_caching,
-                                                           OPERATION operation) {
+static vector<MockS3RequestObservation>
+RunRefreshScenario(MockS3RefreshTarget refresh_target, const string &client_implementation, bool connection_caching,
+                   OPERATION operation, MockS3AuthFailure auth_failure = MockS3AuthFailure::ACCESS_DENIED_403) {
 	MockS3ServerConfig config;
 	config.bucket = BUCKET;
 	config.object_key = OBJECT_KEY;
 	config.stale_key_id = STALE_KEY_ID;
 	config.refresh_target = refresh_target;
+	config.auth_failure = auth_failure;
 	auto object_data = config.object_data;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
 	Connection con(db);
 	auto test_id = ConfigureRefreshTest(db, con, server, client_implementation, connection_caching);
-	INFO(StringUtil::Format("refresh target: %s, client: %s, connection caching: %s",
-	                        MockS3RefreshTargetName(refresh_target), client_implementation,
-	                        connection_caching ? "true" : "false"));
+	INFO(StringUtil::Format("refresh target: %s, stale status: %d, client: %s, connection caching: %s",
+	                        MockS3RefreshTargetName(refresh_target), AuthFailureStatus(auth_failure),
+	                        client_implementation, connection_caching ? "true" : "false"));
 	RequireQueryOk(con, "BEGIN TRANSACTION");
 	operation(con, object_data);
 	RequireQueryOk(con, "COMMIT");
@@ -270,30 +291,50 @@ static void OpenForRead(Connection &con, FileOpenFlags flags = FileFlags::FILE_F
 	REQUIRE(handle);
 }
 
-static void RunHeadRefreshScenario(const string &client_implementation, bool connection_caching) {
+static void RequireFullGetThrows(Connection &con) {
+	bool threw = false;
+	try {
+		auto &fs = FileSystem::GetFileSystem(*con.context);
+		auto handle = fs.OpenFile(S3_PATH, FileFlags::FILE_FLAGS_READ);
+		string buffer(8, '\0');
+		handle->Read(QueryContext(*con.context), &buffer[0], buffer.size(), 0);
+	} catch (std::exception &) {
+		threw = true;
+	}
+	REQUIRE(threw);
+}
+
+static void RunHeadRefreshScenario(const string &client_implementation, bool connection_caching,
+                                   MockS3AuthFailure auth_failure = MockS3AuthFailure::ACCESS_DENIED_403) {
 	auto observations = RunRefreshScenario(
-	    MockS3RefreshTarget::HEAD, client_implementation, connection_caching, [](Connection &con, const string &) {
+	    MockS3RefreshTarget::HEAD, client_implementation, connection_caching,
+	    [](Connection &con, const string &) {
 		    OpenForRead(con, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
-	    });
-	REQUIRE(MockS3HasObservation(observations, "HEAD", STALE_KEY_ID, 403));
-	REQUIRE(MockS3HasObservation(observations, "HEAD", FRESH_KEY_ID, 200));
+	    },
+	    auth_failure);
+	REQUIRE(CountExactObservations(observations, "HEAD", STALE_KEY_ID, AuthFailureStatus(auth_failure)) == 1);
+	REQUIRE(CountExactObservations(observations, "HEAD", FRESH_KEY_ID, 200) == 1);
 }
 
-static void RunFullGetRefreshScenario(const string &client_implementation, bool connection_caching) {
-	auto observations = RunRefreshScenario(MockS3RefreshTarget::FULL_GET, client_implementation, connection_caching,
-	                                       [](Connection &con, const string &object_data) {
-		                                       RequireQueryOk(con, "SET force_download=true");
-		                                       auto &fs = FileSystem::GetFileSystem(*con.context);
-		                                       auto handle = fs.OpenFile(S3_PATH, FileFlags::FILE_FLAGS_READ);
-		                                       string buffer(8, '\0');
-		                                       handle->Read(QueryContext(*con.context), &buffer[0], buffer.size(), 0);
-		                                       REQUIRE(buffer == object_data.substr(0, buffer.size()));
-	                                       });
-	REQUIRE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 403));
-	REQUIRE(MockS3HasObservation(observations, "GET", FRESH_KEY_ID, 200));
+static void RunFullGetRefreshScenario(const string &client_implementation, bool connection_caching,
+                                      MockS3AuthFailure auth_failure = MockS3AuthFailure::ACCESS_DENIED_403) {
+	auto observations = RunRefreshScenario(
+	    MockS3RefreshTarget::FULL_GET, client_implementation, connection_caching,
+	    [](Connection &con, const string &object_data) {
+		    RequireQueryOk(con, "SET force_download=true");
+		    auto &fs = FileSystem::GetFileSystem(*con.context);
+		    auto handle = fs.OpenFile(S3_PATH, FileFlags::FILE_FLAGS_READ);
+		    string buffer(8, '\0');
+		    handle->Read(QueryContext(*con.context), &buffer[0], buffer.size(), 0);
+		    REQUIRE(buffer == object_data.substr(0, buffer.size()));
+	    },
+	    auth_failure);
+	REQUIRE(CountExactObservations(observations, "GET", STALE_KEY_ID, AuthFailureStatus(auth_failure)) == 1);
+	REQUIRE(CountExactObservations(observations, "GET", FRESH_KEY_ID, 200) == 1);
 }
 
-static void RunRangeRefreshScenario(const string &client_implementation, bool connection_caching) {
+static void RunRangeRefreshScenario(const string &client_implementation, bool connection_caching,
+                                    MockS3AuthFailure auth_failure = MockS3AuthFailure::ACCESS_DENIED_403) {
 	auto observations = RunRefreshScenario(
 	    MockS3RefreshTarget::RANGE_GET, client_implementation, connection_caching,
 	    [](Connection &con, const string &object_data) {
@@ -311,24 +352,30 @@ static void RunRangeRefreshScenario(const string &client_implementation, bool co
 		    string second_buffer(second_read_size, '\0');
 		    handle->Read(QueryContext(*con.context), &second_buffer[0], second_read_size, second_offset);
 		    REQUIRE(second_buffer == object_data.substr(second_offset, second_read_size));
-	    });
-	REQUIRE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 403, "bytes=7-15"));
-	REQUIRE(MockS3HasObservation(observations, "GET", FRESH_KEY_ID, 206, "bytes=7-15"));
-	REQUIRE(MockS3HasObservation(observations, "GET", FRESH_KEY_ID, 206, "bytes=20-24"));
-	REQUIRE_FALSE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 403, "bytes=20-24"));
+	    },
+	    auth_failure);
+	REQUIRE(CountExactObservations(observations, "GET", STALE_KEY_ID, AuthFailureStatus(auth_failure), "bytes=7-15") ==
+	        1);
+	REQUIRE(CountExactObservations(observations, "GET", FRESH_KEY_ID, 206, "bytes=7-15") == 1);
+	REQUIRE(CountExactObservations(observations, "GET", FRESH_KEY_ID, 206, "bytes=20-24") == 1);
+	REQUIRE(CountExactObservations(observations, "GET", STALE_KEY_ID, AuthFailureStatus(auth_failure), "bytes=20-24") ==
+	        0);
 }
 
-static void RunPutRefreshScenario(const string &client_implementation, bool connection_caching) {
+static void RunPutRefreshScenario(const string &client_implementation, bool connection_caching,
+                                  MockS3AuthFailure auth_failure = MockS3AuthFailure::ACCESS_DENIED_403) {
 	auto observations = RunRefreshScenario(
-	    MockS3RefreshTarget::PUT, client_implementation, connection_caching, [](Connection &con, const string &) {
+	    MockS3RefreshTarget::PUT, client_implementation, connection_caching,
+	    [](Connection &con, const string &) {
 		    auto &fs = FileSystem::GetFileSystem(*con.context);
 		    auto handle = fs.OpenFile(S3_PATH, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
 		    string payload = "hello from httpfs refresh";
 		    handle->Write(QueryContext(*con.context), &payload[0], payload.size());
 		    handle->Close();
-	    });
-	REQUIRE(MockS3HasObservation(observations, "PUT", STALE_KEY_ID, 403));
-	REQUIRE(MockS3HasObservation(observations, "PUT", FRESH_KEY_ID, 200));
+	    },
+	    auth_failure);
+	REQUIRE(CountExactObservations(observations, "PUT", STALE_KEY_ID, AuthFailureStatus(auth_failure)) == 1);
+	REQUIRE(CountExactObservations(observations, "PUT", FRESH_KEY_ID, 200) == 1);
 }
 
 static void WriteMultipartPayload(Connection &con) {
@@ -351,33 +398,43 @@ static void WriteSinglePutPayload(Connection &con) {
 	handle->Close();
 }
 
-static void RunMultipartInitiatePostRefreshScenario(const string &client_implementation, bool connection_caching) {
-	auto observations =
-	    RunRefreshScenario(MockS3RefreshTarget::MULTIPART_INITIATE_POST, client_implementation, connection_caching,
-	                       [](Connection &con, const string &) { WriteMultipartPayload(con); });
-	REQUIRE(MockS3HasObservation(observations, "POST", STALE_KEY_ID, 403, string(), "uploads"));
-	REQUIRE(MockS3HasObservation(observations, "POST", FRESH_KEY_ID, 200, string(), "uploads"));
-	REQUIRE(MockS3HasObservation(observations, "POST", FRESH_KEY_ID, 200, string(), "uploadId"));
+static void
+RunMultipartInitiatePostRefreshScenario(const string &client_implementation, bool connection_caching,
+                                        MockS3AuthFailure auth_failure = MockS3AuthFailure::ACCESS_DENIED_403) {
+	auto observations = RunRefreshScenario(
+	    MockS3RefreshTarget::MULTIPART_INITIATE_POST, client_implementation, connection_caching,
+	    [](Connection &con, const string &) { WriteMultipartPayload(con); }, auth_failure);
+	REQUIRE(CountExactObservations(observations, "POST", STALE_KEY_ID, AuthFailureStatus(auth_failure), string(),
+	                               "uploads") == 1);
+	REQUIRE(CountExactObservations(observations, "POST", FRESH_KEY_ID, 200, string(), "uploads") == 1);
+	REQUIRE(CountExactObservations(observations, "POST", FRESH_KEY_ID, 200, string(), "uploadId") == 1);
 }
 
-static void RunMultipartCompletePostRefreshScenario(const string &client_implementation, bool connection_caching) {
-	auto observations =
-	    RunRefreshScenario(MockS3RefreshTarget::MULTIPART_COMPLETE_POST, client_implementation, connection_caching,
-	                       [](Connection &con, const string &) { WriteMultipartPayload(con); });
-	REQUIRE(MockS3HasObservation(observations, "POST", STALE_KEY_ID, 403, string(), "uploadId"));
-	REQUIRE(MockS3HasObservation(observations, "POST", FRESH_KEY_ID, 200, string(), "uploadId"));
+static void
+RunMultipartCompletePostRefreshScenario(const string &client_implementation, bool connection_caching,
+                                        MockS3AuthFailure auth_failure = MockS3AuthFailure::ACCESS_DENIED_403) {
+	auto observations = RunRefreshScenario(
+	    MockS3RefreshTarget::MULTIPART_COMPLETE_POST, client_implementation, connection_caching,
+	    [](Connection &con, const string &) { WriteMultipartPayload(con); }, auth_failure);
+	REQUIRE(CountExactObservations(observations, "POST", STALE_KEY_ID, AuthFailureStatus(auth_failure), string(),
+	                               "uploadId") == 1);
+	REQUIRE(CountExactObservations(observations, "POST", FRESH_KEY_ID, 200, string(), "uploadId") == 1);
 }
 
-static void RunBulkDeletePostRefreshScenario(const string &client_implementation, bool connection_caching) {
-	auto observations = RunRefreshScenario(MockS3RefreshTarget::BULK_DELETE_POST, client_implementation,
-	                                       connection_caching, [](Connection &con, const string &) {
-		                                       auto &fs = FileSystem::GetFileSystem(*con.context);
-		                                       vector<string> paths;
-		                                       paths.push_back(S3_PATH);
-		                                       fs.RemoveFiles(paths);
-	                                       });
-	REQUIRE(MockS3HasObservation(observations, "POST", STALE_KEY_ID, 403, string(), "delete"));
-	REQUIRE(MockS3HasObservation(observations, "POST", FRESH_KEY_ID, 200, string(), "delete"));
+static void RunBulkDeletePostRefreshScenario(const string &client_implementation, bool connection_caching,
+                                             MockS3AuthFailure auth_failure = MockS3AuthFailure::ACCESS_DENIED_403) {
+	auto observations = RunRefreshScenario(
+	    MockS3RefreshTarget::BULK_DELETE_POST, client_implementation, connection_caching,
+	    [](Connection &con, const string &) {
+		    auto &fs = FileSystem::GetFileSystem(*con.context);
+		    vector<string> paths;
+		    paths.push_back(S3_PATH);
+		    fs.RemoveFiles(paths);
+	    },
+	    auth_failure);
+	REQUIRE(CountExactObservations(observations, "POST", STALE_KEY_ID, AuthFailureStatus(auth_failure), string(),
+	                               "delete") == 1);
+	REQUIRE(CountExactObservations(observations, "POST", FRESH_KEY_ID, 200, string(), "delete") == 1);
 }
 
 static void RunBulkDeleteEndpointRefreshScenario(const string &client_implementation) {
@@ -412,29 +469,35 @@ static void RunBulkDeleteEndpointRefreshScenario(const string &client_implementa
 	REQUIRE(CountObservations(fresh_observations, "POST", STALE_KEY_ID, 200) == 1);
 }
 
-static void RunDeleteRefreshScenario(const string &client_implementation, bool connection_caching) {
-	auto observations = RunRefreshScenario(MockS3RefreshTarget::DELETE_OBJECT, client_implementation,
-	                                       connection_caching, [](Connection &con, const string &) {
-		                                       auto &fs = FileSystem::GetFileSystem(*con.context);
-		                                       fs.RemoveFile(S3_PATH);
-	                                       });
-	REQUIRE(MockS3HasObservation(observations, "DELETE", STALE_KEY_ID, 403));
-	REQUIRE(MockS3HasObservation(observations, "DELETE", FRESH_KEY_ID, 204));
+static void RunDeleteRefreshScenario(const string &client_implementation, bool connection_caching,
+                                     MockS3AuthFailure auth_failure = MockS3AuthFailure::ACCESS_DENIED_403) {
+	auto observations = RunRefreshScenario(
+	    MockS3RefreshTarget::DELETE_OBJECT, client_implementation, connection_caching,
+	    [](Connection &con, const string &) {
+		    auto &fs = FileSystem::GetFileSystem(*con.context);
+		    fs.RemoveFile(S3_PATH);
+	    },
+	    auth_failure);
+	REQUIRE(CountExactObservations(observations, "DELETE", STALE_KEY_ID, AuthFailureStatus(auth_failure)) == 1);
+	REQUIRE(CountExactObservations(observations, "DELETE", FRESH_KEY_ID, 204) == 1);
 }
 
-static void RunListGlobRefreshScenario(const string &client_implementation, bool connection_caching) {
-	auto observations =
-	    RunRefreshScenario(MockS3RefreshTarget::LIST_OBJECTS_GET, client_implementation, connection_caching,
-	                       [](Connection &con, const string &) {
-		                       auto result = con.Query("SELECT file FROM glob('s3://refresh-bucket/object*.bin')");
-		                       REQUIRE(result);
-		                       INFO((result->HasError() ? result->GetError() : string()));
-		                       REQUIRE_FALSE(result->HasError());
-		                       REQUIRE(result->RowCount() == 1);
-		                       REQUIRE(result->GetValue(0, 0).ToString() == S3_PATH);
-	                       });
-	REQUIRE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 403, string(), "list-type=2"));
-	REQUIRE(MockS3HasObservation(observations, "GET", FRESH_KEY_ID, 200, string(), "list-type=2"));
+static void RunListGlobRefreshScenario(const string &client_implementation, bool connection_caching,
+                                       MockS3AuthFailure auth_failure = MockS3AuthFailure::ACCESS_DENIED_403) {
+	auto observations = RunRefreshScenario(
+	    MockS3RefreshTarget::LIST_OBJECTS_GET, client_implementation, connection_caching,
+	    [](Connection &con, const string &) {
+		    auto result = con.Query("SELECT file FROM glob('s3://refresh-bucket/object*.bin')");
+		    REQUIRE(result);
+		    INFO((result->HasError() ? result->GetError() : string()));
+		    REQUIRE_FALSE(result->HasError());
+		    REQUIRE(result->RowCount() == 1);
+		    REQUIRE(result->GetValue(0, 0).ToString() == S3_PATH);
+	    },
+	    auth_failure);
+	REQUIRE(CountExactObservations(observations, "GET", STALE_KEY_ID, AuthFailureStatus(auth_failure), string(),
+	                               "list-type=2") == 1);
+	REQUIRE(CountExactObservations(observations, "GET", FRESH_KEY_ID, 200, string(), "list-type=2") == 1);
 }
 
 static void RunAllRequestRefreshScenarios(const string &client_implementation, bool connection_caching) {
@@ -456,12 +519,142 @@ static void RunHandleRequestRefreshScenarios(const string &client_implementation
 	RunDeleteRefreshScenario(client_implementation, connection_caching);
 }
 
-static void RunRangeRefreshDisabledScenario() {
+static void RunExpiredTokenRefreshScenarios(const string &client_implementation, bool connection_caching) {
+	auto auth_failure = MockS3AuthFailure::EXPIRED_TOKEN_400;
+	RunFullGetRefreshScenario(client_implementation, connection_caching, auth_failure);
+	RunRangeRefreshScenario(client_implementation, connection_caching, auth_failure);
+	RunPutRefreshScenario(client_implementation, connection_caching, auth_failure);
+	RunMultipartInitiatePostRefreshScenario(client_implementation, connection_caching, auth_failure);
+	RunMultipartCompletePostRefreshScenario(client_implementation, connection_caching, auth_failure);
+	RunBulkDeletePostRefreshScenario(client_implementation, connection_caching, auth_failure);
+	RunDeleteRefreshScenario(client_implementation, connection_caching, auth_failure);
+	RunListGlobRefreshScenario(client_implementation, connection_caching, auth_failure);
+}
+
+static void RunMalformedExpiredTokenNotRefreshedScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	config.refresh_target = MockS3RefreshTarget::FULL_GET;
+	config.auth_failure = MockS3AuthFailure::EXPIRED_TOKEN_400;
+	config.truncated_failure_body = true;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto test_id = ConfigureRefreshTest(db, con, server, client_implementation, false);
+
+	RequireQueryOk(con, "SET force_download=true");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	RequireFullGetThrows(con);
+	RequireQueryOk(con, "ROLLBACK");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(CountObservations(observations, "GET", STALE_KEY_ID, 400) == 1);
+	REQUIRE_FALSE(HasRequestWithKey(observations, FRESH_KEY_ID));
+	AssertNoRefresh(test_id);
+}
+
+static void RunPersistentExpiredTokenSingleRefreshScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	config.refresh_target = MockS3RefreshTarget::FULL_GET;
+	config.auth_failure = MockS3AuthFailure::EXPIRED_TOKEN_400;
+	config.reject_fresh_credentials = true;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto test_id = ConfigureRefreshTest(db, con, server, client_implementation, false);
+
+	RequireQueryOk(con, "SET force_download=true");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	RequireFullGetThrows(con);
+	RequireQueryOk(con, "ROLLBACK");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(CountObservations(observations, "GET", STALE_KEY_ID, 400) == 1);
+	REQUIRE(CountObservations(observations, "GET", FRESH_KEY_ID, 400) == 1);
+	AssertSingleRefresh(test_id);
+}
+
+enum class NegativeGetErrorBody : uint8_t { INVALID_REQUEST, TRUNCATED_XML, BODYLESS };
+
+static void RunNegativeGetErrorScenario(const string &client_implementation, bool range_request,
+                                        NegativeGetErrorBody error_body) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	// Use an auth target the read never exercises. These failures are injected independently of credentials.
+	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.transient_get_failures = 1000;
+	if (error_body == NegativeGetErrorBody::INVALID_REQUEST) {
+		config.failure_is_request_timeout = false;
+	} else if (error_body == NegativeGetErrorBody::TRUNCATED_XML) {
+		config.truncated_failure_body = true;
+	} else {
+		config.bodyless_failure = true;
+	}
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto test_id = ConfigureRefreshTest(db, con, server, client_implementation, false);
+
+	RequireQueryOk(con, "SET http_retries=3");
+	RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	if (!range_request) {
+		RequireQueryOk(con, "SET force_download=true");
+	}
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	const idx_t offset = range_request ? 7 : 0;
+	const idx_t read_size = range_request ? 9 : 8;
+	string buffer(read_size, '#');
+	bool threw = false;
+	try {
+		auto &fs = FileSystem::GetFileSystem(*con.context);
+		FileOpenFlags flags = FileFlags::FILE_FLAGS_READ;
+		if (range_request) {
+			flags |= FileFlags::FILE_FLAGS_DIRECT_IO;
+		}
+		auto handle = fs.OpenFile(S3_PATH, flags);
+		handle->Read(QueryContext(*con.context), &buffer[0], buffer.size(), offset);
+	} catch (std::exception &) {
+		threw = true;
+	}
+	REQUIRE(threw);
+	REQUIRE(buffer == string(read_size, '#'));
+	RequireQueryOk(con, "ROLLBACK");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	auto range = range_request ? "bytes=7-15" : string();
+	REQUIRE(CountExactObservations(observations, "GET", STALE_KEY_ID, 400, range) == 1);
+	REQUIRE_FALSE(HasRequestWithKey(observations, FRESH_KEY_ID));
+	AssertNoRefresh(test_id);
+}
+
+static void RunAllNegativeGetErrorScenarios(const string &client_implementation) {
+	for (auto error_body :
+	     {NegativeGetErrorBody::INVALID_REQUEST, NegativeGetErrorBody::TRUNCATED_XML, NegativeGetErrorBody::BODYLESS}) {
+		RunNegativeGetErrorScenario(client_implementation, false, error_body);
+		RunNegativeGetErrorScenario(client_implementation, true, error_body);
+	}
+}
+
+static void RunRangeRefreshDisabledScenario(MockS3AuthFailure auth_failure = MockS3AuthFailure::ACCESS_DENIED_403) {
 	MockS3ServerConfig config;
 	config.bucket = BUCKET;
 	config.object_key = OBJECT_KEY;
 	config.stale_key_id = STALE_KEY_ID;
 	config.refresh_target = MockS3RefreshTarget::RANGE_GET;
+	config.auth_failure = auth_failure;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -480,17 +673,19 @@ static void RunRangeRefreshDisabledScenario() {
 
 	auto observations = server.Observations();
 	INFO(MockS3DescribeObservations(observations));
-	REQUIRE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 403, "bytes=7-15"));
+	REQUIRE(CountExactObservations(observations, "GET", STALE_KEY_ID, AuthFailureStatus(auth_failure), "bytes=7-15") ==
+	        1);
 	REQUIRE_FALSE(HasRequestWithKey(observations, FRESH_KEY_ID));
 	AssertNoRefresh(test_id);
 }
 
-static void RunListGlobRefreshDisabledScenario() {
+static void RunListGlobRefreshDisabledScenario(MockS3AuthFailure auth_failure = MockS3AuthFailure::ACCESS_DENIED_403) {
 	MockS3ServerConfig config;
 	config.bucket = BUCKET;
 	config.object_key = OBJECT_KEY;
 	config.stale_key_id = STALE_KEY_ID;
 	config.refresh_target = MockS3RefreshTarget::LIST_OBJECTS_GET;
+	config.auth_failure = auth_failure;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
@@ -505,17 +700,48 @@ static void RunListGlobRefreshDisabledScenario() {
 
 	auto observations = server.Observations();
 	INFO(MockS3DescribeObservations(observations));
-	REQUIRE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 403, string(), "list-type=2"));
+	REQUIRE(CountExactObservations(observations, "GET", STALE_KEY_ID, AuthFailureStatus(auth_failure), string(),
+	                               "list-type=2") == 1);
 	REQUIRE_FALSE(HasRequestWithKey(observations, FRESH_KEY_ID));
 	AssertNoRefresh(test_id);
 }
 
-static void RunMultipleStaleHandlesSingleRefreshScenario() {
+static void RunHeadExpiredTokenFallbackScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	config.refresh_target = MockS3RefreshTarget::HEAD_AND_RANGE_GET;
+	config.auth_failure = MockS3AuthFailure::EXPIRED_TOKEN_400;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto test_id = ConfigureRefreshTest(db, con, server, client_implementation, false);
+
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	OpenForRead(con, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	RequireQueryOk(con, "COMMIT");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	// HEAD bodies are unavailable, so the HEAD itself must not refresh. The stale range fallback carries the XML body.
+	REQUIRE(CountExactObservations(observations, "HEAD", STALE_KEY_ID, 400) == 1);
+	REQUIRE(CountExactObservations(observations, "HEAD", FRESH_KEY_ID, 200) == 0);
+	REQUIRE(CountExactObservations(observations, "GET", STALE_KEY_ID, 400, "bytes=0-1") == 1);
+	REQUIRE(CountExactObservations(observations, "GET", FRESH_KEY_ID, 206, "bytes=0-1") == 1);
+	AssertSingleRefresh(test_id);
+}
+
+static void RunConcurrentStaleHandlesSingleRefreshScenario() {
+	static constexpr idx_t HANDLE_COUNT = 4;
 	MockS3ServerConfig config;
 	config.bucket = BUCKET;
 	config.object_key = OBJECT_KEY;
 	config.stale_key_id = STALE_KEY_ID;
 	config.refresh_target = MockS3RefreshTarget::RANGE_GET;
+	config.auth_failure = MockS3AuthFailure::EXPIRED_TOKEN_400;
+	config.auth_failure_barrier_count = HANDLE_COUNT;
 	auto object_data = config.object_data;
 	MockS3Server server(std::move(config));
 
@@ -526,24 +752,57 @@ static void RunMultipleStaleHandlesSingleRefreshScenario() {
 	RequireQueryOk(con, "BEGIN TRANSACTION");
 	auto &fs = FileSystem::GetFileSystem(*con.context);
 	vector<unique_ptr<FileHandle>> handles;
-	for (idx_t i = 0; i < 4; i++) {
+	for (idx_t i = 0; i < HANDLE_COUNT; i++) {
 		handles.push_back(fs.OpenFile(S3_PATH, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO));
 		REQUIRE(handles.back());
 	}
 
 	const idx_t offset = 7;
 	const idx_t read_size = 9;
-	for (auto &handle : handles) {
-		string buffer(read_size, '\0');
-		handle->Read(QueryContext(*con.context), &buffer[0], read_size, offset);
-		REQUIRE(buffer == object_data.substr(offset, read_size));
+	vector<string> buffers(HANDLE_COUNT, string(read_size, '\0'));
+	vector<string> errors(HANDLE_COUNT);
+	std::mutex start_lock;
+	std::condition_variable start_cv;
+	idx_t ready = 0;
+	bool start = false;
+	vector<std::thread> threads;
+	for (idx_t i = 0; i < HANDLE_COUNT; i++) {
+		threads.emplace_back([&, i]() {
+			{
+				std::unique_lock<std::mutex> lock(start_lock);
+				ready++;
+				start_cv.notify_all();
+				start_cv.wait(lock, [&]() { return start; });
+			}
+			try {
+				handles[i]->Read(QueryContext(*con.context), &buffers[i][0], read_size, offset);
+			} catch (std::exception &ex) {
+				errors[i] = ex.what();
+			} catch (...) {
+				errors[i] = "unknown exception";
+			}
+		});
+	}
+	{
+		std::unique_lock<std::mutex> lock(start_lock);
+		start_cv.wait(lock, [&]() { return ready == HANDLE_COUNT; });
+		start = true;
+		start_cv.notify_all();
+	}
+	for (auto &thread : threads) {
+		thread.join();
+	}
+	for (idx_t i = 0; i < HANDLE_COUNT; i++) {
+		INFO(errors[i]);
+		REQUIRE(errors[i].empty());
+		REQUIRE(buffers[i] == object_data.substr(offset, read_size));
 	}
 	RequireQueryOk(con, "COMMIT");
 
 	auto observations = server.Observations();
 	INFO(MockS3DescribeObservations(observations));
-	REQUIRE(CountObservations(observations, "GET", STALE_KEY_ID, 403) >= handles.size());
-	REQUIRE(CountObservations(observations, "GET", FRESH_KEY_ID, 206) == handles.size());
+	REQUIRE(CountExactObservations(observations, "GET", STALE_KEY_ID, 400, "bytes=7-15") == HANDLE_COUNT);
+	REQUIRE(CountExactObservations(observations, "GET", FRESH_KEY_ID, 206, "bytes=7-15") == HANDLE_COUNT);
 	AssertSingleRefresh(test_id);
 }
 
@@ -559,7 +818,7 @@ static void RunTransientPutRetryScenario(const string &client_implementation) {
 
 	DuckDB db(nullptr);
 	Connection con(db);
-	ConfigureRefreshTest(db, con, server, client_implementation, false);
+	auto test_id = ConfigureRefreshTest(db, con, server, client_implementation, false);
 
 	RequireQueryOk(con, "SET http_retries=3");
 	RequireQueryOk(con, "SET http_retry_wait_ms=1");
@@ -574,6 +833,7 @@ static void RunTransientPutRetryScenario(const string &client_implementation) {
 	REQUIRE(MockS3HasObservation(observations, "PUT", STALE_KEY_ID, 200, string(), "partNumber"));
 	// The multipart upload completed successfully.
 	REQUIRE(MockS3HasObservation(observations, "POST", STALE_KEY_ID, 200, string(), "uploadId"));
+	AssertNoRefresh(test_id);
 }
 
 static idx_t CountObservationsTarget(const vector<MockS3RequestObservation> &observations, const string &method,
@@ -602,7 +862,7 @@ static void RunGenericErrorNotRetriedScenario(const string &client_implementatio
 
 	DuckDB db(nullptr);
 	Connection con(db);
-	ConfigureRefreshTest(db, con, server, client_implementation, false);
+	auto test_id = ConfigureRefreshTest(db, con, server, client_implementation, false);
 
 	RequireQueryOk(con, "SET http_retries=3");
 	RequireQueryOk(con, "SET http_retry_wait_ms=1");
@@ -613,6 +873,51 @@ static void RunGenericErrorNotRetriedScenario(const string &client_implementatio
 	auto observations = server.Observations();
 	INFO(MockS3DescribeObservations(observations));
 	REQUIRE(CountObservations(observations, "PUT", STALE_KEY_ID, 400) == 1);
+	AssertNoRefresh(test_id);
+}
+
+static void RunGenericGetErrorBodyScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.transient_get_failures = 1000;
+	config.failure_is_request_timeout = false;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto test_id = ConfigureRefreshTest(db, con, server, client_implementation, false, false);
+
+	RequireQueryOk(con, "SET http_retries=3");
+	RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	RequireQueryOk(con, "SET force_download=true");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	bool threw = false;
+	string response_body;
+	try {
+		auto &fs = FileSystem::GetFileSystem(*con.context);
+		auto handle = fs.OpenFile(S3_PATH, FileFlags::FILE_FLAGS_READ);
+		string buffer(8, '\0');
+		handle->Read(QueryContext(*con.context), &buffer[0], buffer.size(), 0);
+	} catch (std::exception &ex) {
+		threw = true;
+		ErrorData error(ex);
+		auto entry = error.ExtraInfo().find("response_body");
+		if (entry != error.ExtraInfo().end()) {
+			response_body = entry->second;
+		}
+	}
+	REQUIRE(threw);
+	REQUIRE(response_body.find("<Code>InvalidRequest</Code>") != string::npos);
+	RequireQueryOk(con, "ROLLBACK");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(CountObservations(observations, "GET", STALE_KEY_ID, 400) == 1);
+	REQUIRE_FALSE(HasRequestWithKey(observations, FRESH_KEY_ID));
+	AssertNoRefresh(test_id);
 }
 
 // A truncated error body (an open <Code> with no closing tag) must degrade to a plain HTTP error:
@@ -670,7 +975,20 @@ static void RunMultipartInitNotRetriedScenario(const string &client_implementati
 	RequireQueryOk(con, "SET http_retries=3");
 	RequireQueryOk(con, "SET http_retry_wait_ms=1");
 	RequireQueryOk(con, "BEGIN TRANSACTION");
-	REQUIRE_THROWS(WriteMultipartPayload(con));
+	bool threw = false;
+	string response_body;
+	try {
+		WriteMultipartPayload(con);
+	} catch (std::exception &ex) {
+		threw = true;
+		ErrorData error(ex);
+		auto entry = error.ExtraInfo().find("response_body");
+		if (entry != error.ExtraInfo().end()) {
+			response_body = entry->second;
+		}
+	}
+	REQUIRE(threw);
+	REQUIRE(response_body.find("<Code>RequestTimeout</Code>") != string::npos);
 	RequireQueryOk(con, "ROLLBACK");
 
 	auto observations = server.Observations();
@@ -755,7 +1073,7 @@ static void RunTransientGetRetryScenario(const string &client_implementation) {
 
 	DuckDB db(nullptr);
 	Connection con(db);
-	ConfigureRefreshTest(db, con, server, client_implementation, false);
+	auto test_id = ConfigureRefreshTest(db, con, server, client_implementation, false);
 
 	RequireQueryOk(con, "SET http_retries=3");
 	RequireQueryOk(con, "SET http_retry_wait_ms=1");
@@ -771,8 +1089,42 @@ static void RunTransientGetRetryScenario(const string &client_implementation) {
 	auto observations = server.Observations();
 	INFO(MockS3DescribeObservations(observations));
 	// The read hit transient RequestTimeout 400s and was retried until it succeeded.
-	REQUIRE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 400));
-	REQUIRE(MockS3HasObservation(observations, "GET", STALE_KEY_ID, 200));
+	REQUIRE(CountExactObservations(observations, "GET", STALE_KEY_ID, 400) == 2);
+	REQUIRE(CountExactObservations(observations, "GET", STALE_KEY_ID, 200) == 1);
+	AssertNoRefresh(test_id);
+}
+
+static void RunTransientRangeGetRetryScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.bucket = BUCKET;
+	config.object_key = OBJECT_KEY;
+	config.stale_key_id = STALE_KEY_ID;
+	config.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.transient_get_failures = 2;
+	auto object_data = config.object_data;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto test_id = ConfigureRefreshTest(db, con, server, client_implementation, false);
+
+	RequireQueryOk(con, "SET http_retries=3");
+	RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(S3_PATH, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	const idx_t offset = 7;
+	const idx_t read_size = 9;
+	string buffer(read_size, '\0');
+	handle->Read(QueryContext(*con.context), &buffer[0], buffer.size(), offset);
+	REQUIRE(buffer == object_data.substr(offset, read_size));
+	RequireQueryOk(con, "COMMIT");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(CountExactObservations(observations, "GET", STALE_KEY_ID, 400, "bytes=7-15") == 2);
+	REQUIRE(CountExactObservations(observations, "GET", STALE_KEY_ID, 206, "bytes=7-15") == 1);
+	AssertNoRefresh(test_id);
 }
 
 static void RunTransientDeleteRetryScenario(const string &client_implementation) {
@@ -924,11 +1276,17 @@ static void RunAllTransientRetryScenarios(const string &client_implementation) {
 	SECTION("object read retries and completes") {
 		RunTransientGetRetryScenario(client_implementation);
 	}
+	SECTION("range read retries and completes") {
+		RunTransientRangeGetRetryScenario(client_implementation);
+	}
 	SECTION("object delete retries and completes") {
 		RunTransientDeleteRetryScenario(client_implementation);
 	}
 	SECTION("a generic 400 is not retried") {
 		RunGenericErrorNotRetriedScenario(client_implementation);
+	}
+	SECTION("a generic GET 400 preserves its response body and is not retried") {
+		RunGenericGetErrorBodyScenario(client_implementation);
 	}
 	SECTION("a truncated error body is not retried and does not invalidate the database") {
 		RunTruncatedErrorBodyScenario(client_implementation);
@@ -973,17 +1331,65 @@ TEST_CASE("HTTPFS refreshes S3 credentials across request methods", "[httpfs][s3
 	}
 }
 
-TEST_CASE("HTTPFS can disable S3 credential refresh", "[httpfs][s3][refresh]") {
-	SECTION("range reads fail without refresh") {
-		RunRangeRefreshDisabledScenario();
+TEST_CASE("HTTPFS refreshes expired S3 credentials across request methods", "[httpfs][s3][refresh]") {
+	SECTION("httplib") {
+		RunExpiredTokenRefreshScenarios("httplib", false);
 	}
-	SECTION("list glob fails without refresh") {
-		RunListGlobRefreshDisabledScenario();
+	SECTION("curl") {
+		RunExpiredTokenRefreshScenarios("curl", false);
 	}
 }
 
-TEST_CASE("HTTPFS reuses one S3 credential refresh across stale handles", "[httpfs][s3][refresh]") {
-	RunMultipleStaleHandlesSingleRefreshScenario();
+TEST_CASE("HTTPFS bounds ExpiredToken credential refresh", "[httpfs][s3][refresh]") {
+	SECTION("malformed httplib response") {
+		RunMalformedExpiredTokenNotRefreshedScenario("httplib");
+	}
+	SECTION("malformed curl response") {
+		RunMalformedExpiredTokenNotRefreshedScenario("curl");
+	}
+	SECTION("persistent httplib response") {
+		RunPersistentExpiredTokenSingleRefreshScenario("httplib");
+	}
+	SECTION("persistent curl response") {
+		RunPersistentExpiredTokenSingleRefreshScenario("curl");
+	}
+}
+
+TEST_CASE("HTTPFS does not refresh non-auth S3 GET failures", "[httpfs][s3][refresh]") {
+	SECTION("httplib") {
+		RunAllNegativeGetErrorScenarios("httplib");
+	}
+	SECTION("curl") {
+		RunAllNegativeGetErrorScenarios("curl");
+	}
+}
+
+TEST_CASE("HTTPFS refreshes from the GET fallback after a bodyless HEAD ExpiredToken", "[httpfs][s3][refresh]") {
+	SECTION("httplib") {
+		RunHeadExpiredTokenFallbackScenario("httplib");
+	}
+	SECTION("curl") {
+		RunHeadExpiredTokenFallbackScenario("curl");
+	}
+}
+
+TEST_CASE("HTTPFS can disable S3 credential refresh", "[httpfs][s3][refresh]") {
+	SECTION("403 range reads fail without refresh") {
+		RunRangeRefreshDisabledScenario();
+	}
+	SECTION("403 list glob fails without refresh") {
+		RunListGlobRefreshDisabledScenario();
+	}
+	SECTION("ExpiredToken range reads fail without refresh") {
+		RunRangeRefreshDisabledScenario(MockS3AuthFailure::EXPIRED_TOKEN_400);
+	}
+	SECTION("ExpiredToken list glob fails without refresh") {
+		RunListGlobRefreshDisabledScenario(MockS3AuthFailure::EXPIRED_TOKEN_400);
+	}
+}
+
+TEST_CASE("HTTPFS single-flights concurrent S3 credential refresh", "[httpfs][s3][refresh]") {
+	RunConcurrentStaleHandlesSingleRefreshScenario();
 }
 
 TEST_CASE("HTTPFS bulk delete follows a refreshed S3 endpoint", "[httpfs][s3][refresh]") {

--- a/test/unittest/mock_s3_server.cpp
+++ b/test/unittest/mock_s3_server.cpp
@@ -6,6 +6,8 @@
 #include "httplib.hpp"
 
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <cstring>
 #include <mutex>
 #include <thread>
@@ -119,6 +121,8 @@ struct MockS3Server::Impl {
 		switch (config.refresh_target) {
 		case MockS3RefreshTarget::HEAD:
 			return request.method == "HEAD";
+		case MockS3RefreshTarget::HEAD_AND_RANGE_GET:
+			return request.method == "HEAD" || (request.method == "GET" && !range.empty());
 		case MockS3RefreshTarget::FULL_GET:
 			return request.method == "GET" && range.empty();
 		case MockS3RefreshTarget::RANGE_GET:
@@ -140,8 +144,9 @@ struct MockS3Server::Impl {
 		}
 	}
 
-	bool ShouldRejectStaleCredentials(const httplib::Request &request) const {
-		return ExtractCredentialKey(GetHeader(request, "Authorization")) == config.stale_key_id &&
+	bool ShouldRejectCredentials(const httplib::Request &request) const {
+		auto key_id = ExtractCredentialKey(GetHeader(request, "Authorization"));
+		return (key_id == config.stale_key_id || (config.reject_fresh_credentials && key_id == config.fresh_key_id)) &&
 		       MatchesRefreshTarget(request);
 	}
 
@@ -174,10 +179,37 @@ struct MockS3Server::Impl {
 		Record(request, response.status);
 	}
 
-	void SendForbidden(const httplib::Request &request, httplib::Response &response) const {
-		response.status = 403;
-		response.set_content("<Error><Code>AccessDenied</Code><Message>stale credentials</Message></Error>",
-		                     "application/xml");
+	void SendAuthFailure(const httplib::Request &request, httplib::Response &response) const {
+		if (config.auth_failure_barrier_count > 0 &&
+		    ExtractCredentialKey(GetHeader(request, "Authorization")) == config.stale_key_id) {
+			std::unique_lock<std::mutex> lock(auth_failure_barrier_lock);
+			auth_failures_waiting++;
+			if (auth_failures_waiting >= config.auth_failure_barrier_count) {
+				auth_failure_barrier_cv.notify_all();
+			} else {
+				if (!auth_failure_barrier_cv.wait_for(lock, std::chrono::seconds(5), [this]() {
+					    return auth_failures_waiting >= config.auth_failure_barrier_count ||
+					           auth_failure_barrier_aborted;
+				    })) {
+					auth_failure_barrier_aborted = true;
+					auth_failure_barrier_cv.notify_all();
+				}
+			}
+		}
+		if (config.auth_failure == MockS3AuthFailure::EXPIRED_TOKEN_400) {
+			response.status = 400;
+			if (config.truncated_failure_body) {
+				response.set_content("<Error><Code>ExpiredToken</Code>", "application/xml");
+			} else {
+				response.set_content("<Error><Code>ExpiredToken</Code>"
+				                     "<Message>The provided token has expired.</Message></Error>",
+				                     "application/xml");
+			}
+		} else {
+			response.status = 403;
+			response.set_content("<Error><Code>AccessDenied</Code><Message>stale credentials</Message></Error>",
+			                     "application/xml");
+		}
 		Record(request, response.status);
 	}
 
@@ -189,7 +221,9 @@ struct MockS3Server::Impl {
 
 	void SendS3Error400(const httplib::Request &request, httplib::Response &response, bool request_timeout) const {
 		response.status = 400;
-		if (config.truncated_failure_body) {
+		if (config.bodyless_failure) {
+			// Intentionally leave the response body empty.
+		} else if (config.truncated_failure_body) {
 			response.set_content("<?xml version=\"1.0\" encoding=\"UTF-8\"?><Error><Code>RequestTimeout",
 			                     "application/xml");
 		} else if (request_timeout) {
@@ -281,8 +315,8 @@ struct MockS3Server::Impl {
 			if (request.method != "HEAD" || request.path != path) {
 				return httplib::Server::HandlerResponse::Unhandled;
 			}
-			if (ShouldRejectStaleCredentials(request)) {
-				SendForbidden(request, response);
+			if (ShouldRejectCredentials(request)) {
+				SendAuthFailure(request, response);
 				return httplib::Server::HandlerResponse::Handled;
 			}
 			if (remaining_head_failures.load() > 0) {
@@ -297,8 +331,8 @@ struct MockS3Server::Impl {
 		});
 
 		server.Get(path, [this](const httplib::Request &request, httplib::Response &response) {
-			if (ShouldRejectStaleCredentials(request)) {
-				SendForbidden(request, response);
+			if (ShouldRejectCredentials(request)) {
+				SendAuthFailure(request, response);
 				return;
 			}
 			if (remaining_get_failures.load() > 0) {
@@ -364,8 +398,8 @@ struct MockS3Server::Impl {
 				Record(request, response.status);
 				return;
 			}
-			if (ShouldRejectStaleCredentials(request)) {
-				SendForbidden(request, response);
+			if (ShouldRejectCredentials(request)) {
+				SendAuthFailure(request, response);
 				return;
 			}
 			if (config.transient_503_lists > 0 && transient_503_lists_sent.fetch_add(1) < config.transient_503_lists) {
@@ -382,8 +416,8 @@ struct MockS3Server::Impl {
 		server.Get(bucket_path_with_slash, list_objects);
 
 		server.Put(path, [this](const httplib::Request &request, httplib::Response &response) {
-			if (ShouldRejectStaleCredentials(request)) {
-				SendForbidden(request, response);
+			if (ShouldRejectCredentials(request)) {
+				SendAuthFailure(request, response);
 				return;
 			}
 			if (remaining_put_failures.load() > 0) {
@@ -395,8 +429,8 @@ struct MockS3Server::Impl {
 		});
 
 		server.Post(path, [this](const httplib::Request &request, httplib::Response &response) {
-			if (ShouldRejectStaleCredentials(request)) {
-				SendForbidden(request, response);
+			if (ShouldRejectCredentials(request)) {
+				SendAuthFailure(request, response);
 				return;
 			}
 			if (request.target.find("uploads") != string::npos && remaining_post_failures.load() > 0) {
@@ -418,8 +452,8 @@ struct MockS3Server::Impl {
 		});
 
 		auto bulk_delete = [this](const httplib::Request &request, httplib::Response &response) {
-			if (ShouldRejectStaleCredentials(request)) {
-				SendForbidden(request, response);
+			if (ShouldRejectCredentials(request)) {
+				SendAuthFailure(request, response);
 				return;
 			}
 			SendBulkDeleteSuccess(request, response);
@@ -428,8 +462,8 @@ struct MockS3Server::Impl {
 		server.Post(bucket_path_with_slash, bulk_delete);
 
 		server.Delete(path, [this](const httplib::Request &request, httplib::Response &response) {
-			if (ShouldRejectStaleCredentials(request)) {
-				SendForbidden(request, response);
+			if (ShouldRejectCredentials(request)) {
+				SendAuthFailure(request, response);
 				return;
 			}
 			if (remaining_delete_failures.load() > 0) {
@@ -456,6 +490,10 @@ struct MockS3Server::Impl {
 	mutable std::atomic<idx_t> remaining_post_failures {0};
 	mutable std::atomic<idx_t> remaining_complete_post_failures {0};
 	mutable std::atomic<idx_t> remaining_complete_post_200_errors {0};
+	mutable std::mutex auth_failure_barrier_lock;
+	mutable std::condition_variable auth_failure_barrier_cv;
+	mutable idx_t auth_failures_waiting = 0;
+	mutable bool auth_failure_barrier_aborted = false;
 	mutable std::mutex observation_lock;
 	mutable vector<MockS3RequestObservation> observations;
 };
@@ -490,6 +528,8 @@ string MockS3RefreshTargetName(MockS3RefreshTarget target) {
 	switch (target) {
 	case MockS3RefreshTarget::HEAD:
 		return "HEAD";
+	case MockS3RefreshTarget::HEAD_AND_RANGE_GET:
+		return "HEAD_AND_RANGE_GET";
 	case MockS3RefreshTarget::FULL_GET:
 		return "FULL_GET";
 	case MockS3RefreshTarget::RANGE_GET:

--- a/test/unittest/mock_s3_server.hpp
+++ b/test/unittest/mock_s3_server.hpp
@@ -7,6 +7,7 @@ namespace duckdb {
 
 enum class MockS3RefreshTarget : uint8_t {
 	HEAD,
+	HEAD_AND_RANGE_GET,
 	FULL_GET,
 	RANGE_GET,
 	PUT,
@@ -17,6 +18,8 @@ enum class MockS3RefreshTarget : uint8_t {
 	LIST_OBJECTS_GET
 };
 
+enum class MockS3AuthFailure : uint8_t { ACCESS_DENIED_403, EXPIRED_TOKEN_400 };
+
 enum class MockS3RangeBehavior : uint8_t { NORMAL, IGNORE_RANGE, TRUNCATE_TRANSFER, SHORT_SUCCESS };
 
 struct MockS3ServerConfig {
@@ -24,8 +27,11 @@ struct MockS3ServerConfig {
 	string object_key = "object.bin";
 	string object_data = "abcdefghijklmnopqrstuvwxyz0123456789";
 	string stale_key_id = "STALE_KEY";
+	string fresh_key_id = "FRESH_KEY";
+	bool reject_fresh_credentials = false;
 	string etag = "\"httpfs-refresh-test-etag\"";
 	MockS3RefreshTarget refresh_target = MockS3RefreshTarget::HEAD;
+	MockS3AuthFailure auth_failure = MockS3AuthFailure::ACCESS_DENIED_403;
 	//! Answer this many leading ListObjectsV2 requests with HTTP 503 SlowDown
 	idx_t transient_503_lists = 0;
 	//! Answer this many leading ListObjectsV2 requests with HTTP 400
@@ -57,6 +63,10 @@ struct MockS3ServerConfig {
 	bool failure_is_request_timeout = true;
 	//! Whether injected 400 bodies are truncated mid-XML (an open <Code> with no closing tag)
 	bool truncated_failure_body = false;
+	//! Whether injected 400s carry no response body
+	bool bodyless_failure = false;
+	//! Hold stale auth failures until this many matching requests are concurrently waiting
+	idx_t auth_failure_barrier_count = 0;
 };
 
 struct MockS3RequestObservation {


### PR DESCRIPTION
Refresh on 400 with `ExpiredToken` in the body

EDIT1: this is already fixed on the `main` branch that will go into v2.0 :)
EDIT2: also fixed a flaky test