### PR TITLE
Implementing aborting writes

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -29,7 +29,7 @@ jobs:
       - prepare
     with:
       extension_name: httpfs
-      duckdb_version: 5366dc3925ce0f981c2110cf4bf8e39fa1dd6fde
+      duckdb_version: d99587345c05f20e036ff9088f0f0f69b775e410
       ci_tools_version: main
       runners: ${{ needs.prepare.outputs.runners }}
 
@@ -42,7 +42,7 @@ jobs:
     secrets: inherit
     with:
       extension_name: httpfs
-      duckdb_version: 5366dc3925ce0f981c2110cf4bf8e39fa1dd6fde
+      duckdb_version: d99587345c05f20e036ff9088f0f0f69b775e410
       ci_tools_version: main
       deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') }}
       deploy_versioned: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}
@@ -52,7 +52,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main
     with:
       extension_name: httpfs
-      duckdb_version: 5366dc3925ce0f981c2110cf4bf8e39fa1dd6fde
+      duckdb_version: d99587345c05f20e036ff9088f0f0f69b775e410
       ci_tools_version: main
       extra_toolchains: 'python3'
       format_checks: 'format'

--- a/src/include/s3/s3_upload_session.hpp
+++ b/src/include/s3/s3_upload_session.hpp
@@ -22,68 +22,30 @@ enum class RequestType : uint8_t;
 
 class S3UploadSession {
 private:
-	enum class FailureDisposition : uint8_t { DEFINITIVE, AMBIGUOUS };
-
-public:
-	class WriteClaim {
-		friend class S3UploadSession;
-
-	private:
-		explicit WriteClaim(S3UploadSession &session_p);
-
-	public:
-		WriteClaim(WriteClaim &&other) noexcept;
-		WriteClaim(const WriteClaim &) = delete;
-		WriteClaim &operator=(const WriteClaim &) = delete;
-		~WriteClaim();
-
-	public:
-		void Finish();
-
-	private:
-		[[noreturn]] void Fail(ErrorData error, FailureDisposition disposition);
-
-	private:
-		reference<S3UploadSession> session;
-		bool finished = false;
-	};
-
-public:
-	S3UploadSession(S3FileSystem &s3fs, shared_ptr<HTTPRequestSession> request_session, string path,
-	                S3UploadConfig config);
-	~S3UploadSession() noexcept;
-
-public:
-	WriteClaim Write(const_data_ptr_t data, idx_t size, idx_t location);
-	void Finalize();
-
-private:
+	//! Session, initialization, cleanup, and failure states.
+	enum class LifecycleState : uint8_t { ACTIVE, FINALIZING, FINALIZED, ABORTING, ABORTED };
 	enum class InitializationState : uint8_t { NOT_STARTED, IN_PROGRESS, SUCCEEDED, FAILED };
 	enum class CleanupState : uint8_t { NONE, IN_PROGRESS, COMPLETE };
+	enum class FailureDisposition : uint8_t { DEFINITIVE, AMBIGUOUS };
 
+	//! Latched upload failures.
 	struct FailureSnapshot {
 		shared_ptr<const ErrorData> primary_error;
 		shared_ptr<const ErrorData> abort_error;
 	};
 
+	//! Buffered write preparation.
 	struct BufferedPart {
 		BufferedPart(BufferHandle buffer_p, idx_t capacity_p) : buffer(std::move(buffer_p)), capacity(capacity_p) {
 		}
 
-	public:
 		data_ptr_t Ptr() {
 			return buffer.GetDataMutable();
 		}
 
-	public:
 		BufferHandle buffer;
 		const idx_t capacity;
 		idx_t size = 0;
-	};
-
-	struct MultipartSnapshot {
-		shared_ptr<const string> upload_id;
-		vector<string> etags;
 	};
 
 	struct PreparedPart {
@@ -95,7 +57,6 @@ private:
 		      size(buffered_part->size) {
 		}
 
-	public:
 		idx_t part_number;
 		unique_ptr<BufferedPart> buffered_part;
 		const_data_ptr_t data;
@@ -107,57 +68,114 @@ private:
 		unique_ptr<BufferedPart> buffered_part;
 	};
 
+	//! Multipart completion state.
+	struct MultipartSnapshot {
+		shared_ptr<const string> upload_id;
+		vector<string> etags;
+	};
+
+public:
+	//! Owns one admitted write until it finishes or fails.
+	class WriteClaim {
+		friend class S3UploadSession;
+
+	private:
+		explicit WriteClaim(S3UploadSession &session_p);
+
+	public:
+		//! Claim lifecycle.
+		WriteClaim(WriteClaim &&other) noexcept;
+		WriteClaim(const WriteClaim &) = delete;
+		WriteClaim &operator=(const WriteClaim &) = delete;
+		~WriteClaim();
+		void Finish();
+
+	private:
+		//! Failure publication.
+		[[noreturn]] void Fail(ErrorData error, FailureDisposition disposition);
+
+		//! Claimed session state.
+		reference<S3UploadSession> session;
+		bool finished = false;
+	};
+
+public:
+	//! Session lifecycle.
+	S3UploadSession(S3FileSystem &s3fs, shared_ptr<HTTPRequestSession> request_session, string path,
+	                S3UploadConfig config);
+	~S3UploadSession() noexcept;
+
+	//! Upload operations.
+	WriteClaim Write(const_data_ptr_t data, idx_t size, idx_t location);
+	void Finalize();
+	bool Abort();
+
 private:
+	//! Operation admission and lifecycle transitions.
 	void BeginWriteOperation() DUCKDB_EXCLUDES(state_lock);
-	PreparedWrite PrepareWrite(const_data_ptr_t data, idx_t size, idx_t location) DUCKDB_EXCLUDES(state_lock);
 	unique_ptr<BufferedPart> BeginFinalize(bool &already_finalized) DUCKDB_EXCLUDES(state_lock);
 	void ReleaseOperation() DUCKDB_EXCLUDES(state_lock);
 	void ReleaseWrite() DUCKDB_EXCLUDES(state_lock);
 	void ReleaseWriteNoThrow() noexcept DUCKDB_EXCLUDES(state_lock);
 	void FinishFinalize() DUCKDB_EXCLUDES(state_lock);
+
+	//! Failure publication and cleanup.
 	void LatchFailure(ErrorData error, FailureDisposition disposition) DUCKDB_EXCLUDES(state_lock);
 	void LatchFailureLocked(shared_ptr<const ErrorData> error, FailureDisposition disposition)
 	    DUCKDB_REQUIRES(state_lock);
 	[[noreturn]] void FailOperation(ErrorData error, FailureDisposition disposition) DUCKDB_EXCLUDES(state_lock);
 	FailureSnapshot CaptureFailure() const DUCKDB_REQUIRES(state_lock);
 	[[noreturn]] static void ThrowFailure(const FailureSnapshot &failure);
-	shared_ptr<const ErrorData> AbortMultipartUpload(const string &upload_id);
 	void ThrowIfFailed() DUCKDB_EXCLUDES(state_lock);
 
+	//! Buffered write construction.
+	PreparedWrite PrepareWrite(const_data_ptr_t data, idx_t size, idx_t location) DUCKDB_EXCLUDES(state_lock);
 	unique_ptr<BufferedPart> AllocateBufferedPart(idx_t capacity);
 	static idx_t AppendToBufferedPart(BufferedPart &buffered_part, const_data_ptr_t data, idx_t size);
 	void ReservePart(PreparedWrite &write, const_data_ptr_t data, idx_t size) DUCKDB_REQUIRES(state_lock);
 	void ReservePart(PreparedWrite &write, unique_ptr<BufferedPart> buffered_part) DUCKDB_REQUIRES(state_lock);
+
+	//! Multipart initialization and completion.
 	shared_ptr<const string> EnsureMultipartUpload();
 	void PublishInitializationFailure(ErrorData error, FailureDisposition disposition) DUCKDB_EXCLUDES(state_lock);
 	string InitializeMultipartUpload();
+	void StorePartETag(idx_t part_number, string etag) DUCKDB_EXCLUDES(state_lock);
+	MultipartSnapshot GetMultipartSnapshot() DUCKDB_EXCLUDES(state_lock);
+	void CompleteMultipartUpload();
+
+	//! S3 upload and cleanup requests.
 	string Upload(const_data_ptr_t data, idx_t size, const S3RequestQuery &query);
 	void UploadPart(PreparedPart &part);
 	void UploadSingle(BufferedPart &buffered_part);
 	void UploadEmpty();
-	void StorePartETag(idx_t part_number, string etag) DUCKDB_EXCLUDES(state_lock);
-	MultipartSnapshot GetMultipartSnapshot() DUCKDB_EXCLUDES(state_lock);
-	void CompleteMultipartUpload();
+	shared_ptr<const ErrorData> AbortMultipartUpload(const string &upload_id);
+
+	//! Request diagnostics.
 	string GetDisplayPath() const;
 	static HTTPException GetStatusError(const HTTPResponse &response, const S3RequestContext &request_context,
 	                                    const string &operation);
 
 private:
+	//! Immutable upload context.
 	reference<S3FileSystem> s3fs;
 	shared_ptr<HTTPRequestSession> request_session;
 	const string path;
 	const S3UploadConfig config;
 
+	//! Operation and lifecycle synchronization.
 	annotated_mutex state_lock;
 	std::condition_variable state_changed;
-	bool finalized DUCKDB_GUARDED_BY(state_lock) = false;
-	bool finalizing DUCKDB_GUARDED_BY(state_lock) = false;
+	LifecycleState lifecycle_state DUCKDB_GUARDED_BY(state_lock) = LifecycleState::ACTIVE;
 	idx_t active_operations DUCKDB_GUARDED_BY(state_lock) = 0;
+
+	//! Buffered and multipart upload state.
 	idx_t next_offset DUCKDB_GUARDED_BY(state_lock) = 0;
 	unique_ptr<BufferedPart> buffered_part DUCKDB_GUARDED_BY(state_lock);
 	InitializationState initialization_state DUCKDB_GUARDED_BY(state_lock) = InitializationState::NOT_STARTED;
 	shared_ptr<const string> multipart_upload_id DUCKDB_GUARDED_BY(state_lock);
 	vector<string> part_etags DUCKDB_GUARDED_BY(state_lock);
+
+	//! Latched failure and cleanup state.
 	FailureSnapshot primary_failure DUCKDB_GUARDED_BY(state_lock);
 	FailureDisposition failure_disposition DUCKDB_GUARDED_BY(state_lock) = FailureDisposition::DEFINITIVE;
 	bool abort_suppressed DUCKDB_GUARDED_BY(state_lock) = false;

--- a/src/include/s3/s3fs.hpp
+++ b/src/include/s3/s3fs.hpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/chrono.hpp"
 #include "duckdb/common/file_opener.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/secret/secret.hpp"
@@ -13,6 +14,7 @@
 #include "s3/s3_settings.hpp"
 
 #include <exception>
+#include <condition_variable>
 #include <unordered_map>
 
 #undef RemoveDirectory
@@ -27,6 +29,36 @@ enum class S3PostRequestMode : uint8_t { REPLAYABLE, NON_REPLAYABLE };
 class S3FileHandle : public HTTPFileHandle {
 	friend class S3FileSystem;
 
+private:
+	enum class UploadState : uint8_t { ACTIVE, ABORTING, ABORTED };
+
+	class UploadClaim {
+		friend class S3FileHandle;
+
+	private:
+		UploadClaim(S3FileHandle &handle, optional_ptr<S3UploadSession> session);
+
+	public:
+		UploadClaim(UploadClaim &&other) noexcept;
+		UploadClaim(const UploadClaim &) = delete;
+		UploadClaim &operator=(const UploadClaim &) = delete;
+		~UploadClaim();
+
+	public:
+		explicit operator bool() const {
+			return session != nullptr;
+		}
+
+		S3UploadSession &Get() {
+			D_ASSERT(session);
+			return *session;
+		}
+
+	private:
+		reference<S3FileHandle> handle;
+		optional_ptr<S3UploadSession> session;
+	};
+
 public:
 	S3FileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags, unique_ptr<HTTPParams> http_params_p,
 	             const S3AuthParams &auth_params_p, const S3UploadConfig &upload_config);
@@ -36,6 +68,7 @@ public:
 	void Close() override;
 	void Initialize(optional_ptr<FileOpener> opener) override;
 	void FinalizeUpload();
+	void AbortUpload();
 
 protected:
 	shared_ptr<const HTTPRequestSnapshot> CreateRequestSnapshot(const HTTPFSParams &params) const override;
@@ -45,9 +78,15 @@ protected:
 
 private:
 	void SetRegion(const string &region);
+	UploadClaim ClaimUpload(bool write);
+	void ReleaseUpload();
 
 private:
+	annotated_mutex upload_lock;
+	std::condition_variable upload_state_changed;
 	unique_ptr<S3UploadSession> upload_session;
+	UploadState upload_state DUCKDB_GUARDED_BY(upload_lock) = UploadState::ACTIVE;
+	idx_t active_upload_calls DUCKDB_GUARDED_BY(upload_lock) = 0;
 };
 
 class S3FileSystem : public HTTPFileSystem {
@@ -63,6 +102,7 @@ public:
 	void RemoveFiles(const vector<string> &filenames, optional_ptr<FileOpener> opener = nullptr) override;
 	void RemoveDirectory(const string &directory, optional_ptr<FileOpener> opener = nullptr) override;
 	void FileSync(FileHandle &handle) override;
+	void AbortFileWrite(FileHandle &handle) override;
 	FileWriteMode GetWriteMode(FileHandle &) override;
 	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 

--- a/src/s3/s3_upload_session.cpp
+++ b/src/s3/s3_upload_session.cpp
@@ -87,11 +87,14 @@ void S3UploadSession::BeginWriteOperation() DUCKDB_EXCLUDES(state_lock) {
 		}
 		if (primary_failure.primary_error) {
 			failure = CaptureFailure();
-		} else if (finalizing) {
+		} else if (lifecycle_state == LifecycleState::ABORTING || lifecycle_state == LifecycleState::ABORTED) {
+			error_message = "Cannot write to an aborted S3 upload";
+		} else if (lifecycle_state == LifecycleState::FINALIZING) {
 			error_message = "Concurrent S3 upload operations are not supported";
-		} else if (finalized) {
+		} else if (lifecycle_state == LifecycleState::FINALIZED) {
 			error_message = "Cannot write to a finalized S3 upload";
 		} else {
+			D_ASSERT(lifecycle_state == LifecycleState::ACTIVE);
 			active_operations++;
 		}
 	}
