### PR TITLE
Informed non-idempotent request retries

### DIFF
--- a/src/include/s3/s3_request.hpp
+++ b/src/include/s3/s3_request.hpp
@@ -35,6 +35,7 @@ public:
 };
 
 enum class S3RequestTarget : uint8_t { OBJECT, BUCKET };
+enum class S3PostRequestMode : uint8_t { DEFAULT, RETRY_RECEIVED_RESPONSES };
 
 struct S3RequestQuery {
 	S3RequestQuery() = default;
@@ -91,6 +92,7 @@ struct S3RequestUtil {
 	                                 string payload_hash = "", string content_type = "", string content_md5 = "");
 	static string GetPayloadHash(EncryptionUtil &encryption_util, const_data_ptr_t buffer, idx_t buffer_len);
 	static bool IsRequestTimeout(const HTTPResponse &response);
+	static bool IsRetryableReceivedResponse(const HTTPResponse &response);
 
 	static string ParseError(const string &error);
 	static HTTPException GetError(const S3AuthParams &auth_params, const HTTPResponse &response,
@@ -109,7 +111,8 @@ struct S3RequestExecutor {
 	                                           const string &content_type, const string &content_md5,
 	                                           const RequestCallback &request,
 	                                           const RegionRedirectCallback &region_redirect = {},
-	                                           optional_ptr<S3RequestContext> request_context = nullptr);
+	                                           optional_ptr<S3RequestContext> request_context = nullptr,
+	                                           S3PostRequestMode post_request_mode = S3PostRequestMode::DEFAULT);
 	static unique_ptr<HTTPResponse> RunHandle(EncryptionUtil &encryption_util, S3FileHandle &handle,
 	                                          const string &s3_url, RequestType request_type, const string &version_id,
 	                                          const RequestCallback &request);
@@ -135,7 +138,8 @@ private:
 
 	static unique_ptr<HTTPResponse> Run(const string &s3_url, const CreateDataCallback &create_data,
 	                                    const RequestCallback &request, const RefreshCallback &refresh_auth_params,
-	                                    const SetRegionCallback &set_region, const FinalRequestCallback &final_request);
+	                                    const SetRegionCallback &set_region, const FinalRequestCallback &final_request,
+	                                    S3PostRequestMode post_request_mode = S3PostRequestMode::DEFAULT);
 	static bool TryRefreshSession(HTTPRequestSession &session, const S3RequestData &request_data);
 	static S3RequestData CreateRequestData(EncryptionUtil &encryption_util, const CapturedHTTPRequestSnapshot &captured,
 	                                       const string &s3_url, RequestType request_type, S3RequestTarget target,

--- a/src/include/s3/s3fs.hpp
+++ b/src/include/s3/s3fs.hpp
@@ -24,8 +24,6 @@ namespace duckdb {
 class S3FileSystem;
 class S3UploadSession;
 
-enum class S3PostRequestMode : uint8_t { REPLAYABLE, NON_REPLAYABLE };
-
 class S3FileHandle : public HTTPFileHandle {
 	friend class S3FileSystem;
 
@@ -119,7 +117,7 @@ public:
 	unique_ptr<HTTPResponse> PostRequest(HTTPRequestSession &session, const string &s3_url, string &buffer_out,
 	                                     const_data_ptr_t buffer_in, idx_t buffer_in_len,
 	                                     const S3RequestQuery &query = S3RequestQuery(),
-	                                     S3PostRequestMode mode = S3PostRequestMode::REPLAYABLE,
+	                                     S3PostRequestMode mode = S3PostRequestMode::DEFAULT,
 	                                     optional_ptr<S3RequestContext> request_context = nullptr);
 	unique_ptr<HTTPResponse> PutRequest(HTTPRequestSession &session, const string &s3_url, const_data_ptr_t buffer_in,
 	                                    idx_t buffer_in_len, const S3RequestQuery &query = S3RequestQuery(),

--- a/src/s3/s3_request.cpp
+++ b/src/s3/s3_request.cpp
@@ -476,6 +476,22 @@ bool S3RequestUtil::IsRequestTimeout(const HTTPResponse &response) {
 	return S3XMLResponseParser::TryParseError(response.body, error) && error.code == "RequestTimeout";
 }
 
+bool S3RequestUtil::IsRetryableReceivedResponse(const HTTPResponse &response) {
+	if (response.HasRequestError()) {
+		return false;
+	}
+	auto status = static_cast<int>(response.status);
+	if (response.status == HTTPStatusCode::TooManyRequests_429 || (status >= 500 && status < 600)) {
+		return true;
+	}
+	S3XMLError error;
+	if (!S3XMLResponseParser::TryParseError(response.body, error)) {
+		return false;
+	}
+	return error.code == "InternalError" || error.code == "OperationAborted" || error.code == "SlowDown" ||
+	       error.code == "ServiceUnavailable" || error.code == "TooManyRequests" || error.code == "RequestTimeout";
+}
+
 static bool IsS3RequestTimeoutError(const ErrorData &error) {
 	auto &extra_info = error.ExtraInfo();
 	auto status_entry = extra_info.find("status_code");
@@ -503,12 +519,23 @@ static bool IsTransientRetryEligibleMethod(RequestType request_type) {
 	       request_type == RequestType::PUT_REQUEST || request_type == RequestType::DELETE_REQUEST;
 }
 
-unique_ptr<HTTPResponse> S3RequestExecutor::Run(const string &s3_url, const CreateDataCallback &create_data,
-                                                const RequestCallback &request,
-                                                const RefreshCallback &refresh_auth_params,
-                                                const SetRegionCallback &set_region,
-                                                const FinalRequestCallback &final_request) {
-	// Auth refresh and region redirect are one-shot; transient timeouts follow the configured HTTP retry policy.
+static bool ShouldRetryReceivedResponse(const S3RequestData &request_data, const HTTPResponse &response,
+                                        S3PostRequestMode post_request_mode) {
+	if (response.HasRequestError()) {
+		return false;
+	}
+	if (IsTransientRetryEligibleMethod(request_data.request_type) && S3RequestUtil::IsRequestTimeout(response)) {
+		return true;
+	}
+	return post_request_mode == S3PostRequestMode::RETRY_RECEIVED_RESPONSES &&
+	       S3RequestUtil::IsRetryableReceivedResponse(response);
+}
+
+unique_ptr<HTTPResponse>
+S3RequestExecutor::Run(const string &s3_url, const CreateDataCallback &create_data, const RequestCallback &request,
+                       const RefreshCallback &refresh_auth_params, const SetRegionCallback &set_region,
+                       const FinalRequestCallback &final_request, S3PostRequestMode post_request_mode) {
+	// Auth refresh and region redirect are one-shot; transient responses follow the configured HTTP retry policy.
 	bool retried_auth_refresh = false;
 	bool retried_region = false;
 	idx_t transient_retries = 0;
@@ -518,19 +545,21 @@ unique_ptr<HTTPResponse> S3RequestExecutor::Run(const string &s3_url, const Crea
 		auto &http_params = request_data.http_params->Cast<HTTPFSParams>();
 		try {
 			auto result = request(request_data);
-			if (result && !retried_auth_refresh && IsAuthRefreshStatus(*result) && refresh_auth_params(request_data)) {
+			auto received_response = result && !result->HasRequestError();
+			if (received_response && !retried_auth_refresh && IsAuthRefreshStatus(*result) &&
+			    refresh_auth_params(request_data)) {
 				retried_auth_refresh = true;
 				continue;
 			}
 			string correct_region;
-			if (result && !retried_region &&
+			if (received_response && !retried_region &&
 			    GetRegionRedirect(*result, request_data.auth_params, correct_region).IsValid()) {
 				set_region(request_data, correct_region);
 				retried_region = true;
 				continue;
 			}
-			if (IsTransientRetryEligibleMethod(request_data.request_type) && result &&
-			    transient_retries < http_params.retries && S3RequestUtil::IsRequestTimeout(*result)) {
+			if (received_response && transient_retries < http_params.retries &&
+			    ShouldRetryReceivedResponse(request_data, *result, post_request_mode)) {
 				SleepForRetry(http_params, transient_retries, transient_wait_ms);
 				transient_retries++;
 				continue;
@@ -633,13 +662,12 @@ bool S3RequestExecutor::SetSessionRegion(HTTPRequestSession &session, const stri
 	}
 }
 
-unique_ptr<HTTPResponse> S3RequestExecutor::RunSession(EncryptionUtil &encryption_util, HTTPRequestSession &session,
-                                                       const string &s3_url, RequestType request_type,
-                                                       S3RequestTarget target, const CreateQueryCallback &create_query,
-                                                       const string &payload_hash, const string &content_type,
-                                                       const string &content_md5, const RequestCallback &request,
-                                                       const RegionRedirectCallback &region_redirect,
-                                                       optional_ptr<S3RequestContext> request_context) {
+unique_ptr<HTTPResponse>
+S3RequestExecutor::RunSession(EncryptionUtil &encryption_util, HTTPRequestSession &session, const string &s3_url,
+                              RequestType request_type, S3RequestTarget target, const CreateQueryCallback &create_query,
+                              const string &payload_hash, const string &content_type, const string &content_md5,
+                              const RequestCallback &request, const RegionRedirectCallback &region_redirect,
+                              optional_ptr<S3RequestContext> request_context, S3PostRequestMode post_request_mode) {
 	return S3RequestExecutor::Run(
 	    s3_url,
 	    [&]() {
@@ -660,7 +688,8 @@ unique_ptr<HTTPResponse> S3RequestExecutor::RunSession(EncryptionUtil &encryptio
 			    request_context->auth_params = request_data.auth_params;
 			    request_context->display_url = request_data.display_url;
 		    }
-	    });
+	    },
+	    post_request_mode);
 }
 
 unique_ptr<HTTPResponse> S3RequestExecutor::RunHandle(EncryptionUtil &encryption_util, S3FileHandle &s3_handle,
@@ -687,7 +716,7 @@ unique_ptr<HTTPResponse> S3RequestExecutor::RunHandle(EncryptionUtil &encryption
 			        request_data.display_url, previous_region, correct_region);
 		    }
 	    },
-	    {});
+	    {}, S3PostRequestMode::DEFAULT);
 }
 
 unique_ptr<HTTPResponse> S3RequestExecutor::SendSessionRequest(HTTPRequestSession &session,
@@ -767,17 +796,14 @@ unique_ptr<HTTPResponse> S3FileSystem::PostRequest(HTTPRequestSession &session, 
 	    [&](S3RequestData &request_data) {
 		    result.clear();
 		    auto &params = request_data.http_params->Cast<HTTPFSParams>();
-		    if (mode == S3PostRequestMode::NON_REPLAYABLE) {
-			    params.retries = 0;
-		    }
 		    return RunPostRequest(request_data.http_url, request_data.headers, params, result, buffer_in, buffer_in_len,
 		                          [&](BaseRequest &request) {
-			                          request.try_request = mode == S3PostRequestMode::NON_REPLAYABLE;
+			                          request.try_request = true;
 			                          return S3RequestExecutor::SendSessionRequest(session, request_data.captured,
 			                                                                       params, request);
 		                          });
 	    },
-	    {}, request_context);
+	    {}, request_context, mode);
 }
 
 unique_ptr<HTTPResponse> S3FileSystem::PutRequest(HTTPRequestSession &session, const string &url,

--- a/src/s3/s3_upload_session.cpp
+++ b/src/s3/s3_upload_session.cpp
@@ -353,7 +353,7 @@ string S3UploadSession::InitializeMultipartUpload() {
 	S3RequestContext request_context;
 	auto response =
 	    s3fs.get().PostRequest(*request_session, path, result, nullptr, 0, S3RequestQuery({{"uploads", ""}}),
-	                           S3PostRequestMode::NON_REPLAYABLE, request_context);
+	                           S3PostRequestMode::DEFAULT, request_context);
 	if (response->HasRequestError()) {
 		throw S3AmbiguousUploadException(StringUtil::Format(
 		    "S3 multipart upload initialization for \"%s\" has an unknown outcome because the response was not "
@@ -523,53 +523,39 @@ void S3UploadSession::CompleteMultipartUpload() {
 	auto completion_body = S3XMLWriter::WriteCompleteMultipartUploadRequest(snapshot.etags);
 
 	S3RequestQuery query {{"uploadId", *snapshot.upload_id}};
-	idx_t retries = 0;
-	double wait_ms = 0;
-	for (;;) {
-		string result;
-		S3RequestContext request_context;
-		auto response =
-		    s3fs.get().PostRequest(*request_session, path, result, const_data_ptr_cast(completion_body.data()),
-		                           completion_body.size(), query, S3PostRequestMode::NON_REPLAYABLE, request_context);
-		if (response->HasRequestError()) {
-			throw S3AmbiguousUploadException(
-			    StringUtil::Format("S3 multipart upload completion for \"%s\" has an unknown outcome because the "
-			                       "response was not received; "
-			                       "the request was not retried or aborted",
-			                       request_context.display_url));
-		}
-		if (!IsSuccessfulStatus(response->status)) {
-			throw GetStatusError(*response, request_context, "completing multipart upload for");
-		}
+	string result;
+	S3RequestContext request_context;
+	auto response = s3fs.get().PostRequest(*request_session, path, result, const_data_ptr_cast(completion_body.data()),
+	                                       completion_body.size(), query, S3PostRequestMode::RETRY_RECEIVED_RESPONSES,
+	                                       request_context);
+	if (response->HasRequestError()) {
+		throw S3AmbiguousUploadException(
+		    StringUtil::Format("S3 multipart upload completion for \"%s\" has an unknown outcome because the "
+		                       "response was not received; "
+		                       "the request was not retried or aborted",
+		                       request_context.display_url));
+	}
+	if (!IsSuccessfulStatus(response->status)) {
+		throw GetStatusError(*response, request_context, "completing multipart upload for");
+	}
 
-		S3XMLResponse parsed_response;
-		if (!S3XMLResponseParser::TryParse(result, parsed_response)) {
-			throw S3AmbiguousUploadException(StringUtil::Format(
-			    "S3 multipart upload completion for \"%s\" returned malformed XML; the request was not retried or "
-			    "aborted",
-			    request_context.display_url));
-		}
-		if (parsed_response.type == S3XMLResponseType::ERROR) {
-			auto captured = request_session->Capture();
-			auto &http_params = captured.snapshot->Params();
-			if (response->status == HTTPStatusCode::OK_200 && parsed_response.error_code == "InternalError" &&
-			    retries < http_params.retries) {
-				S3RequestExecutor::SleepForRetry(http_params, retries, wait_ms);
-				retries++;
-				continue;
-			}
-			throw HTTPException(
-			    *response, "S3 multipart upload completion for \"%s\" failed: %s%s%s", request_context.display_url,
-			    parsed_response.error_code.empty() ? "S3 returned an embedded error" : parsed_response.error_code,
-			    parsed_response.error_message.empty() ? "" : ": ", parsed_response.error_message);
-		}
-		if (parsed_response.type != S3XMLResponseType::MULTIPART_COMPLETION) {
-			throw S3AmbiguousUploadException(StringUtil::Format(
-			    "S3 multipart upload completion for \"%s\" returned an unrecognized response; the request was not "
-			    "retried or aborted",
-			    request_context.display_url));
-		}
-		return;
+	S3XMLResponse parsed_response;
+	if (!S3XMLResponseParser::TryParse(result, parsed_response)) {
+		throw S3AmbiguousUploadException(StringUtil::Format(
+		    "S3 multipart upload completion for \"%s\" returned malformed XML; the request was not retried or aborted",
+		    request_context.display_url));
+	}
+	if (parsed_response.type == S3XMLResponseType::ERROR) {
+		throw HTTPException(
+		    *response, "S3 multipart upload completion for \"%s\" failed: %s%s%s", request_context.display_url,
+		    parsed_response.error_code.empty() ? "S3 returned an embedded error" : parsed_response.error_code,
+		    parsed_response.error_message.empty() ? "" : ": ", parsed_response.error_message);
+	}
+	if (parsed_response.type != S3XMLResponseType::MULTIPART_COMPLETION) {
+		throw S3AmbiguousUploadException(StringUtil::Format("S3 multipart upload completion for \"%s\" returned an "
+		                                                    "unrecognized response; the request was not retried or "
+		                                                    "aborted",
+		                                                    request_context.display_url));
 	}
 }
 

--- a/test/unittest/s3/mock_s3_server.cpp
+++ b/test/unittest/s3/mock_s3_server.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/mutex.hpp"
+#include "duckdb/common/atomic.hpp"
 #include "duckdb/common/string_util.hpp"
 
 #include "httplib.hpp"
@@ -72,7 +73,7 @@ static bool ParseRange(const string &range, idx_t object_size, idx_t &start, idx
 	return start <= end && end < object_size;
 }
 
-static bool ConsumeBehavior(std::atomic<idx_t> &remaining) {
+static bool ConsumeBehavior(atomic<idx_t> &remaining) {
 	auto current = remaining.load();
 	while (current > 0) {
 		if (remaining.compare_exchange_weak(current, current - 1)) {
@@ -241,8 +242,7 @@ public:
 		remaining_head_not_found = config.failures.head_not_found_requests;
 		remaining_delete_failures = config.failures.transient_delete_failures;
 		remaining_post_failures = config.failures.transient_post_failures;
-		remaining_complete_post_failures = config.failures.transient_complete_post_failures;
-		remaining_complete_post_200_errors = config.failures.transient_complete_post_200_errors;
+		remaining_completion_faults = config.failures.completion_fault.count;
 		if (config.range.behavior == MockS3RangeBehavior::SHORT_SUCCESS && config.range.behavior_requests > 0) {
 			server.set_keep_alive_max_count(1);
 		}
@@ -389,7 +389,7 @@ public:
 		       ExtractCredentialRegion(GetHeader(request, "Authorization")) != config.auth.required_region;
 	}
 
-	void Record(const httplib::Request &request, int status) const DUCKDB_EXCLUDES(observation_lock) {
+	void Record(const httplib::Request &request, int status) const DUCKDB_EXCLUDES(observation_lock, upload_lock) {
 		MockS3RequestObservation observation;
 		observation.method = request.method;
 		observation.path = request.path;
@@ -412,6 +412,10 @@ public:
 		observation.session_header_count = CountHeader(request, "X-HTTPFS-Session");
 		observation.status = status;
 		observation.remote_port = request.remote_port;
+		{
+			annotated_lock_guard<annotated_mutex> lock(upload_lock);
+			observation.multipart_upload_published = multipart_upload_published;
+		}
 
 		annotated_lock_guard<annotated_mutex> lock(observation_lock);
 		observations.push_back(std::move(observation));
@@ -451,8 +455,9 @@ public:
 		Record(request, response.status);
 	}
 
-	void SendDisconnectedSuccess(const httplib::Request &request, httplib::Response &response) const {
-		response.status = 200;
+	void SendDisconnectedResponse(const httplib::Request &request, httplib::Response &response,
+	                              int status = 200) const {
+		response.status = status;
 		response.set_content_provider(1, "application/xml", [](size_t, size_t, httplib::DataSink &) { return false; });
 		Record(request, response.status);
 	}
@@ -507,11 +512,13 @@ public:
 		Record(request, response.status);
 	}
 
-	void SendComplete200Error(const httplib::Request &request, httplib::Response &response) const {
-		response.status = 200;
-		response.set_content("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-		                     "<Error><Code>InternalError</Code>"
-		                     "<Message>We encountered an internal error. Please try again.</Message></Error>",
+	void SendCompletionFault(const httplib::Request &request, httplib::Response &response) const {
+		auto &fault = config.failures.completion_fault;
+		response.status = fault.status;
+		response.set_content(StringUtil::Format("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+		                                        "<Error><Code>%s</Code><Message>%s</Message></Error>",
+		                                        MockS3XMLText::Escape(fault.code),
+		                                        MockS3XMLText::Escape(fault.message)),
 		                     "application/xml");
 		Record(request, response.status);
 	}
@@ -547,6 +554,7 @@ public:
 			previous_part_number = manifest_part.part_number;
 		}
 		uploaded_object = std::move(completed_object);
+		multipart_upload_published = true;
 		return true;
 	}
 
@@ -587,7 +595,7 @@ public:
 				Record(request, response.status);
 				return;
 			case MockS3MultipartInitializationBehavior::CREATE_THEN_DISCONNECT:
-				SendDisconnectedSuccess(request, response);
+				SendDisconnectedResponse(request, response);
 				return;
 			default:
 				throw InternalException("Unknown multipart initialization behavior");
@@ -639,7 +647,7 @@ public:
 			Record(request, response.status);
 			return;
 		case MockS3MultipartCompletionBehavior::COMMIT_THEN_DISCONNECT:
-			SendDisconnectedSuccess(request, response);
+			SendDisconnectedResponse(request, response, config.upload.completion_disconnect_status);
 			return;
 		case MockS3MultipartCompletionBehavior::EMBEDDED_ERROR:
 			throw InternalException("Embedded multipart errors must be handled before committing the upload");
@@ -872,7 +880,7 @@ public:
 				return;
 			}
 			if (config.range.block_first_body_until_second && range_request_index == 1) {
-				auto wait_for_second_request = make_shared_ptr<std::atomic<bool>>(true);
+				auto wait_for_second_request = make_shared_ptr<atomic<bool>>(true);
 				response.set_content_provider(
 				    config.object.data.size(), "application/octet-stream",
 				    [this, wait_for_second_request](size_t offset, size_t length, httplib::DataSink &sink) {
@@ -977,17 +985,20 @@ public:
 			}
 			if (request.target.find("uploads") != string::npos && remaining_post_failures.load() > 0) {
 				remaining_post_failures--;
-				SendS3Error400(request, response, config.failures.failure_is_request_timeout);
+				if (config.failures.transient_post_status == 400) {
+					SendS3Error400(request, response, config.failures.failure_is_request_timeout);
+				} else {
+					response.status = config.failures.transient_post_status;
+					response.set_content("<Error><Code>TooManyRequests</Code><Message>Injected initialization "
+					                     "throttle</Message></Error>",
+					                     "application/xml");
+					Record(request, response.status);
+				}
 				return;
 			}
-			if (request.target.find("uploadId") != string::npos && remaining_complete_post_failures.load() > 0) {
-				remaining_complete_post_failures--;
-				SendS3Error400(request, response, config.failures.failure_is_request_timeout);
-				return;
-			}
-			if (request.target.find("uploadId") != string::npos && remaining_complete_post_200_errors.load() > 0) {
-				remaining_complete_post_200_errors--;
-				SendComplete200Error(request, response);
+			if (request.target.find("uploadId") != string::npos && remaining_completion_faults.load() > 0) {
+				remaining_completion_faults--;
+				SendCompletionFault(request, response);
 				return;
 			}
 			SendMultipartPost(request, response);
@@ -1046,17 +1057,16 @@ public:
 	int port = 0;
 
 	//! Injected request failures
-	mutable std::atomic<idx_t> transient_503_lists_sent {0};
-	mutable std::atomic<idx_t> transient_400_lists_sent {0};
-	mutable std::atomic<idx_t> remaining_put_failures {0};
-	mutable std::atomic<idx_t> remaining_get_failures {0};
-	mutable std::atomic<idx_t> remaining_range_behavior_requests {0};
-	mutable std::atomic<idx_t> remaining_head_failures {0};
-	mutable std::atomic<idx_t> remaining_head_not_found {0};
-	mutable std::atomic<idx_t> remaining_delete_failures {0};
-	mutable std::atomic<idx_t> remaining_post_failures {0};
-	mutable std::atomic<idx_t> remaining_complete_post_failures {0};
-	mutable std::atomic<idx_t> remaining_complete_post_200_errors {0};
+	mutable atomic<idx_t> transient_503_lists_sent {0};
+	mutable atomic<idx_t> transient_400_lists_sent {0};
+	mutable atomic<idx_t> remaining_put_failures {0};
+	mutable atomic<idx_t> remaining_get_failures {0};
+	mutable atomic<idx_t> remaining_range_behavior_requests {0};
+	mutable atomic<idx_t> remaining_head_failures {0};
+	mutable atomic<idx_t> remaining_head_not_found {0};
+	mutable atomic<idx_t> remaining_delete_failures {0};
+	mutable atomic<idx_t> remaining_post_failures {0};
+	mutable atomic<idx_t> remaining_completion_faults {0};
 
 	//! Request observations
 	mutable annotated_mutex observation_lock;
@@ -1069,6 +1079,7 @@ public:
 	set<idx_t> released_part_numbers DUCKDB_GUARDED_BY(upload_lock);
 	string uploaded_object DUCKDB_GUARDED_BY(upload_lock);
 	string completion_body DUCKDB_GUARDED_BY(upload_lock);
+	bool multipart_upload_published DUCKDB_GUARDED_BY(upload_lock) = false;
 	idx_t active_part_uploads DUCKDB_GUARDED_BY(upload_lock) = 0;
 	idx_t maximum_active_part_uploads DUCKDB_GUARDED_BY(upload_lock) = 0;
 	bool part_uploads_released DUCKDB_GUARDED_BY(upload_lock) = false;
@@ -1209,12 +1220,14 @@ string MockS3DescribeObservations(const vector<MockS3RequestObservation> &observ
 		}
 		result += StringUtil::Format(
 		    "%s %s status=%d key=%s region=%s range=%s if_match=%s version_id=%s target=%s upload_id=%s "
-		    "part_number=%s body_size=%llu body_digest=%s sse=%s kms_key_id=%s user_agent=%s session_header=%s",
+		    "part_number=%s body_size=%llu body_digest=%s published=%s sse=%s kms_key_id=%s user_agent=%s "
+		    "session_header=%s",
 		    observation.method, observation.path, observation.status, observation.key_id, observation.region,
 		    observation.range, observation.if_match, observation.version_id, observation.target, observation.upload_id,
 		    observation.part_number.IsValid() ? std::to_string(observation.part_number.GetIndex()) : string(),
-		    observation.body_size, observation.body_digest, observation.server_side_encryption, observation.kms_key_id,
-		    observation.user_agent, observation.session_header);
+		    observation.body_size, observation.body_digest, observation.multipart_upload_published ? "true" : "false",
+		    observation.server_side_encryption, observation.kms_key_id, observation.user_agent,
+		    observation.session_header);
 	}
 	return result;
 }

--- a/test/unittest/s3/mock_s3_server.hpp
+++ b/test/unittest/s3/mock_s3_server.hpp
@@ -66,6 +66,14 @@ struct MockS3MetadataConfig {
 	optional_idx head_content_length;
 };
 
+struct MockS3CompletionFaultConfig {
+	//! Number of leading multipart-completion responses to replace
+	idx_t count = 0;
+	int status = 200;
+	string code = "InternalError";
+	string message = "Injected multipart completion failure";
+};
+
 struct MockS3FailureConfig {
 	//! Answer this many leading ListObjectsV2 requests with HTTP 503 SlowDown
 	idx_t transient_503_lists = 0;
@@ -81,12 +89,12 @@ struct MockS3FailureConfig {
 	idx_t head_not_found_requests = 0;
 	//! Number of object DELETEs to fail with a 400 before succeeding
 	idx_t transient_delete_failures = 0;
-	//! Number of multipart-init POSTs (uploads=) to fail with a 400 before succeeding
+	//! Number of multipart-init POSTs (uploads=) to fail before succeeding
 	idx_t transient_post_failures = 0;
-	//! Number of multipart-complete POSTs (uploadId=) to fail with a 400 before succeeding
-	idx_t transient_complete_post_failures = 0;
-	//! Number of multipart-complete POSTs to answer with an HTTP 200 containing InternalError before succeeding
-	idx_t transient_complete_post_200_errors = 0;
+	//! HTTP status used for injected multipart-init failures
+	int transient_post_status = 400;
+	//! Leading multipart-completion response fault
+	MockS3CompletionFaultConfig completion_fault;
 	//! Whether injected 400s carry S3's retryable RequestTimeout code or a generic (non-retryable) code
 	bool failure_is_request_timeout = true;
 	//! Whether injected 400 bodies are truncated mid-XML (an open <Code> with no closing tag)
@@ -128,6 +136,8 @@ struct MockS3UploadConfig {
 	bool block_initialization = false;
 	MockS3MultipartInitializationBehavior initialization_behavior = MockS3MultipartInitializationBehavior::SUCCESS;
 	MockS3MultipartCompletionBehavior completion_behavior = MockS3MultipartCompletionBehavior::SUCCESS;
+	//! HTTP status sent before disconnecting a multipart-completion response body
+	int completion_disconnect_status = 200;
 	MockS3MultipartAbortBehavior abort_behavior = MockS3MultipartAbortBehavior::SUCCESS;
 };
 
@@ -162,6 +172,7 @@ struct MockS3RequestObservation {
 	idx_t user_agent_count = 0;
 	idx_t session_header_count = 0;
 	int status = 0;
+	bool multipart_upload_published = false;
 	//! Client's ephemeral source port; a new connection shows a new port
 	int remote_port = 0;
 };

--- a/test/unittest/s3/s3_retry_test.cpp
+++ b/test/unittest/s3/s3_retry_test.cpp
@@ -54,6 +54,116 @@ static idx_t CountObservationsTarget(const vector<MockS3RequestObservation> &obs
 	return result;
 }
 
+template <class CALLBACK>
+static string RequireError(CALLBACK callback, optional_ptr<ErrorData> error_data = nullptr) {
+	try {
+		callback();
+	} catch (std::exception &ex) {
+		if (error_data) {
+			*error_data = ErrorData(ex);
+		}
+		return ex.what();
+	}
+	FAIL("Expected operation to throw");
+	return string();
+}
+
+static unique_ptr<FileHandle> OpenWriter(Connection &con) {
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	return fs.OpenFile(S3TestHelper::S3_PATH, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+}
+
+static string MultipartPayload() {
+	return string(10ULL * 1024ULL * 1024ULL + 1, 'x');
+}
+
+static string ConfigureUploadTest(DuckDB &db, Connection &con, MockS3Server &server,
+                                  const string &client_implementation, idx_t retries) {
+	auto test_id = S3TestHelper::ConfigureRefresh(db, con, server, client_implementation, false);
+	S3TestHelper::RequireQueryOk(con, "SET s3_uploader_max_filesize='50GB'");
+	S3TestHelper::RequireQueryOk(con, "SET http_retries=" + to_string(retries));
+	S3TestHelper::RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	return test_id;
+}
+
+static void RunRecoveringCompletionFaultScenario(const string &client_implementation,
+                                                 MockS3CompletionFaultConfig completion_fault, idx_t retries) {
+	MockS3ServerConfig config;
+	config.object.bucket = S3TestHelper::BUCKET;
+	config.object.key = S3TestHelper::OBJECT_KEY;
+	config.auth.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.upload.initial_published_object = "existing object";
+	auto expected_attempts = completion_fault.count + 1;
+	auto expected_fault_status = completion_fault.status;
+	config.failures.completion_fault = std::move(completion_fault);
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureUploadTest(db, con, server, client_implementation, retries);
+	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto handle = OpenWriter(con);
+	auto payload = MultipartPayload();
+	handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()), payload.size());
+	handle->Close();
+	handle.reset();
+	S3TestHelper::RequireQueryOk(con, "COMMIT");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	S3TestHelper::RequireCompletionIdentity(observations, expected_attempts);
+	auto completions = S3TestHelper::CompletionObservations(observations);
+	for (idx_t attempt = 0; attempt < completions.size() - 1; attempt++) {
+		REQUIRE(completions[attempt].status == expected_fault_status);
+		REQUIRE_FALSE(completions[attempt].multipart_upload_published);
+	}
+	REQUIRE(completions.back().status == 200);
+	REQUIRE(completions.back().multipart_upload_published);
+	REQUIRE(CountObservationsTarget(observations, "DELETE", 204, "uploadId") == 0);
+	REQUIRE(server.UploadedObject() == payload);
+}
+
+static void RunFailedCompletionFaultScenario(const string &client_implementation,
+                                             MockS3CompletionFaultConfig completion_fault, idx_t retries,
+                                             idx_t expected_attempts) {
+	MockS3ServerConfig config;
+	config.object.bucket = S3TestHelper::BUCKET;
+	config.object.key = S3TestHelper::OBJECT_KEY;
+	config.auth.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+	config.upload.initial_published_object = "existing object";
+	auto expected_status = completion_fault.status;
+	auto expected_code = completion_fault.code;
+	config.failures.completion_fault = std::move(completion_fault);
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureUploadTest(db, con, server, client_implementation, retries);
+	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto handle = OpenWriter(con);
+	auto payload = MultipartPayload();
+	handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()), payload.size());
+	ErrorData error;
+	auto first_error = RequireError([&]() { handle->Sync(); }, error);
+	auto second_error = RequireError([&]() { handle->Close(); });
+	REQUIRE(second_error == first_error);
+	handle.reset();
+	S3TestHelper::RequireQueryOk(con, "ROLLBACK");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	S3TestHelper::RequireCompletionIdentity(observations, expected_attempts);
+	for (const auto &completion : S3TestHelper::CompletionObservations(observations)) {
+		REQUIRE(completion.status == expected_status);
+		REQUIRE_FALSE(completion.multipart_upload_published);
+	}
+	REQUIRE(error.Type() == ExceptionType::HTTP);
+	REQUIRE(error.ExtraInfo().at("status_code") == to_string(expected_status));
+	REQUIRE(StringUtil::Contains(error.ExtraInfo().at("response_body"), expected_code));
+	REQUIRE(CountObservationsTarget(observations, "DELETE", 204, "uploadId") == 1);
+	REQUIRE(server.UploadedObject() == "existing object");
+}
+
 // A generic (non-RequestTimeout) 400 must fail on the first try. Uses a single-shot PUT so exactly one
 // request is expected, distinguishing "not retried" from "retried N times and still failed".
 static void RunGenericErrorNotRetriedScenario(const string &client_implementation) {
@@ -304,91 +414,106 @@ static void RunHeadNotRetriedScenario(const string &client_implementation) {
 	REQUIRE(error_ports[0] == success_ports[0]);
 }
 
-// Like multipart-init, a multipart-complete POST must not be replayed even on RequestTimeout.
-static void RunMultipartCompleteNotRetriedScenario(const string &client_implementation) {
+// A received RequestTimeout response permits multipart completion to use its explicit S3 retry budget.
+static void RunMultipartCompleteRequestTimeoutRetryScenario(const string &client_implementation) {
+	RunFailedCompletionFaultScenario(client_implementation,
+	                                 {1000, 400, "RequestTimeout", "Injected completion timeout"}, 3, 4);
+}
+
+static void RunCompletionErrorCodeRecoveryScenarios(const string &client_implementation) {
+	for (const auto &code :
+	     {"InternalError", "OperationAborted", "SlowDown", "ServiceUnavailable", "TooManyRequests", "RequestTimeout"}) {
+		INFO("S3 error code: " << code);
+		RunRecoveringCompletionFaultScenario(client_implementation,
+		                                     {2, 200, code, "Injected retryable multipart completion error"}, 3);
+	}
+}
+
+static void RunCompletionStatusRecoveryScenarios(const string &client_implementation) {
+	for (const auto status : {429, 500, 502, 503}) {
+		INFO("HTTP status: " << status);
+		RunRecoveringCompletionFaultScenario(
+		    client_implementation, {1, status, "PermanentError", "Injected status-classified completion error"}, 1);
+	}
+}
+
+static void RunPermanentCompletionFailureScenarios(const string &client_implementation) {
+	RunFailedCompletionFaultScenario(client_implementation,
+	                                 {1000, 400, "InvalidRequest", "Injected permanent completion error"}, 3, 1);
+	RunFailedCompletionFaultScenario(client_implementation,
+	                                 {1000, 200, "internalerror", "Retry codes are case-sensitive"}, 3, 1);
+}
+
+static void RunCompletionWithoutRetriesScenario(const string &client_implementation) {
+	RunFailedCompletionFaultScenario(client_implementation, {1000, 503, "SlowDown", "No completion retries configured"},
+	                                 0, 1);
+}
+
+static void RunMultipartInitializationThrottleScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
 	config.object.bucket = S3TestHelper::BUCKET;
 	config.object.key = S3TestHelper::OBJECT_KEY;
-	config.auth.stale_key_id = S3TestHelper::STALE_KEY_ID;
 	config.auth.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
-	config.failures.transient_complete_post_failures = 1000;
+	config.failures.transient_post_failures = 1000;
+	config.failures.transient_post_status = 429;
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
 	Connection con(db);
-	S3TestHelper::ConfigureRefresh(db, con, server, client_implementation, false);
-
-	S3TestHelper::RequireQueryOk(con, "SET http_retries=3");
-	S3TestHelper::RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	ConfigureUploadTest(db, con, server, client_implementation, 3);
 	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
-	REQUIRE_THROWS(S3TestHelper::WriteMultipartPayload(con));
+	auto handle = OpenWriter(con);
+	auto payload = MultipartPayload();
+	auto first_error = RequireError(
+	    [&]() { handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()), payload.size()); });
+	auto second_error = RequireError([&]() { handle->Close(); });
+	REQUIRE(second_error == first_error);
+	handle.reset();
 	S3TestHelper::RequireQueryOk(con, "ROLLBACK");
 
 	auto observations = server.Observations();
 	INFO(MockS3DescribeObservations(observations));
-	REQUIRE(CountObservationsTarget(observations, "POST", 400, "uploadId") == 1);
+	REQUIRE(CountObservationsTarget(observations, "POST", 429, "uploads") == 1);
+	REQUIRE(CountObservationsTarget(observations, "POST", 200, "uploadId") == 0);
+	REQUIRE(CountObservationsTarget(observations, "DELETE", 204, "uploadId") == 0);
 }
 
-static void RunCompletePost200ErrorRetryScenario(const string &client_implementation) {
+static void RunCompletionRefreshThenRetryScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
 	config.object.bucket = S3TestHelper::BUCKET;
 	config.object.key = S3TestHelper::OBJECT_KEY;
-	config.auth.stale_key_id = S3TestHelper::STALE_KEY_ID;
-	config.auth.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
-	config.failures.transient_complete_post_200_errors = 2;
+	config.auth.refresh_target = MockS3RefreshTarget::MULTIPART_COMPLETE_POST;
+	config.upload.initial_published_object = "existing object";
+	config.failures.completion_fault = {1, 503, "SlowDown", "Retry after refreshing credentials"};
 	MockS3Server server(std::move(config));
 
 	DuckDB db(nullptr);
 	Connection con(db);
-	S3TestHelper::ConfigureRefresh(db, con, server, client_implementation, false);
-
-	S3TestHelper::RequireQueryOk(con, "SET http_retries=3");
-	S3TestHelper::RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	auto test_id = ConfigureUploadTest(db, con, server, client_implementation, 1);
 	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
-	S3TestHelper::WriteMultipartPayload(con);
+	auto handle = OpenWriter(con);
+	auto payload = MultipartPayload();
+	handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()), payload.size());
+	handle->Close();
+	handle.reset();
 	S3TestHelper::RequireQueryOk(con, "COMMIT");
 
+	S3TestHelper::AssertSingleRefresh(test_id);
 	auto observations = server.Observations();
 	INFO(MockS3DescribeObservations(observations));
-	REQUIRE(CountObservationsTarget(observations, "POST", 200, "uploadId") == 3);
+	S3TestHelper::RequireCompletionIdentity(observations, 3);
+	auto completions = S3TestHelper::CompletionObservations(observations);
+	REQUIRE(completions[0].status == 403);
+	REQUIRE(completions[0].key_id == S3TestHelper::STALE_KEY_ID);
+	REQUIRE_FALSE(completions[0].multipart_upload_published);
+	REQUIRE(completions[1].status == 503);
+	REQUIRE(completions[1].key_id == S3TestHelper::FRESH_KEY_ID);
+	REQUIRE_FALSE(completions[1].multipart_upload_published);
+	REQUIRE(completions[2].status == 200);
+	REQUIRE(completions[2].key_id == S3TestHelper::FRESH_KEY_ID);
+	REQUIRE(completions[2].multipart_upload_published);
 	REQUIRE(CountObservationsTarget(observations, "DELETE", 204, "uploadId") == 0);
-	REQUIRE(server.UploadedObject().size() == 10 * 1024 * 1024 + 1);
-}
-
-static void RunCompletePost200ErrorExhaustsBudgetScenario(const string &client_implementation) {
-	MockS3ServerConfig config;
-	config.object.bucket = S3TestHelper::BUCKET;
-	config.object.key = S3TestHelper::OBJECT_KEY;
-	config.auth.stale_key_id = S3TestHelper::STALE_KEY_ID;
-	config.auth.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
-	config.failures.transient_complete_post_200_errors = 1000;
-	MockS3Server server(std::move(config));
-
-	DuckDB db(nullptr);
-	Connection con(db);
-	S3TestHelper::ConfigureRefresh(db, con, server, client_implementation, false);
-
-	S3TestHelper::RequireQueryOk(con, "SET http_retries=3");
-	S3TestHelper::RequireQueryOk(con, "SET http_retry_wait_ms=1");
-	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
-	ErrorData error;
-	bool threw = false;
-	try {
-		S3TestHelper::WriteMultipartPayload(con);
-	} catch (std::exception &ex) {
-		threw = true;
-		error = ErrorData(ex);
-	}
-	S3TestHelper::RequireQueryOk(con, "ROLLBACK");
-
-	REQUIRE(threw);
-	REQUIRE(error.Type() == ExceptionType::HTTP);
-	REQUIRE(error.ExtraInfo().at("status_code") == "200");
-	REQUIRE(StringUtil::Contains(error.ExtraInfo().at("response_body"), "InternalError"));
-	auto observations = server.Observations();
-	INFO(MockS3DescribeObservations(observations));
-	REQUIRE(CountObservationsTarget(observations, "POST", 200, "uploadId") == 4);
-	REQUIRE(CountObservationsTarget(observations, "DELETE", 204, "uploadId") == 1);
+	REQUIRE(server.UploadedObject() == payload);
 }
 
 static void RunAllTransientRetryScenarios(const string &client_implementation) {
@@ -407,17 +532,29 @@ static void RunAllTransientRetryScenarios(const string &client_implementation) {
 	SECTION("a truncated error body is not retried and does not invalidate the database") {
 		RunTruncatedErrorBodyScenario(client_implementation);
 	}
-	SECTION("a multipart-init POST is not retried even on RequestTimeout") {
+	SECTION("multipart initialization does not retry a received RequestTimeout") {
 		RunMultipartInitNotRetriedScenario(client_implementation);
 	}
-	SECTION("a multipart-complete POST is not retried even on RequestTimeout") {
-		RunMultipartCompleteNotRetriedScenario(client_implementation);
+	SECTION("multipart initialization does not receive core throttle retries") {
+		RunMultipartInitializationThrottleScenario(client_implementation);
 	}
-	SECTION("a multipart-complete 200 InternalError is retried") {
-		RunCompletePost200ErrorRetryScenario(client_implementation);
+	SECTION("multipart completion retries a received RequestTimeout within the configured budget") {
+		RunMultipartCompleteRequestTimeoutRetryScenario(client_implementation);
 	}
-	SECTION("multipart-complete 200 InternalError retries are bounded by http_retries") {
-		RunCompletePost200ErrorExhaustsBudgetScenario(client_implementation);
+	SECTION("multipart completion retries every configured S3 error code") {
+		RunCompletionErrorCodeRecoveryScenarios(client_implementation);
+	}
+	SECTION("multipart completion retries HTTP throttle and server-error statuses") {
+		RunCompletionStatusRecoveryScenarios(client_implementation);
+	}
+	SECTION("multipart completion does not retry permanent errors") {
+		RunPermanentCompletionFailureScenarios(client_implementation);
+	}
+	SECTION("multipart completion honors http_retries=0") {
+		RunCompletionWithoutRetriesScenario(client_implementation);
+	}
+	SECTION("credential refresh preserves the multipart completion retry budget") {
+		RunCompletionRefreshThenRetryScenario(client_implementation);
 	}
 	SECTION("a HEAD 400 is not retried because HEAD responses carry no error body") {
 		RunHeadNotRetriedScenario(client_implementation);

--- a/test/unittest/s3/s3_test_helper.cpp
+++ b/test/unittest/s3/s3_test_helper.cpp
@@ -278,6 +278,31 @@ idx_t S3TestHelper::CountObservations(const vector<MockS3RequestObservation> &ob
 	return result;
 }
 
+vector<MockS3RequestObservation>
+S3TestHelper::CompletionObservations(const vector<MockS3RequestObservation> &observations) {
+	vector<MockS3RequestObservation> result;
+	for (const auto &observation : observations) {
+		if (observation.method == "POST" && StringUtil::Contains(observation.target, "uploadId")) {
+			result.push_back(observation);
+		}
+	}
+	return result;
+}
+
+void S3TestHelper::RequireCompletionIdentity(const vector<MockS3RequestObservation> &observations,
+                                             idx_t expected_attempts) {
+	auto completions = CompletionObservations(observations);
+	REQUIRE(completions.size() == expected_attempts);
+	REQUIRE(completions.front().body_size > 0);
+	REQUIRE_FALSE(completions.front().body_digest.empty());
+	REQUIRE_FALSE(completions.front().upload_id.empty());
+	for (const auto &completion : completions) {
+		REQUIRE(completion.body_size == completions.front().body_size);
+		REQUIRE(completion.body_digest == completions.front().body_digest);
+		REQUIRE(completion.upload_id == completions.front().upload_id);
+	}
+}
+
 vector<int> S3TestHelper::ObservationPorts(const vector<MockS3RequestObservation> &observations, const string &method,
                                            const string &key_id, int status, const string &range) {
 	vector<int> result;

--- a/test/unittest/s3/s3_test_helper.hpp
+++ b/test/unittest/s3/s3_test_helper.hpp
@@ -35,6 +35,10 @@ public:
 	static bool HasRequestWithKey(const vector<MockS3RequestObservation> &observations, const string &key_id);
 	static idx_t CountObservations(const vector<MockS3RequestObservation> &observations, const string &method,
 	                               const string &key_id, int status);
+	static vector<MockS3RequestObservation>
+	CompletionObservations(const vector<MockS3RequestObservation> &observations);
+	static void RequireCompletionIdentity(const vector<MockS3RequestObservation> &observations,
+	                                      idx_t expected_attempts);
 	static vector<int> ObservationPorts(const vector<MockS3RequestObservation> &observations, const string &method,
 	                                    const string &key_id, int status, const string &range = string());
 	static void WriteMultipartPayload(Connection &con);

--- a/test/unittest/s3/s3_upload_lifecycle_test.cpp
+++ b/test/unittest/s3/s3_upload_lifecycle_test.cpp
@@ -134,12 +134,18 @@ struct S3UploadLifecycleTest {
 	}
 
 	static void RunAmbiguousCompletion(const string &client_implementation, MockS3MultipartCompletionBehavior behavior,
-	                                   const string &error_fragment) {
+	                                   const string &error_fragment, bool leading_retryable_response = false) {
 		MockS3ServerConfig config;
 		config.object.bucket = S3TestHelper::BUCKET;
 		config.object.key = S3TestHelper::OBJECT_KEY;
 		config.auth.refresh_target = MockS3RefreshTarget::HEAD;
 		config.upload.completion_behavior = behavior;
+		if (behavior == MockS3MultipartCompletionBehavior::COMMIT_THEN_DISCONNECT) {
+			config.upload.completion_disconnect_status = 503;
+		}
+		if (leading_retryable_response) {
+			config.failures.completion_fault = {1, 503, "SlowDown", "Retry before an ambiguous completion"};
+		}
 		auto upload_id = config.upload.upload_id;
 		MockS3Server server(std::move(config));
 
@@ -162,7 +168,17 @@ struct S3UploadLifecycleTest {
 
 		auto observations = server.Observations();
 		INFO(MockS3DescribeObservations(observations));
-		REQUIRE(Count(observations, "POST", "uploadId") == 1);
+		auto expected_attempts = leading_retryable_response ? 2 : 1;
+		S3TestHelper::RequireCompletionIdentity(observations, expected_attempts);
+		auto completions = S3TestHelper::CompletionObservations(observations);
+		for (idx_t attempt = 0; attempt < completions.size() - 1; attempt++) {
+			REQUIRE_FALSE(completions[attempt].multipart_upload_published);
+		}
+		REQUIRE(completions.back().multipart_upload_published);
+		if (leading_retryable_response) {
+			REQUIRE(completions[0].status == 503);
+			REQUIRE(completions[1].status == 503);
+		}
 		REQUIRE(Count(observations, "DELETE") == 0);
 		REQUIRE(server.UploadedObject() == payload);
 	}
@@ -622,6 +638,10 @@ struct S3UploadLifecycleTest {
 		SECTION("completion transport loss is ambiguous") {
 			RunAmbiguousCompletion(client_implementation, MockS3MultipartCompletionBehavior::COMMIT_THEN_DISCONNECT,
 			                       "unknown outcome");
+		}
+		SECTION("a retryable completion response followed by transport loss is ambiguous") {
+			RunAmbiguousCompletion(client_implementation, MockS3MultipartCompletionBehavior::COMMIT_THEN_DISCONNECT,
+			                       "unknown outcome", true);
 		}
 		SECTION("empty completion success is ambiguous") {
 			RunAmbiguousCompletion(client_implementation, MockS3MultipartCompletionBehavior::EMPTY_SUCCESS,

--- a/test/unittest/s3/s3_upload_test.cpp
+++ b/test/unittest/s3/s3_upload_test.cpp
@@ -750,7 +750,7 @@ public:
 		config.object.bucket = S3TestHelper::BUCKET;
 		config.object.key = S3TestHelper::OBJECT_KEY;
 		config.auth.refresh_target = MockS3RefreshTarget::HEAD;
-		config.failures.transient_complete_post_failures = 1000;
+		config.failures.completion_fault = {1000, 400, "RequestTimeout", "Injected completion timeout"};
 		MockS3Server server(std::move(config));
 
 		DuckDB db(nullptr);


### PR DESCRIPTION
I've disabled automatic retry of non-idempotent requests like `POST` in DuckDB core in https://github.com/duckdb/duckdb/pull/25047

This PR bumps the DuckDB core submodule to pull in that behaviour, and now handles retries of such requests within httpfs using information about S3 error codes and the XML body which should make the retries actually safe.