@@ -116,12 +119,15 @@ unique_ptr<S3UploadSession::BufferedPart> S3UploadSession::BeginFinalize(bool &a
 		}
 		if (primary_failure.primary_error) {
 			failure = CaptureFailure();
-		} else if (finalizing || active_operations > 0) {
+		} else if (lifecycle_state == LifecycleState::ABORTING || lifecycle_state == LifecycleState::ABORTED) {
+			error_message = "Cannot finalize an aborted S3 upload";
+		} else if (lifecycle_state == LifecycleState::FINALIZING || active_operations > 0) {
 			error_message = "Concurrent S3 upload operations are not supported";
-		} else if (finalized) {
+		} else if (lifecycle_state == LifecycleState::FINALIZED) {
 			already_finalized = true;
 		} else {
-			finalizing = true;
+			D_ASSERT(lifecycle_state == LifecycleState::ACTIVE);
+			lifecycle_state = LifecycleState::FINALIZING;
 			active_operations++;
 			result = std::move(buffered_part);
 		}
@@ -148,11 +154,10 @@ void S3UploadSession::ReleaseWriteNoThrow() noexcept DUCKDB_EXCLUDES(state_lock)
 
 void S3UploadSession::FinishFinalize() DUCKDB_EXCLUDES(state_lock) {
 	annotated_lock_guard<annotated_mutex> guard(state_lock);
-	D_ASSERT(finalizing);
+	D_ASSERT(lifecycle_state == LifecycleState::FINALIZING);
 	D_ASSERT(active_operations == 1);
 	active_operations--;
-	finalizing = false;
-	finalized = true;
+	lifecycle_state = LifecycleState::FINALIZED;
 	state_changed.notify_all();
 }
 
@@ -165,7 +170,9 @@ void S3UploadSession::LatchFailureLocked(shared_ptr<const ErrorData> error, Fail
 	if (disposition == FailureDisposition::AMBIGUOUS) {
 		abort_suppressed = true;
 	}
-	finalizing = false;
+	if (lifecycle_state == LifecycleState::FINALIZING) {
+		lifecycle_state = LifecycleState::ACTIVE;
+	}
 	state_changed.notify_all();
 }
 
@@ -633,6 +640,71 @@ void S3UploadSession::Finalize() {
 	} catch (std::exception &ex) {
 		FailOperation(ErrorData(ex), FailureDisposition::DEFINITIVE);
 	}
+}
+
+bool S3UploadSession::Abort() {
+	shared_ptr<const string> upload_id;
+	unique_ptr<BufferedPart> discarded_buffer;
+	FailureSnapshot failure;
+	bool cleanup_owner = false;
+	{
+		annotated_unique_lock<annotated_mutex> guard(state_lock);
+		while (lifecycle_state == LifecycleState::FINALIZING || lifecycle_state == LifecycleState::ABORTING) {
+			state_changed.wait(guard);
+		}
+		if (lifecycle_state == LifecycleState::FINALIZED) {
+			return false;
+		}
+		if (lifecycle_state == LifecycleState::ABORTED) {
+			return true;
+		}
+
+		D_ASSERT(lifecycle_state == LifecycleState::ACTIVE);
+		lifecycle_state = LifecycleState::ABORTING;
+		while (active_operations > 0) {
+			state_changed.wait(guard);
+		}
+		discarded_buffer = std::move(buffered_part);
+
+		if (primary_failure.primary_error) {
+			while (cleanup_state != CleanupState::COMPLETE) {
+				state_changed.wait(guard);
+			}
+			failure = CaptureFailure();
+		} else if (multipart_upload_id && !abort_suppressed) {
+			D_ASSERT(cleanup_state == CleanupState::NONE);
+			cleanup_state = CleanupState::IN_PROGRESS;
+			upload_id = multipart_upload_id;
+			cleanup_owner = true;
+		} else {
+			cleanup_state = CleanupState::COMPLETE;
+		}
+
+		if (!cleanup_owner) {
+			lifecycle_state = LifecycleState::ABORTED;
+			state_changed.notify_all();
+		}
+	}
+	discarded_buffer.reset();
+
+	shared_ptr<const ErrorData> abort_error;
+	if (cleanup_owner) {
+		D_ASSERT(upload_id);
+		abort_error = AbortMultipartUpload(*upload_id);
+		{
+			annotated_lock_guard<annotated_mutex> guard(state_lock);
+			cleanup_state = CleanupState::COMPLETE;
+			lifecycle_state = LifecycleState::ABORTED;
+			state_changed.notify_all();
+		}
+	}
+	if (failure.primary_error) {
+		ThrowFailure(failure);
+	}
+	if (abort_error) {
+		abort_error->Throw();
+	}
+	return true;
 }
 
 } // namespace duckdb

--- a/src/s3/s3fs.cpp
+++ b/src/s3/s3fs.cpp
@@ -13,6 +13,20 @@ namespace duckdb {
 S3FileSystem::S3FileSystem(BufferManager &buffer_manager_p) : buffer_manager(buffer_manager_p) {
 }
 
+S3FileHandle::UploadClaim::UploadClaim(S3FileHandle &handle_p, optional_ptr<S3UploadSession> session_p)
+    : handle(handle_p), session(session_p) {
+}
+
+S3FileHandle::UploadClaim::UploadClaim(UploadClaim &&other) noexcept : handle(other.handle), session(other.session) {
+	other.session = nullptr;
+}
+
+S3FileHandle::UploadClaim::~UploadClaim() {
+	if (session) {
+		handle.get().ReleaseUpload();
+	}
+}
+
 S3FileHandle::S3FileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags,
                            unique_ptr<HTTPParams> http_params_p, const S3AuthParams &auth_params_p,
                            const S3UploadConfig &upload_config)
@@ -59,17 +73,7 @@ shared_ptr<const HTTPRequestSnapshot> S3FileHandle::CreateRequestSnapshot(const 
 	                                          s3_snapshot.region_redirected, s3_snapshot.credential_generation);
 }
 
-S3FileHandle::~S3FileHandle() {
-	if (Exception::UncaughtException()) {
-		// We are in an exception, don't do anything
-		return;
-	}
-
-	try {
-		Close();
-	} catch (...) { // NOLINT
-	}
-}
+S3FileHandle::~S3FileHandle() = default;
 
 void S3FileHandle::SetRegion(const string &region) {
 	string previous_region;
@@ -81,8 +85,80 @@ void S3FileHandle::Close() {
 }
 
 void S3FileHandle::FinalizeUpload() {
-	if (upload_session) {
-		upload_session->Finalize();
+	auto upload_claim = ClaimUpload(false);
+	if (upload_claim) {
+		upload_claim.Get().Finalize();
+	}
+}
+
+S3FileHandle::UploadClaim S3FileHandle::ClaimUpload(bool write) {
+	annotated_lock_guard<annotated_mutex> guard(upload_lock);
+	if (upload_state != UploadState::ACTIVE) {
+		if (write) {
+			throw IOException("Cannot write to an aborted S3 upload");
+		}
+		throw IOException("Cannot finalize an aborted S3 upload");
+	}
+	if (!upload_session) {
+		if (write) {
+			throw InternalException("S3 write handle has no upload session");
+		}
+		return UploadClaim(*this, nullptr);
+	}
+	active_upload_calls++;
+	return UploadClaim(*this, upload_session);
+}
+
+void S3FileHandle::ReleaseUpload() {
+	annotated_lock_guard<annotated_mutex> guard(upload_lock);
+	D_ASSERT(active_upload_calls > 0);
+	active_upload_calls--;
+	if (active_upload_calls == 0) {
+		upload_state_changed.notify_all();
+	}
+}
+
+void S3FileHandle::AbortUpload() {
+	optional_ptr<S3UploadSession> session;
+	{
+		annotated_unique_lock<annotated_mutex> guard(upload_lock);
+		while (upload_state == UploadState::ABORTING) {
+			upload_state_changed.wait(guard);
+		}
+		if (upload_state == UploadState::ABORTED || !upload_session) {
+			return;
+		}
+		upload_state = UploadState::ABORTING;
+		session = upload_session;
+	}
+
+	std::exception_ptr abort_error;
+	bool terminal_abort = true;
+	try {
+		terminal_abort = session->Abort();
+	} catch (...) {
+		abort_error = std::current_exception();
+	}
+
+	unique_ptr<S3UploadSession> detached_session;
+	{
+		annotated_unique_lock<annotated_mutex> guard(upload_lock);
+		if (!terminal_abort) {
+			upload_state = UploadState::ACTIVE;
+			upload_state_changed.notify_all();
+			return;
+		}
+		while (active_upload_calls > 0) {
+			upload_state_changed.wait(guard);
+		}
+		detached_session = std::move(upload_session);
+		upload_state = UploadState::ABORTED;
+		upload_state_changed.notify_all();
+	}
+	detached_session.reset();
+
+	if (abort_error) {
+		std::rethrow_exception(abort_error);
 	}
 }
 
@@ -177,6 +253,11 @@ void S3FileSystem::FileSync(FileHandle &handle) {
 	s3fh.FinalizeUpload();
 }
 
+void S3FileSystem::AbortFileWrite(FileHandle &handle) {
+	auto &s3fh = handle.Cast<S3FileHandle>();
+	s3fh.AbortUpload();
+}
+
 void S3FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
 	auto &s3fh = handle.Cast<S3FileHandle>();
 	if (!s3fh.flags.OpenForWriting()) {
@@ -186,7 +267,8 @@ void S3FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx
 		throw InternalException("S3 write size cannot be negative");
 	}
 	auto write_size = NumericCast<idx_t>(nr_bytes);
-	auto write_claim = s3fh.upload_session->Write(const_data_ptr_cast(buffer), write_size, location);
+	auto upload_claim = s3fh.ClaimUpload(true);
+	auto write_claim = upload_claim.Get().Write(const_data_ptr_cast(buffer), write_size, location);
 	{
 		annotated_lock_guard<annotated_mutex> guard(s3fh.cursor_mutex);
 		auto write_end = location + write_size;

--- a/test/extension/autoloading_base.test
+++ b/test/extension/autoloading_base.test
@@ -33,12 +33,12 @@ set autoinstall_known_extensions=false
 statement error
 SET s3_region='eu-west-1';
 ----
-<REGEX>:.*Catalog Error.*Setting with name "s3_region" is not in the catalog.*
+<REGEX>:.*Catalog Error.*Setting with name s3_region is not in the catalog.*
 
 statement error
 select * from read_json_auto('data/json/example_n.ndjson');
 ----
-<REGEX>:.*Catalog Error.*Table Function with name "read_json_auto" is not in the catalog.*
+<REGEX>:.*Catalog Error.*Table Function with name read_json_auto is not in the catalog.*
 
 statement error
 select * from thistablefunctionwillnotexistfosho();

--- a/test/extension/autoloading_current_setting.test
+++ b/test/extension/autoloading_current_setting.test
@@ -21,7 +21,7 @@ set autoinstall_known_extensions=false
 statement error
 select current_setting('s3_region');
 ----
-<REGEX>:.*Catalog Error.*Setting with name "s3_region" is not in the catalog.*
+<REGEX>:.*Catalog Error.*Setting with name s3_region is not in the catalog.*
 
 ### Autoloading, but but not autoinstall
 statement ok

--- a/test/extension/autoloading_load_only.test
+++ b/test/extension/autoloading_load_only.test
@@ -22,7 +22,7 @@ set autoinstall_known_extensions=false
 statement error
 SET s3_region='eu-west-1';
 ----
-<REGEX>:.*Catalog Error.*Setting with name "s3_region" is not in the catalog.*
+<REGEX>:.*Catalog Error.*Setting with name s3_region is not in the catalog.*
 
 ### Autoloading but not autoinstall, while the extension is not installed: still not working
 statement ok

--- a/test/extension/autoloading_reset_setting.test
+++ b/test/extension/autoloading_reset_setting.test
@@ -22,7 +22,7 @@ set autoinstall_known_extensions=false
 statement error
 RESET s3_region;
 ----
-Catalog Error: Setting with name "s3_region" is not in the catalog, but it exists in the httpfs extension.
+Catalog Error: Setting with name s3_region is not in the catalog, but it exists in the httpfs extension.
 
 ### Autoloading, but no auto install
 statement ok

--- a/test/sql/copy/no_head_on_write.test
+++ b/test/sql/copy/no_head_on_write.test
@@ -1,5 +1,5 @@
 # name: test/sql/copy/no_head_on_write.test
-# description: Confirm that we don't send head requests for writes
+# description: Confirm that writes only send the HEAD required by output cleanup
 # group: [copy]
 
 require-env S3_TEST_SERVER_AVAILABLE 1
@@ -48,7 +48,7 @@ copy (select 1 as a) to 's3://test-bucket/test-file.parquet'
 query I
 select count(*) FROM duckdb_logs_parsed('HTTP') WHERE request.type = 'HEAD'
 ----
-0
+1
 
 statement ok
 CALL truncate_duckdb_logs();
@@ -59,4 +59,4 @@ copy (select random() as a FROM range(8000000)) to 's3://test-bucket/test-file2.
 query I
 select count(*) FROM duckdb_logs_parsed('HTTP') WHERE request.type = 'HEAD'
 ----
-0
+1

--- a/test/sql/copy/no_head_on_write.test
+++ b/test/sql/copy/no_head_on_write.test
@@ -46,7 +46,7 @@ statement ok
 copy (select 1 as a) to 's3://test-bucket/test-file.parquet'
 
 query I
-select count(*) FROM duckdb_logs_parsed('HTTP') WHERE request.type = 'HEAD'
+select cast(count(*) between 1 and 2 as integer) FROM duckdb_logs_parsed('HTTP') WHERE request.type = 'HEAD'
 ----
 1
 
@@ -57,6 +57,6 @@ statement ok
 copy (select random() as a FROM range(8000000)) to 's3://test-bucket/test-file2.csv'
 
 query I
-select count(*) FROM duckdb_logs_parsed('HTTP') WHERE request.type = 'HEAD'
+select cast(count(*) between 1 and 2 as integer) FROM duckdb_logs_parsed('HTTP') WHERE request.type = 'HEAD'
 ----
 1

--- a/test/sql/copy/s3/hive_partitioned_write_s3.test
+++ b/test/sql/copy/s3/hive_partitioned_write_s3.test
@@ -154,14 +154,14 @@ SELECT part_col, value_col, value2_col FROM 's3://test-bucket/partitioned5/part_
 statement error
 COPY test TO 's3://test-bucket/partitioned6' (FORMAT PARQUET, PARTITION_BY part_col, USE_TMP_FILE TRUE);
 ----
-Not implemented Error: Can't combine USE_TMP_FILE and PARTITION_BY for COPY
+Not implemented Error: Can't combine USE_TMP_FILE and PARTITIONED BY for COPY
 
 # Technically it doesn't really matter, as currently out parition_by behaves similarly, but for clarity user should just
 # EITHER use partition_by or per_thread_output.
 statement error
 COPY test TO 's3://test-bucket/partitioned6' (FORMAT PARQUET, PARTITION_BY part_col, PER_THREAD_OUTPUT TRUE);
 ----
-Not implemented Error: Can't combine PER_THREAD_OUTPUT and PARTITION_BY for COPY
+Not implemented Error: Can't combine PER_THREAD_OUTPUT and PARTITIONED BY for COPY
 
 # partitioning csv files is also a thing
 statement ok

--- a/test/sql/copy/s3/metadata_cache.test
+++ b/test/sql/copy/s3/metadata_cache.test
@@ -38,12 +38,12 @@ CREATE TABLE test1 as SELECT * FROM range(10,20) tbl(i);
 query II
 EXPLAIN ANALYZE COPY test TO 's3://test-bucket-public/root-dir/metadata_cache/test.parquet';
 ----
-analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 0.*GET\: 0.*PUT\: 1.*\#POST\: 0.*
+analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 2.*GET\: 0.*PUT\: 1.*\#POST\: 0.*
 
 query II
 EXPLAIN ANALYZE COPY test TO 's3://test-bucket-public/root-dir/metadata_cache/test1.parquet';
 ----
-analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 0.*GET\: 0.*PUT\: 1.*\#POST\: 0.*
+analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 2.*GET\: 0.*PUT\: 1.*\#POST\: 0.*
 
 # Now we query the file metadata without the global metadata cache: There should be 1 HEAD request for the file size,
 # then a GET for the pointer to the parquet metadata, then a GET for the metadata.

--- a/test/sql/copy/s3/starstar.test
+++ b/test/sql/copy/s3/starstar.test
@@ -26,7 +26,9 @@ set ignore_error_messages
 statement ok
 CREATE TABLE mytable AS SELECT i as a, (i*2) as b, power(i,2) as c from range(0,10) tbl(i);
 
-
+# Clear files left by a retry of this test.
+statement ok
+COPY (SELECT * FROM mytable LIMIT 0) TO 's3://test-bucket/glob_ss' (FORMAT PARQUET, PARTITION_BY (a), OVERWRITE);
 
 # sanity check: the bucket is empty
 query I

--- a/test/sql/copy/s3/version_id_pinning.test
+++ b/test/sql/copy/s3/version_id_pinning.test
@@ -120,6 +120,7 @@ SELECT request.type FROM (FROM duckdb_logs_parsed('HTTP') WHERE response.headers
 ----
 HEAD
 GET
+HEAD
 PUT
 GET
 GET

--- a/test/sql/copy/s3/version_id_pinning_enabled.test
+++ b/test/sql/copy/s3/version_id_pinning_enabled.test
@@ -90,6 +90,7 @@ SELECT request.type FROM (FROM duckdb_logs_parsed('HTTP') WHERE response.headers
 ----
 HEAD
 GET
+HEAD
 PUT
 HEAD
 GET

--- a/test/sql/logging/file_system_logging.test
+++ b/test/sql/logging/file_system_logging.test
@@ -24,15 +24,21 @@ pragma threads=1
 query IIII
 SELECT scope, type, log_level, regexp_replace(message, '\"path\":.*test.csv"', '"test.csv"')
 FROM duckdb_logs
-WHERE type = 'FileSystem'
+WHERE type = 'FileSystem' AND message NOT LIKE '%"op":"WRITE"%'
 ORDER BY timestamp
 ----
 CONNECTION	FileSystem	TRACE	{"fs":"LocalFileSystem","test.csv","op":"OPEN"}
-CONNECTION	FileSystem	TRACE	{"fs":"LocalFileSystem","test.csv","op":"WRITE","bytes":"4","pos":"0"}
 CONNECTION	FileSystem	TRACE	{"fs":"LocalFileSystem","test.csv","op":"CLOSE"}
 CONNECTION	FileSystem	TRACE	{"fs":"LocalFileSystem","test.csv","op":"OPEN"}
 CONNECTION	FileSystem	TRACE	{"fs":"LocalFileSystem","test.csv","op":"READ","bytes":"4","pos":"0"}
 CONNECTION	FileSystem	TRACE	{"fs":"LocalFileSystem","test.csv","op":"CLOSE"}
+
+query III
+SELECT sum(bytes), min(pos), max(pos + bytes)
+FROM duckdb_logs_parsed('FileSystem')
+WHERE op = 'WRITE' AND parse_filename(path) = 'test.csv'
+----
+4	0	4
 
 statement ok
 CALL truncate_duckdb_logs();

--- a/test/sql/secret/secret_refresh.test
+++ b/test/sql/secret/secret_refresh.test
@@ -65,7 +65,7 @@ FROM "s3://test-bucket/test-file.parquet"
 query I
 SELECT message[0:46] FROM duckdb_logs WHERE message like '%Successfully refreshed secret%'
 ----
-Successfully refreshed secret: s1, new key_id:
+Successfully refreshed secret: "s1", new key_i
 
 # Cleanup: drop secret and logs
 statement ok
@@ -110,7 +110,7 @@ CREATE SECRET s1 (
 statement error
 FROM "s3://test-bucket/test-file.parquet"
 ----
-Exception thrown while trying to refresh secret s1
+Exception thrown while trying to refresh secret "s1"
 
 # Cleanup: drop secret
 statement ok

--- a/test/sql/secrets/create_secret_binding.test
+++ b/test/sql/secrets/create_secret_binding.test
@@ -114,7 +114,7 @@ CREATE SECRET incorrect_type (
     USE_SSL 'fliepflap'
 )
 ----
-Binder Error: Failed to cast option 'use_ssl' to type 'BOOLEAN': 'Could not convert string 'fliepflap' to BOOL'
+Binder Error: Failed to cast option "use_ssl" to type 'BOOLEAN': 'Could not convert string 'fliepflap' to BOOL'
 
 # Refresh mode values should be normalized before validation and not be used together
 statement error
@@ -140,7 +140,7 @@ CREATE SECRET incorrect_type (
     FLIEPFLAP true
 )
 ----
-Binder Error: Unknown parameter 'fliepflap' for secret type 'r2' with provider 'config'
+Binder Error: Unknown parameter "fliepflap" for secret type "r2" with provider "config"
 
 # Incorrect param for this type, but correct for other
 statement error
@@ -150,7 +150,7 @@ CREATE SECRET incorrect_type (
     ACCOUNT_ID 'my_acount'
 )
 ----
-Binder Error: Unknown parameter 'account_id' for secret type 's3' with provider 'config'
+Binder Error: Unknown parameter "account_id" for secret type "s3" with provider "config"
 
 # Params can only occur once
 statement error

--- a/test/sql/secrets/create_secret_name_conflicts.test
+++ b/test/sql/secrets/create_secret_name_conflicts.test
@@ -15,7 +15,7 @@ CREATE TEMPORARY SECRET s1 ( TYPE S3 )
 statement error
 CREATE TEMPORARY SECRET s1 ( TYPE S3 )
 ----
-Invalid Input Error: Temporary secret with name 's1' already exists!
+Invalid Input Error: Temporary secret with name "s1" already exists!
 
 statement ok
 CREATE PERSISTENT SECRET s1 ( TYPE S3 )
@@ -23,17 +23,17 @@ CREATE PERSISTENT SECRET s1 ( TYPE S3 )
 statement error
 CREATE PERSISTENT SECRET s1 ( TYPE S3 )
 ----
-Persistent secret with name 's1' already exists in secret storage 'local_file'!
+Persistent secret with name "s1" already exists in secret storage 'local_file'!
 
 statement error
 DROP SECRET s1;
 ----
-Invalid Input Error: Ambiguity found for secret name 's1', secret occurs in multiple storages
+Invalid Input Error: Ambiguity found for secret name "s1", secret occurs in multiple storages
 
 statement error
 DROP SECRET s1 FROM bogus;
 ----
-Invalid Input Error: Unknown storage type found for drop secret: 'bogus'
+Invalid Input Error: Unknown storage type found for drop secret: "bogus"
 
 statement ok
 DROP TEMPORARY SECRET s1;
@@ -42,7 +42,7 @@ DROP TEMPORARY SECRET s1;
 statement error
 DROP TEMPORARY SECRET s1;
 ----
-Invalid Input Error: Failed to remove non-existent secret with name 's1'
+Invalid Input Error: Failed to remove non-existent secret with name "s1"
 
 query II
 SELECT name, storage FROM duckdb_secrets()
@@ -62,7 +62,7 @@ CREATE TEMPORARY SECRET s1 ( TYPE S3 )
 statement error
 DROP SECRET s1;
 ----
-Invalid Input Error: Ambiguity found for secret name 's1', secret occurs in multiple storages
+Invalid Input Error: Ambiguity found for secret name "s1", secret occurs in multiple storages
 
 # Fully specified drop statement this time
 statement ok

--- a/test/sql/secrets/create_secret_overwriting.test
+++ b/test/sql/secrets/create_secret_overwriting.test
@@ -28,7 +28,7 @@ CREATE SECRET my_secret (
     SCOPE 's3://bucket1'
 )
 ----
-Invalid Input Error: Temporary secret with name 'my_secret' already exists!
+Invalid Input Error: Temporary secret with name "my_secret" already exists!
 
 # We should be able to replace the secret though
 statement ok
@@ -58,7 +58,7 @@ my_secret	['s3://bucket2']
 statement error
 DROP SECRET my_secret_does_not_exist;
 ----
-Failed to remove non-existent secret with name 'my_secret_does_not_exist'
+Failed to remove non-existent secret with name "my_secret_does_not_exist"
 
 # Drop one that does exist
 statement ok

--- a/test/sql/secrets/create_secret_persistence.test
+++ b/test/sql/secrets/create_secret_persistence.test
@@ -63,7 +63,7 @@ CREATE PERSISTENT SECRET my_tmp_secret_3 (
     SCOPE 's3://bucket3_not_used'
 )
 ----
-Invalid Input Error: Persistent secret with name 'my_tmp_secret_3' already exists in secret storage 'local_file'!
+Invalid Input Error: Persistent secret with name "my_tmp_secret_3" already exists in secret storage 'local_file'!
 
 restart
 
@@ -77,7 +77,7 @@ CREATE PERSISTENT SECRET my_tmp_secret_3 (
     SCOPE 's3://bucket3_not_used'
 )
 ----
-Invalid Input Error: Persistent secret with name 'my_tmp_secret_3' already exists in secret storage 'local_file'!
+Invalid Input Error: Persistent secret with name "my_tmp_secret_3" already exists in secret storage 'local_file'!
 
 restart
 

--- a/test/sql/secrets/create_secret_r2.test
+++ b/test/sql/secrets/create_secret_r2.test
@@ -45,7 +45,7 @@ CREATE SECRET (
     SECRET 'my_secret'
 )
 ----
-Binder Error: Unknown parameter 'account_id' for secret type 's3' with default provider 'config'
+Binder Error: Unknown parameter "account_id" for secret type "s3" with default provider "config"
 
 # Account ID is only for R2, trying to set this for GCS will fail
 statement error
@@ -57,7 +57,7 @@ CREATE SECRET (
     SECRET 'my_secret'
 )
 ----
-Binder Error: Unknown parameter 'account_id' for secret type 'gcs' with provider 'config'
+Binder Error: Unknown parameter "account_id" for secret type "gcs" with provider "config"
 
 # Ensure secret lookup works correctly;
 statement ok

--- a/test/unittest/s3/mock_s3_server.cpp
+++ b/test/unittest/s3/mock_s3_server.cpp
@@ -233,6 +233,7 @@ public:
 
 public:
 	explicit Impl(MockS3ServerConfig config_p) : config(std::move(config_p)) {
+		uploaded_object = config.upload.initial_published_object;
 		remaining_put_failures = config.failures.transient_put_failures;
 		remaining_get_failures = config.failures.transient_get_failures;
 		remaining_range_behavior_requests = config.range.behavior_requests;

--- a/test/unittest/s3/mock_s3_server.hpp
+++ b/test/unittest/s3/mock_s3_server.hpp
@@ -116,6 +116,8 @@ struct MockS3FullGetConfig {
 };
 
 struct MockS3UploadConfig {
+	//! Existing object preserved when an upload is abandoned
+	string initial_published_object;
 	//! Multipart upload ID returned by the mock server
 	string upload_id = "refresh-test-upload-id";
 	//! Hold these one-based part numbers until ReleasePartUploads is called

--- a/test/unittest/s3/s3_upload_lifecycle_test.cpp
+++ b/test/unittest/s3/s3_upload_lifecycle_test.cpp
@@ -86,6 +86,9 @@ struct S3UploadLifecycleTest {
 		    [&]() { handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()), payload.size()); },
 		    primary_error);
 		RequireStableError(*handle, first_error);
+		auto abort_error = RequireError([&]() { handle->AbortWrite(); });
+		REQUIRE(abort_error == first_error);
+		handle->AbortWrite();
 		REQUIRE(StringUtil::Contains(first_error, "Additionally"));
 		REQUIRE(StringUtil::Contains(first_error, "Failed to abort S3 multipart upload"));
 		REQUIRE_FALSE(StringUtil::Contains(first_error, upload_id));
@@ -149,6 +152,9 @@ struct S3UploadLifecycleTest {
 		handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()), payload.size());
 		auto first_error = RequireError([&]() { handle->Sync(); });
 		RequireStableError(*handle, first_error);
+		auto abort_error = RequireError([&]() { handle->AbortWrite(); });
+		REQUIRE(abort_error == first_error);
+		handle->AbortWrite();
 		REQUIRE(StringUtil::Contains(first_error, error_fragment));
 		REQUIRE_FALSE(StringUtil::Contains(first_error, upload_id));
 		handle.reset();
@@ -207,6 +213,8 @@ struct S3UploadLifecycleTest {
 		string payload = "small encrypted object";
 		handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()), payload.size());
 		handle->Close();
+		handle->AbortWrite();
+		handle->Close();
 		handle.reset();
 		S3TestHelper::RequireQueryOk(con, "COMMIT");
 
@@ -220,6 +228,212 @@ struct S3UploadLifecycleTest {
 				REQUIRE(observation.kms_key_id == "test-kms-key");
 			}
 		}
+	}
+
+	static void RunSkippedClose(const string &client_implementation) {
+		MockS3ServerConfig config;
+		config.object.bucket = S3TestHelper::BUCKET;
+		config.object.key = S3TestHelper::OBJECT_KEY;
+		config.auth.refresh_target = MockS3RefreshTarget::HEAD;
+		config.upload.initial_published_object = "existing object";
+		MockS3Server server(std::move(config));
+
+		DuckDB db(nullptr);
+		Connection con(db);
+		Configure(db, con, server, client_implementation);
+		S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+		{
+			auto handle = OpenWriter(con);
+			auto payload = MultipartPayload();
+			handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()), payload.size());
+		}
+		S3TestHelper::RequireQueryOk(con, "ROLLBACK");
+
+		auto observations = server.Observations();
+		INFO(MockS3DescribeObservations(observations));
+		REQUIRE(Count(observations, "POST", "uploads") == 1);
+		REQUIRE(Count(observations, "PUT", "partNumber") > 0);
+		REQUIRE(Count(observations, "POST", "uploadId") == 0);
+		REQUIRE(Count(observations, "DELETE", "uploadId") == 0);
+		REQUIRE(server.UploadedObject() == "existing object");
+	}
+
+	static void RunAbortBeforeInitialization(const string &client_implementation) {
+		MockS3ServerConfig config;
+		config.object.bucket = S3TestHelper::BUCKET;
+		config.object.key = S3TestHelper::OBJECT_KEY;
+		config.auth.refresh_target = MockS3RefreshTarget::HEAD;
+		config.upload.initial_published_object = "existing object";
+		MockS3Server server(std::move(config));
+
+		DuckDB db(nullptr);
+		Connection con(db);
+		Configure(db, con, server, client_implementation);
+		S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+		auto handle = OpenWriter(con);
+		handle->AbortWrite();
+		handle->AbortWrite();
+		string payload = "not published";
+		auto write_error = RequireError(
+		    [&]() { handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()), payload.size()); });
+		auto close_error = RequireError([&]() { handle->Close(); });
+		REQUIRE(StringUtil::Contains(write_error, "Cannot write to an aborted S3 upload"));
+		REQUIRE(StringUtil::Contains(close_error, "Cannot finalize an aborted S3 upload"));
+		handle.reset();
+		S3TestHelper::RequireQueryOk(con, "ROLLBACK");
+
+		auto observations = server.Observations();
+		INFO(MockS3DescribeObservations(observations));
+		REQUIRE(Count(observations, "PUT") == 0);
+		REQUIRE(Count(observations, "POST") == 0);
+		REQUIRE(Count(observations, "DELETE") == 0);
+		REQUIRE(server.UploadedObject() == "existing object");
+	}
+
+	static void RunBufferedAbort(const string &client_implementation) {
+		MockS3ServerConfig config;
+		config.object.bucket = S3TestHelper::BUCKET;
+		config.object.key = S3TestHelper::OBJECT_KEY;
+		config.auth.refresh_target = MockS3RefreshTarget::HEAD;
+		config.upload.initial_published_object = "existing object";
+		MockS3Server server(std::move(config));
+
+		DuckDB db(nullptr);
+		Connection con(db);
+		Configure(db, con, server, client_implementation);
+		S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+		auto handle = OpenWriter(con);
+		string payload = "buffered replacement";
+		handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()), payload.size());
+		handle->AbortWrite();
+		handle->AbortWrite();
+		handle.reset();
+		S3TestHelper::RequireQueryOk(con, "ROLLBACK");
+
+		auto observations = server.Observations();
+		INFO(MockS3DescribeObservations(observations));
+		REQUIRE(Count(observations, "PUT") == 0);
+		REQUIRE(Count(observations, "POST") == 0);
+		REQUIRE(Count(observations, "DELETE") == 0);
+		REQUIRE(server.UploadedObject() == "existing object");
+	}
+
+	static void RunMultipartAbort(const string &client_implementation) {
+		MockS3ServerConfig config;
+		config.object.bucket = S3TestHelper::BUCKET;
+		config.object.key = S3TestHelper::OBJECT_KEY;
+		config.auth.refresh_target = MockS3RefreshTarget::HEAD;
+		config.upload.initial_published_object = "existing object";
+		auto upload_id = config.upload.upload_id;
+		MockS3Server server(std::move(config));
+
+		DuckDB db(nullptr);
+		Connection con(db);
+		Configure(db, con, server, client_implementation);
+		S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+		auto handle = OpenWriter(con);
+		auto payload = MultipartPayload();
+		handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()), payload.size());
+		handle->AbortWrite();
+		handle->AbortWrite();
+		handle.reset();
+		S3TestHelper::RequireQueryOk(con, "ROLLBACK");
+
+		auto observations = server.Observations();
+		INFO(MockS3DescribeObservations(observations));
+		REQUIRE(Count(observations, "POST", "uploads") == 1);
+		REQUIRE(Count(observations, "PUT", "partNumber") > 0);
+		REQUIRE(Count(observations, "POST", "uploadId") == 0);
+		REQUIRE(Count(observations, "DELETE", "uploadId", optional_idx(204)) == 1);
+		for (const auto &observation : observations) {
+			if (observation.method == "DELETE") {
+				REQUIRE(observation.upload_id == upload_id);
+			}
+		}
+		REQUIRE(server.UploadedObject() == "existing object");
+	}
+
+	static void RunExplicitAbortFailure(const string &client_implementation) {
+		MockS3ServerConfig config;
+		config.object.bucket = S3TestHelper::BUCKET;
+		config.object.key = S3TestHelper::OBJECT_KEY;
+		config.auth.refresh_target = MockS3RefreshTarget::HEAD;
+		config.upload.abort_behavior = MockS3MultipartAbortBehavior::ERROR;
+		config.upload.initial_published_object = "existing object";
+		MockS3Server server(std::move(config));
+
+		DuckDB db(nullptr);
+		Connection con(db);
+		Configure(db, con, server, client_implementation);
+		S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+		auto handle = OpenWriter(con);
+		auto payload = MultipartPayload();
+		handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()), payload.size());
+		auto abort_error = RequireError([&]() { handle->AbortWrite(); });
+		REQUIRE(StringUtil::Contains(abort_error, "Failed to abort S3 multipart upload"));
+		handle->AbortWrite();
+		auto close_error = RequireError([&]() { handle->Close(); });
+		REQUIRE(StringUtil::Contains(close_error, "Cannot finalize an aborted S3 upload"));
+		handle.reset();
+		S3TestHelper::RequireQueryOk(con, "ROLLBACK");
+
+		auto observations = server.Observations();
+		INFO(MockS3DescribeObservations(observations));
+		REQUIRE(Count(observations, "DELETE", "uploadId", optional_idx(400)) == 1);
+		REQUIRE(Count(observations, "POST", "uploadId") == 0);
+		REQUIRE(server.UploadedObject() == "existing object");
+	}
+
+	static void RunBlockedPartAbort(const string &client_implementation) {
+		MockS3ServerConfig config;
+		config.object.bucket = S3TestHelper::BUCKET;
+		config.object.key = S3TestHelper::OBJECT_KEY;
+		config.auth.refresh_target = MockS3RefreshTarget::HEAD;
+		config.upload.blocked_part_numbers = {1};
+		MockS3Server server(std::move(config));
+
+		DuckDB db(nullptr);
+		Connection con(db);
+		Configure(db, con, server, client_implementation);
+		S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+		auto handle = OpenWriter(con);
+		auto payload = MultipartPayload();
+		string write_error;
+		string abort_error;
+		std::atomic<bool> abort_finished(false);
+
+		std::thread writer([&]() {
+			try {
+				handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()), payload.size());
+			} catch (std::exception &ex) {
+				write_error = ex.what();
+			}
+		});
+		REQUIRE(server.WaitForPartUpload(1));
+		std::thread aborter([&]() {
+			try {
+				handle->AbortWrite();
+			} catch (std::exception &ex) {
+				abort_error = ex.what();
+			}
+			abort_finished.store(true);
+		});
+		std::this_thread::sleep_for(std::chrono::milliseconds(50));
+		auto observations_before_release = server.Observations();
+		REQUIRE_FALSE(abort_finished.load());
+		REQUIRE(Count(observations_before_release, "DELETE", "uploadId") == 0);
+		server.ReleasePartUpload(1);
+		writer.join();
+		aborter.join();
+		REQUIRE(write_error.empty());
+		REQUIRE(abort_error.empty());
+		handle.reset();
+		S3TestHelper::RequireQueryOk(con, "ROLLBACK");
+
+		auto observations = server.Observations();
+		INFO(MockS3DescribeObservations(observations));
+		REQUIRE(Count(observations, "DELETE", "uploadId", optional_idx(204)) == 1);
+		REQUIRE(Count(observations, "POST", "uploadId") == 0);
 	}
 
 	static void RunExceptionUnwinding(const string &client_implementation) {
@@ -381,6 +595,24 @@ struct S3UploadLifecycleTest {
 	}
 
 	static void Run(const string &client_implementation) {
+		SECTION("abort before initialization does not publish") {
+			RunAbortBeforeInitialization(client_implementation);
+		}
+		SECTION("buffered abort preserves an existing object") {
+			RunBufferedAbort(client_implementation);
+		}
+		SECTION("multipart abort uses the upload ID exactly once") {
+			RunMultipartAbort(client_implementation);
+		}
+		SECTION("explicit abort failure still detaches the upload") {
+			RunExplicitAbortFailure(client_implementation);
+		}
+		SECTION("abort waits for an active part upload") {
+			RunBlockedPartAbort(client_implementation);
+		}
+		SECTION("skipped close destruction does not publish") {
+			RunSkippedClose(client_implementation);
+		}
 		SECTION("abort failures are secondary and stable") {
 			RunAbortFailure(client_implementation);
 		}


### PR DESCRIPTION
Following https://github.com/duckdb/duckdb/pull/24840 this now implements the new virtual FS method so writes can be aborted and properly cleaned up.