### PR TITLE
Validate S3 endpoint configuration / track S3 url styles

### DIFF
--- a/src/create_secret_functions.cpp
+++ b/src/create_secret_functions.cpp
@@ -54,7 +54,9 @@ private:
 		} else if (name == "region" || name == "session_token" || name == "endpoint" || name == "kms_key_id") {
 			secret->secret_map[Identifier(name)] = value.ToString();
 		} else if (name == "url_style") {
-			secret->secret_map[Identifier(name)] = StringUtil::Lower(value.ToString());
+			auto url_style = StringUtil::Lower(value.ToString());
+			S3Provider::ParseURLStyle(url_style);
+			secret->secret_map[Identifier(name)] = std::move(url_style);
 		} else if (name == "use_ssl" || name == "verify_ssl" || name == "url_compatibility_mode" ||
 		           name == "requester_pays") {
 			SetBooleanOption(name, value);

--- a/src/include/s3/s3_auth.hpp
+++ b/src/include/s3/s3_auth.hpp
@@ -8,6 +8,8 @@
 
 namespace duckdb {
 
+enum class S3EndpointMode : uint8_t { AUTOMATIC, EXPLICIT };
+
 class S3KeyValueReader {
 public:
 	S3KeyValueReader(FileOpener &opener_p, optional_ptr<FileOpenerInfo> info, const char **secret_types,
@@ -59,6 +61,7 @@ struct S3AuthParams {
 public:
 	static S3AuthParams ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info);
 	static S3AuthParams ReadFrom(S3KeyValueReader &secret_reader, const string &file_path);
+	void SetEndpoint(string endpoint_p);
 	void SetRegion(string region_p);
 	bool operator==(const S3AuthParams &other) const;
 
@@ -71,6 +74,7 @@ public:
 	string secret_access_key;
 	string session_token;
 	string endpoint;
+	S3EndpointMode endpoint_mode = S3EndpointMode::AUTOMATIC;
 	string kms_key_id;
 	string url_style;
 	bool use_ssl = true;

--- a/src/include/s3/s3_provider.hpp
+++ b/src/include/s3/s3_provider.hpp
@@ -18,6 +18,8 @@ enum class S3ProviderType : uint8_t { S3, GCS, R2 };
 
 enum class S3AuthType : uint8_t { ANONYMOUS, SIGV4, BEARER };
 
+enum class S3URLStyle : uint8_t { VIRTUAL_HOSTED, PATH };
+
 struct S3ProviderMatch {
 	S3ProviderType type;
 	string prefix;
@@ -47,6 +49,7 @@ struct S3Provider {
 	static void InitializeAuthParams(S3AuthParams &auth_params);
 	//! Validate that endpoint once every source has been read, then derive the remaining defaults
 	static void FinalizeAuthParams(S3AuthParams &auth_params);
+	static S3URLStyle ParseURLStyle(const string &url_style);
 	static S3AuthType GetAuthType(const S3AuthParams &auth_params);
 	static string GetBadRequestError(const S3AuthParams &auth_params, const string &correct_region = "");
 	static string GetAuthError(const S3AuthParams &auth_params);

--- a/src/include/s3/s3_provider.hpp
+++ b/src/include/s3/s3_provider.hpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/array.hpp"
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/optional.hpp"
+#include "duckdb/common/optional_idx.hpp"
 
 namespace duckdb {
 
@@ -19,6 +20,18 @@ enum class S3ProviderType : uint8_t { S3, GCS, R2 };
 enum class S3AuthType : uint8_t { ANONYMOUS, SIGV4, BEARER };
 
 enum class S3URLStyle : uint8_t { VIRTUAL_HOSTED, PATH };
+
+enum class S3MultipartPartSizeStrategy : uint8_t { ADAPTIVE, FIXED };
+
+struct S3MultipartUploadPolicy {
+	bool operator==(const S3MultipartUploadPolicy &other) const;
+
+	S3MultipartPartSizeStrategy part_size_strategy;
+	idx_t minimum_part_size;
+	idx_t maximum_part_size;
+	idx_t maximum_part_count;
+	optional_idx maximum_object_size;
+};
 
 struct S3ProviderMatch {
 	S3ProviderType type;
@@ -51,6 +64,7 @@ struct S3Provider {
 	static void FinalizeAuthParams(S3AuthParams &auth_params);
 	static S3URLStyle ParseURLStyle(const string &url_style);
 	static S3AuthType GetAuthType(const S3AuthParams &auth_params);
+	static S3MultipartUploadPolicy GetMultipartUploadPolicy(const S3AuthParams &auth_params);
 	static string GetBadRequestError(const S3AuthParams &auth_params, const string &correct_region = "");
 	static string GetAuthError(const S3AuthParams &auth_params);
 };

--- a/src/include/s3/s3_request.hpp
+++ b/src/include/s3/s3_request.hpp
@@ -58,7 +58,8 @@ struct S3RequestSnapshot : public HTTPRequestSnapshot {
 public:
 	S3RequestSnapshot(const HTTPFSParams &http_params, const S3AuthParams &auth_params_p, string refresh_path_p,
 	                  weak_ptr<ClientContext> client_context_p = {}, bool credential_refresh_enabled_p = true,
-	                  bool region_redirected_p = false, idx_t credential_generation_p = 0);
+	                  bool region_redirected_p = false, idx_t credential_generation_p = 0,
+	                  optional<S3MultipartUploadPolicy> multipart_upload_policy_p = {});
 
 public:
 	static constexpr HTTPRequestSnapshotType TYPE = HTTPRequestSnapshotType::S3;
@@ -68,6 +69,7 @@ public:
 	bool credential_refresh_enabled;
 	bool region_redirected;
 	idx_t credential_generation;
+	optional<S3MultipartUploadPolicy> multipart_upload_policy;
 };
 
 struct S3RequestContext {

--- a/src/include/s3/s3_settings.hpp
+++ b/src/include/s3/s3_settings.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "s3/s3_provider.hpp"
+
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 
@@ -10,25 +12,25 @@ class FileOpener;
 
 struct S3UploadConfig {
 public:
-	static S3UploadConfig Create(uint64_t max_file_size, uint64_t max_parts);
-	static S3UploadConfig ReadFrom(optional_ptr<FileOpener> opener);
+	static S3UploadConfig Create(uint64_t max_file_size, uint64_t max_parts, const S3MultipartUploadPolicy &policy);
+	static S3UploadConfig ReadFrom(optional_ptr<FileOpener> opener, const S3MultipartUploadPolicy &policy);
 
-	idx_t PartSize(idx_t reserved_parts) const;
+	idx_t TargetPartSize(idx_t reserved_parts) const;
+	idx_t DirectPartSize(idx_t reserved_parts, idx_t remaining) const;
 	bool HasPartCapacity(idx_t reserved_parts) const;
 
 public:
 	//! Default upload limits
 	static constexpr uint64_t DEFAULT_MAX_FILESIZE = 80000000000;
 	static constexpr uint64_t DEFAULT_MAX_PARTS_PER_FILE = 10000;
-	static constexpr idx_t MAX_MULTIPART_PARTS = 10000;
-	static constexpr idx_t MIN_MULTIPART_PART_SIZE = 5ULL * 1024ULL * 1024ULL;
-	static constexpr idx_t MAX_MULTIPART_PART_SIZE = 5ULL * 1024ULL * 1024ULL * 1024ULL;
 	static constexpr idx_t PART_SIZE_TIERS = 11;
 
 	uint64_t max_file_size = 0;
 	idx_t max_parts = 0;
 	idx_t initial_part_size = 0;
 	idx_t growth_interval = 0;
+	idx_t maximum_part_size = 0;
+	S3MultipartPartSizeStrategy part_size_strategy = S3MultipartPartSizeStrategy::ADAPTIVE;
 };
 
 struct S3Settings {

--- a/src/include/s3/s3fs.hpp
+++ b/src/include/s3/s3fs.hpp
@@ -59,7 +59,8 @@ private:
 
 public:
 	S3FileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags, unique_ptr<HTTPParams> http_params_p,
-	             const S3AuthParams &auth_params_p, const S3UploadConfig &upload_config);
+	             const S3AuthParams &auth_params_p, const S3UploadConfig &upload_config,
+	             optional<S3MultipartUploadPolicy> multipart_upload_policy);
 	~S3FileHandle() override;
 
 public:

--- a/src/s3/s3_auth.cpp
+++ b/src/s3/s3_auth.cpp
@@ -52,6 +52,18 @@ S3AuthParams S3AuthParams::ReadFrom(S3KeyValueReader &secret_reader, const strin
 	return result;
 }
 
+void S3AuthParams::SetEndpoint(string new_endpoint) {
+	endpoint = std::move(new_endpoint);
+	auto trimmed_endpoint = endpoint;
+	StringUtil::Trim(trimmed_endpoint);
+	if (trimmed_endpoint.empty() ||
+	    (provider_type == S3ProviderType::S3 && !scheme_is_alias && endpoint == "s3.amazonaws.com")) {
+		endpoint_mode = S3EndpointMode::AUTOMATIC;
+	} else {
+		endpoint_mode = S3EndpointMode::EXPLICIT;
+	}
+}
+
 void S3AuthParams::SetRegion(string new_region) {
 	region = std::move(new_region);
 	S3Provider::FinalizeAuthParams(*this);
@@ -60,8 +72,8 @@ void S3AuthParams::SetRegion(string new_region) {
 bool S3AuthParams::operator==(const S3AuthParams &other) const {
 	return provider_type == other.provider_type && scheme_is_alias == other.scheme_is_alias && region == other.region &&
 	       access_key_id == other.access_key_id && secret_access_key == other.secret_access_key &&
-	       session_token == other.session_token && endpoint == other.endpoint && kms_key_id == other.kms_key_id &&
-	       url_style == other.url_style && use_ssl == other.use_ssl &&
+	       session_token == other.session_token && endpoint == other.endpoint && endpoint_mode == other.endpoint_mode &&
+	       kms_key_id == other.kms_key_id && url_style == other.url_style && use_ssl == other.use_ssl &&
 	       s3_url_compatibility_mode == other.s3_url_compatibility_mode && requester_pays == other.requester_pays &&
 	       oauth2_bearer_token == other.oauth2_bearer_token;
 }

--- a/src/s3/s3_delete.cpp
+++ b/src/s3/s3_delete.cpp
@@ -85,6 +85,7 @@ static void AddDeleteBatchAuthKeyParts(S3DeleteBatchKeyBuilder &key_builder, con
 	key_builder.AddString(auth_params.secret_access_key);
 	key_builder.AddString(auth_params.session_token);
 	key_builder.AddString(auth_params.endpoint);
+	key_builder.AddIndex(static_cast<idx_t>(auth_params.endpoint_mode));
 	key_builder.AddString(auth_params.kms_key_id);
 	key_builder.AddString(auth_params.url_style);
 	key_builder.AddBool(auth_params.use_ssl);

--- a/src/s3/s3_provider.cpp
+++ b/src/s3/s3_provider.cpp
@@ -12,6 +12,12 @@
 
 namespace duckdb {
 
+bool S3MultipartUploadPolicy::operator==(const S3MultipartUploadPolicy &other) const {
+	return part_size_strategy == other.part_size_strategy && minimum_part_size == other.minimum_part_size &&
+	       maximum_part_size == other.maximum_part_size && maximum_part_count == other.maximum_part_count &&
+	       maximum_object_size == other.maximum_object_size;
+}
+
 static const array<S3ProviderMatch, 6> &ProviderMatches() {
 	static const array<S3ProviderMatch, 6> provider_matches = {
 	    S3ProviderMatch {S3ProviderType::S3, "s3://"},  S3ProviderMatch {S3ProviderType::S3, "s3a://"},
@@ -328,6 +334,48 @@ S3AuthType S3Provider::GetAuthType(const S3AuthParams &auth_params) {
 		return S3AuthType::ANONYMOUS;
 	}
 	return S3AuthType::SIGV4;
+}
+
+static bool EndpointIsR2(const string &endpoint) {
+	static const string R2_ENDPOINT_SUFFIX = ".r2.cloudflarestorage.com";
+	auto host = endpoint.substr(0, endpoint.find('/'));
+	host = host.substr(0, host.find(':'));
+	host = StringUtil::Lower(host);
+	if (!StringUtil::EndsWith(host, R2_ENDPOINT_SUFFIX)) {
+		return false;
+	}
+	auto prefix = host.substr(0, host.size() - R2_ENDPOINT_SUFFIX.size());
+	auto separator = prefix.find('.');
+	if (prefix.empty() || separator == 0) {
+		return false;
+	}
+	if (separator == string::npos) {
+		return true;
+	}
+	auto jurisdiction = prefix.substr(separator + 1);
+	return jurisdiction == "eu" || jurisdiction == "us" || jurisdiction == "fedramp";
+}
+
+static S3MultipartUploadPolicy DefaultMultipartUploadPolicy() {
+	static constexpr idx_t MIB = 1024ULL * 1024ULL;
+	static constexpr idx_t GIB = 1024ULL * MIB;
+	return {S3MultipartPartSizeStrategy::ADAPTIVE, 5ULL * MIB, 5ULL * GIB, 10000, optional_idx()};
+}
+
+static S3MultipartUploadPolicy R2MultipartUploadPolicy() {
+	static constexpr idx_t MIB = 1024ULL * 1024ULL;
+	static constexpr idx_t GIB = 1024ULL * MIB;
+	static constexpr idx_t MAXIMUM_PART_SIZE = 5ULL * GIB - 5ULL * MIB;
+	static constexpr idx_t MAXIMUM_OBJECT_SIZE = 5ULL * 1024ULL * GIB - 5ULL * GIB;
+	return {S3MultipartPartSizeStrategy::FIXED, 8ULL * MIB, MAXIMUM_PART_SIZE, 10000, MAXIMUM_OBJECT_SIZE};
+}
+
+S3MultipartUploadPolicy S3Provider::GetMultipartUploadPolicy(const S3AuthParams &auth_params) {
+	if (auth_params.provider_type == S3ProviderType::R2 ||
+	    (auth_params.provider_type == S3ProviderType::S3 && EndpointIsR2(auth_params.endpoint))) {
+		return R2MultipartUploadPolicy();
+	}
+	return DefaultMultipartUploadPolicy();
 }
 
 string S3Provider::GetBadRequestError(const S3AuthParams &auth_params, const string &correct_region) {

--- a/src/s3/s3_provider.cpp
+++ b/src/s3/s3_provider.cpp
@@ -218,16 +218,19 @@ void S3Provider::ReadAuthParams(S3KeyValueReader &secret_reader, const string &f
 	                                        "s3_url_compatibility_mode", result.s3_url_compatibility_mode);
 	secret_reader.TryGetSecretKeyOrSetting("requester_pays", "s3_requester_pays", result.requester_pays);
 
-	auto endpoint_result = secret_reader.TryGetSecretKeyOrSetting("endpoint", "s3_endpoint", result.endpoint);
+	string endpoint;
+	auto endpoint_result = secret_reader.TryGetSecretKeyOrSetting("endpoint", "s3_endpoint", endpoint);
 	auto url_style_result = secret_reader.TryGetSecretKeyOrSetting("url_style", "s3_url_style", result.url_style);
 	if (result.provider_type == S3ProviderType::GCS) {
-		if (result.endpoint.empty() || !endpoint_result || endpoint_result.GetScope() != SettingScope::SECRET) {
-			result.endpoint = "storage.googleapis.com";
+		if (endpoint_result && endpoint_result.GetScope() == SettingScope::SECRET) {
+			result.SetEndpoint(std::move(endpoint));
 		}
 		if (result.url_style.empty() || !url_style_result || url_style_result.GetScope() != SettingScope::SECRET) {
 			result.url_style = "path";
 		}
 		secret_reader.TryGetSecretKey("bearer_token", result.oauth2_bearer_token);
+	} else {
+		result.SetEndpoint(std::move(endpoint));
 	}
 	InitializeAuthParams(result);
 }
@@ -255,8 +258,9 @@ static void ApplyProviderDefaults(S3AuthParams &auth_params) {
 	if (auth_params.provider_type != S3ProviderType::GCS) {
 		return;
 	}
-	if (auth_params.endpoint.empty()) {
+	if (EndpointIsUnresolved(auth_params)) {
 		auth_params.endpoint = "storage.googleapis.com";
+		auth_params.endpoint_mode = S3EndpointMode::AUTOMATIC;
 	}
 	if (auth_params.url_style.empty()) {
 		auth_params.url_style = "path";
@@ -264,21 +268,27 @@ static void ApplyProviderDefaults(S3AuthParams &auth_params) {
 }
 
 static void ApplyDerivedDefaults(S3AuthParams &auth_params) {
-	if (!EndpointIsAWS(auth_params.endpoint)) {
+	if (auth_params.provider_type != S3ProviderType::S3 ||
+	    (auth_params.endpoint_mode == S3EndpointMode::EXPLICIT && !EndpointIsAWS(auth_params.endpoint))) {
 		return;
 	}
 	if (auth_params.region.empty()) {
 		if (auth_params.access_key_id.empty()) {
-			auth_params.endpoint = "s3.amazonaws.com";
+			if (auth_params.endpoint_mode == S3EndpointMode::AUTOMATIC) {
+				auth_params.endpoint = "s3.amazonaws.com";
+			}
 			return;
 		}
 		auth_params.region = "us-east-1";
 	}
-	auth_params.endpoint = StringUtil::Format("s3.%s.amazonaws.com", auth_params.region);
+	if (auth_params.endpoint_mode == S3EndpointMode::AUTOMATIC) {
+		auth_params.endpoint = StringUtil::Format("s3.%s.amazonaws.com", auth_params.region);
+	}
 }
 
 void S3Provider::InitializeAuthParams(S3AuthParams &auth_params) {
 	ApplyProviderDefaults(auth_params);
+	ParseURLStyle(auth_params.url_style);
 	if (RequiresExplicitEndpoint(auth_params) && EndpointIsUnresolved(auth_params)) {
 		// Url query parameters still get to supply one; FinalizeAuthParams rejects it if none did
 		return;
@@ -288,6 +298,7 @@ void S3Provider::InitializeAuthParams(S3AuthParams &auth_params) {
 
 void S3Provider::FinalizeAuthParams(S3AuthParams &auth_params) {
 	ApplyProviderDefaults(auth_params);
+	ParseURLStyle(auth_params.url_style);
 	if (RequiresExplicitEndpoint(auth_params) && EndpointIsUnresolved(auth_params)) {
 		if (auth_params.provider_type == S3ProviderType::R2) {
 			throw IOException("R2 requires an endpoint; provide account_id in the secret or s3_endpoint in the URL");
@@ -296,6 +307,17 @@ void S3Provider::FinalizeAuthParams(S3AuthParams &auth_params) {
 		                  "s3_endpoint, or pass s3_endpoint in the URL");
 	}
 	ApplyDerivedDefaults(auth_params);
+}
+
+S3URLStyle S3Provider::ParseURLStyle(const string &url_style) {
+	if (url_style.empty() || url_style == "vhost" || url_style == "virtual") {
+		return S3URLStyle::VIRTUAL_HOSTED;
+	}
+	if (url_style == "path") {
+		return S3URLStyle::PATH;
+	}
+	throw InvalidInputException("Invalid S3 URL style '%s': expected 'vhost', 'virtual', 'path', or an empty string",
+	                            url_style);
 }
 
 S3AuthType S3Provider::GetAuthType(const S3AuthParams &auth_params) {

--- a/src/s3/s3_request.cpp
+++ b/src/s3/s3_request.cpp
@@ -724,11 +724,17 @@ bool S3RequestExecutor::TryRefreshSession(HTTPRequestSession &session, const S3R
 		if (latest.region_redirected) {
 			merged_auth_params.SetRegion(latest.auth_params.region);
 		}
+		if (latest.multipart_upload_policy &&
+		    !(S3Provider::GetMultipartUploadPolicy(merged_auth_params) == *latest.multipart_upload_policy)) {
+			throw IOException("Cannot refresh credentials for an active S3 upload because the refreshed endpoint "
+			                  "requires a different multipart upload policy");
+		}
 		auto merged_http_params = latest.CreateRequestParams();
 		refreshed_http_material.Apply(*merged_http_params);
 		auto replacement = make_shared_ptr<S3RequestSnapshot>(
 		    *merged_http_params, merged_auth_params, latest.refresh_path, latest.client_context,
-		    latest.credential_refresh_enabled, latest.region_redirected, latest.credential_generation + 1);
+		    latest.credential_refresh_enabled, latest.region_redirected, latest.credential_generation + 1,
+		    latest.multipart_upload_policy);
 		auto publication = session.TryPublish(current.snapshot, std::move(replacement));
 		if (publication.published) {
 			return true;
@@ -749,9 +755,10 @@ bool S3RequestExecutor::SetSessionRegion(HTTPRequestSession &session, const stri
 		previous_region = auth_params.region;
 		auth_params.SetRegion(correct_region);
 		auto http_params = snapshot.CreateRequestParams();
-		auto replacement = make_shared_ptr<S3RequestSnapshot>(
-		    *http_params, auth_params, snapshot.refresh_path, snapshot.client_context,
-		    snapshot.credential_refresh_enabled, true, snapshot.credential_generation);
+		auto replacement =
+		    make_shared_ptr<S3RequestSnapshot>(*http_params, auth_params, snapshot.refresh_path,
+		                                       snapshot.client_context, snapshot.credential_refresh_enabled, true,
+		                                       snapshot.credential_generation, snapshot.multipart_upload_policy);
 		auto publication = session.TryPublish(current.snapshot, std::move(replacement));
 		if (publication.published) {
 			return true;
@@ -869,10 +876,12 @@ HTTPException S3RequestUtil::GetRequestError(const S3RequestData &request_data, 
 S3RequestSnapshot::S3RequestSnapshot(const HTTPFSParams &http_params, const S3AuthParams &auth_params_p,
                                      string refresh_path_p, weak_ptr<ClientContext> client_context_p,
                                      bool credential_refresh_enabled_p, bool region_redirected_p,
-                                     idx_t credential_generation_p)
+                                     idx_t credential_generation_p,
+                                     optional<S3MultipartUploadPolicy> multipart_upload_policy_p)
     : HTTPRequestSnapshot(http_params, TYPE), auth_params(auth_params_p), refresh_path(std::move(refresh_path_p)),
       client_context(std::move(client_context_p)), credential_refresh_enabled(credential_refresh_enabled_p),
-      region_redirected(region_redirected_p), credential_generation(credential_generation_p) {
+      region_redirected(region_redirected_p), credential_generation(credential_generation_p),
+      multipart_upload_policy(std::move(multipart_upload_policy_p)) {
 }
 
 string S3RequestUtil::GetPayloadHash(EncryptionUtil &encryption_util, const_data_ptr_t buffer, idx_t buffer_len) {

--- a/src/s3/s3_settings.cpp
+++ b/src/s3/s3_settings.cpp
@@ -1,7 +1,6 @@
 #include "s3/s3_settings.hpp"
 
 #include "s3/s3_auth.hpp"
-#include "s3/s3_provider.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/storage/storage_info.hpp"
@@ -12,11 +11,11 @@ namespace {
 
 struct S3UploadSizing {
 	static bool ScheduleCovers(uint64_t initial_part_size, uint64_t max_file_size, idx_t max_parts,
-	                           idx_t growth_interval) {
+	                           idx_t growth_interval, idx_t maximum_part_size) {
 		uint64_t capacity = 0;
 		idx_t completed_parts = 0;
 		while (completed_parts < max_parts) {
-			auto part_size = PartSize(initial_part_size, growth_interval, completed_parts);
+			auto part_size = PartSize(initial_part_size, growth_interval, completed_parts, maximum_part_size);
 			auto parts_at_size = MinValue<idx_t>(growth_interval, max_parts - completed_parts);
 			if (part_size > (max_file_size - MinValue<uint64_t>(capacity, max_file_size)) / parts_at_size) {
 				return true;
@@ -30,25 +29,28 @@ struct S3UploadSizing {
 		return false;
 	}
 
-	static idx_t PartSize(uint64_t initial_part_size, idx_t growth_interval, idx_t completed_parts) {
+	static idx_t PartSize(uint64_t initial_part_size, idx_t growth_interval, idx_t completed_parts,
+	                      idx_t maximum_part_size) {
 		auto result = initial_part_size;
 		auto doubling_count = completed_parts / growth_interval;
-		while (doubling_count > 0 && result < S3UploadConfig::MAX_MULTIPART_PART_SIZE) {
-			result = MinValue<uint64_t>(result * 2, S3UploadConfig::MAX_MULTIPART_PART_SIZE);
+		while (doubling_count > 0 && result < maximum_part_size) {
+			result = result > maximum_part_size / 2 ? maximum_part_size : result * 2;
 			doubling_count--;
 		}
 		return NumericCast<idx_t>(result);
 	}
 
-	static idx_t InitialPartSize(uint64_t max_file_size, idx_t max_parts, idx_t growth_interval) {
+	static idx_t InitialPartSize(uint64_t max_file_size, idx_t max_parts, idx_t growth_interval,
+	                             const S3MultipartUploadPolicy &policy) {
 		const auto block_size = NumericCast<uint64_t>(Storage::DEFAULT_BLOCK_SIZE + Storage::DEFAULT_BLOCK_HEADER_SIZE);
-		D_ASSERT(S3UploadConfig::MIN_MULTIPART_PART_SIZE % block_size == 0);
-		D_ASSERT(S3UploadConfig::MAX_MULTIPART_PART_SIZE % block_size == 0);
-		auto lower = NumericCast<uint64_t>(S3UploadConfig::MIN_MULTIPART_PART_SIZE) / block_size;
-		auto upper = NumericCast<uint64_t>(S3UploadConfig::MAX_MULTIPART_PART_SIZE) / block_size;
+		D_ASSERT(policy.minimum_part_size % block_size == 0);
+		D_ASSERT(policy.maximum_part_size % block_size == 0);
+		auto lower = NumericCast<uint64_t>(policy.minimum_part_size) / block_size;
+		auto upper = NumericCast<uint64_t>(policy.maximum_part_size) / block_size;
 		while (lower < upper) {
 			auto middle = lower + (upper - lower) / 2;
-			if (ScheduleCovers(middle * block_size, max_file_size, max_parts, growth_interval)) {
+			if (ScheduleCovers(middle * block_size, max_file_size, max_parts, growth_interval,
+			                   policy.maximum_part_size)) {
 				upper = middle;
 			} else {
 				lower = middle + 1;
@@ -56,7 +58,48 @@ struct S3UploadSizing {
 		}
 		return NumericCast<idx_t>(lower * block_size);
 	}
+
+	static idx_t FixedPartSize(uint64_t required_part_size, const S3MultipartUploadPolicy &policy) {
+		auto part_size = NumericCast<uint64_t>(policy.minimum_part_size);
+		while (part_size < required_part_size && part_size <= policy.maximum_part_size / 2) {
+			part_size *= 2;
+		}
+		if (part_size >= required_part_size) {
+			return NumericCast<idx_t>(part_size);
+		}
+		D_ASSERT(required_part_size <= policy.maximum_part_size);
+		return policy.maximum_part_size;
+	}
 };
+
+static void ValidateMultipartUploadPolicy(const S3MultipartUploadPolicy &policy) {
+	if (policy.minimum_part_size == 0) {
+		throw InvalidConfigurationException("S3 multipart upload policy requires a nonzero minimum part size");
+	}
+	if (policy.maximum_part_size < policy.minimum_part_size) {
+		throw InvalidConfigurationException(
+		    "S3 multipart upload policy maximum part size is smaller than its minimum part size");
+	}
+	if (policy.maximum_part_count == 0) {
+		throw InvalidConfigurationException("S3 multipart upload policy requires a nonzero maximum part count");
+	}
+	if (policy.maximum_object_size.IsValid() && policy.maximum_object_size.GetIndex() == 0) {
+		throw InvalidConfigurationException("S3 multipart upload policy maximum object size must be nonzero");
+	}
+	switch (policy.part_size_strategy) {
+	case S3MultipartPartSizeStrategy::ADAPTIVE: {
+		const auto block_size = Storage::DEFAULT_BLOCK_SIZE + Storage::DEFAULT_BLOCK_HEADER_SIZE;
+		if (policy.minimum_part_size % block_size != 0 || policy.maximum_part_size % block_size != 0) {
+			throw InvalidConfigurationException("Adaptive S3 multipart upload policy part sizes must be block aligned");
+		}
+		break;
+	}
+	case S3MultipartPartSizeStrategy::FIXED:
+		break;
+	default:
+		throw InvalidConfigurationException("S3 multipart upload policy has an unknown part-size strategy");
+	}
+}
 
 } // namespace
 
@@ -64,28 +107,41 @@ static void SetS3URLStyle(ClientContext &, SetScope, Value &parameter) {
 	S3Provider::ParseURLStyle(StringValue::Get(parameter));
 }
 
-S3UploadConfig S3UploadConfig::Create(uint64_t max_file_size, uint64_t max_parts) {
+S3UploadConfig S3UploadConfig::Create(uint64_t max_file_size, uint64_t max_parts,
+                                      const S3MultipartUploadPolicy &policy) {
+	ValidateMultipartUploadPolicy(policy);
 	if (max_file_size == 0) {
 		throw InvalidInputException("s3_uploader_max_filesize must be greater than zero");
 	}
-	if (max_parts == 0 || max_parts > MAX_MULTIPART_PARTS) {
-		throw InvalidInputException("s3_uploader_max_parts_per_file must be between 1 and 10000");
+	if (max_parts == 0 || max_parts > policy.maximum_part_count) {
+		throw InvalidInputException("s3_uploader_max_parts_per_file must be between 1 and %llu",
+		                            policy.maximum_part_count);
 	}
-	const auto supported_file_size = NumericCast<uint64_t>(MAX_MULTIPART_PART_SIZE) * max_parts;
-	if (max_file_size > supported_file_size) {
+	const auto required_part_size = max_file_size / max_parts + (max_file_size % max_parts != 0);
+	if (required_part_size > policy.maximum_part_size) {
 		throw InvalidInputException(
 		    "s3_uploader_max_filesize exceeds the size supported by s3_uploader_max_parts_per_file");
+	}
+	if (policy.maximum_object_size.IsValid() && max_file_size > policy.maximum_object_size.GetIndex()) {
+		throw InvalidInputException("s3_uploader_max_filesize exceeds the provider's maximum object size");
 	}
 
 	S3UploadConfig result;
 	result.max_file_size = max_file_size;
 	result.max_parts = NumericCast<idx_t>(max_parts);
-	result.growth_interval = (result.max_parts + PART_SIZE_TIERS - 1) / PART_SIZE_TIERS;
-	result.initial_part_size = S3UploadSizing::InitialPartSize(max_file_size, result.max_parts, result.growth_interval);
+	result.maximum_part_size = policy.maximum_part_size;
+	result.part_size_strategy = policy.part_size_strategy;
+	if (policy.part_size_strategy == S3MultipartPartSizeStrategy::FIXED) {
+		result.initial_part_size = S3UploadSizing::FixedPartSize(required_part_size, policy);
+		return result;
+	}
+	result.growth_interval = result.max_parts / PART_SIZE_TIERS + (result.max_parts % PART_SIZE_TIERS != 0);
+	result.initial_part_size =
+	    S3UploadSizing::InitialPartSize(max_file_size, result.max_parts, result.growth_interval, policy);
 	return result;
 }
 
-S3UploadConfig S3UploadConfig::ReadFrom(optional_ptr<FileOpener> opener) {
+S3UploadConfig S3UploadConfig::ReadFrom(optional_ptr<FileOpener> opener, const S3MultipartUploadPolicy &policy) {
 	uint64_t uploader_max_filesize;
 	uint64_t max_parts_per_file;
 	Value value;
@@ -100,14 +156,26 @@ S3UploadConfig S3UploadConfig::ReadFrom(optional_ptr<FileOpener> opener) {
 	} else {
 		max_parts_per_file = S3UploadConfig::DEFAULT_MAX_PARTS_PER_FILE;
 	}
-	return Create(uploader_max_filesize, max_parts_per_file);
+	return Create(uploader_max_filesize, max_parts_per_file, policy);
 }
 
-idx_t S3UploadConfig::PartSize(idx_t reserved_parts) const {
-	D_ASSERT(initial_part_size >= MIN_MULTIPART_PART_SIZE);
-	D_ASSERT(initial_part_size <= MAX_MULTIPART_PART_SIZE);
+idx_t S3UploadConfig::TargetPartSize(idx_t reserved_parts) const {
+	if (part_size_strategy == S3MultipartPartSizeStrategy::FIXED) {
+		D_ASSERT(initial_part_size <= maximum_part_size);
+		return initial_part_size;
+	}
+	D_ASSERT(initial_part_size <= maximum_part_size);
 	D_ASSERT(growth_interval > 0);
-	return S3UploadSizing::PartSize(initial_part_size, growth_interval, reserved_parts);
+	return S3UploadSizing::PartSize(initial_part_size, growth_interval, reserved_parts, maximum_part_size);
+}
+
+idx_t S3UploadConfig::DirectPartSize(idx_t reserved_parts, idx_t remaining) const {
+	auto target_part_size = TargetPartSize(reserved_parts);
+	D_ASSERT(remaining >= target_part_size);
+	if (part_size_strategy == S3MultipartPartSizeStrategy::FIXED) {
+		return target_part_size;
+	}
+	return MinValue<idx_t>(remaining, maximum_part_size);
 }
 
 bool S3UploadConfig::HasPartCapacity(idx_t reserved_parts) const {

--- a/src/s3/s3_settings.cpp
+++ b/src/s3/s3_settings.cpp
@@ -60,6 +60,10 @@ struct S3UploadSizing {
 
 } // namespace
 
+static void SetS3URLStyle(ClientContext &, SetScope, Value &parameter) {
+	S3Provider::ParseURLStyle(StringValue::Get(parameter));
+}
+
 S3UploadConfig S3UploadConfig::Create(uint64_t max_file_size, uint64_t max_parts) {
 	if (max_file_size == 0) {
 		throw InvalidInputException("s3_uploader_max_filesize must be greater than zero");
@@ -116,7 +120,7 @@ void S3Settings::Register(DBConfig &config) {
 	config.AddExtensionOption("s3_secret_access_key", "S3 Access Key", LogicalType::VARCHAR);
 	config.AddExtensionOption("s3_session_token", "S3 Session Token", LogicalType::VARCHAR);
 	config.AddExtensionOption("s3_endpoint", "S3 Endpoint", LogicalType::VARCHAR);
-	config.AddExtensionOption("s3_url_style", "S3 URL style", LogicalType::VARCHAR, Value("vhost"));
+	config.AddExtensionOption("s3_url_style", "S3 URL style", LogicalType::VARCHAR, Value("vhost"), SetS3URLStyle);
 	config.AddExtensionOption("s3_use_ssl", "S3 use SSL", LogicalType::BOOLEAN, Value(true));
 	config.AddExtensionOption("s3_kms_key_id", "S3 KMS Key ID", LogicalType::VARCHAR);
 	config.AddExtensionOption("s3_url_compatibility_mode", "Disable Globs and Query Parameters on S3 URLs",

--- a/src/s3/s3_upload_session.cpp
+++ b/src/s3/s3_upload_session.cpp
@@ -323,7 +323,7 @@ S3UploadSession::PreparedWrite S3UploadSession::PrepareWrite(const_data_ptr_t da
 
 			while (input_offset < size) {
 				auto remaining = size - input_offset;
-				auto part_size = config.PartSize(part_etags.size());
+				auto part_size = config.TargetPartSize(part_etags.size());
 				auto should_buffer = part_etags.empty() ? remaining <= part_size : remaining < part_size;
 				if (should_buffer) {
 					result.buffered_part = AllocateBufferedPart(part_size);
@@ -332,7 +332,7 @@ S3UploadSession::PreparedWrite S3UploadSession::PrepareWrite(const_data_ptr_t da
 					input_offset += copied;
 					break;
 				}
-				auto direct_size = MinValue<idx_t>(remaining, S3UploadConfig::MAX_MULTIPART_PART_SIZE);
+				auto direct_size = config.DirectPartSize(part_etags.size(), remaining);
 				ReservePart(result, data + input_offset, direct_size);
 				input_offset += direct_size;
 			}

--- a/src/s3/s3_url.cpp
+++ b/src/s3/s3_url.cpp
@@ -12,12 +12,14 @@ string S3Url::Encode(const string &input, S3URLEncodeMode mode) {
 	return StringUtil::URLEncode(input, mode == S3URLEncodeMode::QUERY_COMPONENT);
 }
 
-static void GetQueryParam(const string &key, string &param, unordered_map<string, string> &query_params) {
+static bool GetQueryParam(const string &key, string &param, unordered_map<string, string> &query_params) {
 	auto found_param = query_params.find(key);
-	if (found_param != query_params.end()) {
-		param = found_param->second;
-		query_params.erase(found_param);
+	if (found_param == query_params.end()) {
+		return false;
 	}
+	param = found_param->second;
+	query_params.erase(found_param);
+	return true;
 }
 
 unordered_map<string, string> S3Url::ParseQueryParameters(const string &url_query_param) {
@@ -57,8 +59,13 @@ void S3Url::ReadQueryParams(const string &url_query_param, S3AuthParams &params)
 	GetQueryParam("s3_access_key_id", params.access_key_id, query_params);
 	GetQueryParam("s3_secret_access_key", params.secret_access_key, query_params);
 	GetQueryParam("s3_session_token", params.session_token, query_params);
-	GetQueryParam("s3_endpoint", params.endpoint, query_params);
-	GetQueryParam("s3_url_style", params.url_style, query_params);
+	string endpoint;
+	if (GetQueryParam("s3_endpoint", endpoint, query_params)) {
+		params.SetEndpoint(std::move(endpoint));
+	}
+	if (GetQueryParam("s3_url_style", params.url_style, query_params)) {
+		S3Provider::ParseURLStyle(params.url_style);
+	}
 	auto found_param = query_params.find("s3_use_ssl");
 	if (found_param != query_params.end()) {
 		if (found_param->second == "true") {
@@ -168,9 +175,10 @@ ParsedS3Url S3Url::Parse(const string &url, const S3AuthParams &params) {
 
 	// Update host and path according to the url style
 	// See https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
-	bool use_vhost = params.url_style.empty() || params.url_style == "vhost" || params.url_style == "virtual";
+	auto url_style = S3Provider::ParseURLStyle(params.url_style);
+	bool use_vhost = url_style == S3URLStyle::VIRTUAL_HOSTED;
 	// A bucket name containing periods (.) is not addressable vhost-style over TLS. Fallback to path style url
-	bool use_path = params.url_style == "path" || (use_vhost && params.use_ssl && bucket.find('.') != string::npos);
+	bool use_path = url_style == S3URLStyle::PATH || (use_vhost && params.use_ssl && bucket.find('.') != string::npos);
 	if (use_path) {
 		path += "/" + bucket;
 	} else if (use_vhost) {

--- a/src/s3/s3fs.cpp
+++ b/src/s3/s3fs.cpp
@@ -31,12 +31,15 @@ S3FileHandle::UploadClaim::~UploadClaim() {
 
 S3FileHandle::S3FileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags,
                            unique_ptr<HTTPParams> http_params_p, const S3AuthParams &auth_params_p,
-                           const S3UploadConfig &upload_config)
+                           const S3UploadConfig &upload_config,
+                           optional<S3MultipartUploadPolicy> multipart_upload_policy)
     : HTTPFileHandle(fs, file, flags, std::move(http_params_p)) {
 	auto captured = request_session->Capture();
 	auto request_params = captured.snapshot->CreateRequestParams();
 	request_session->TryPublish(captured.snapshot,
-	                            make_shared_ptr<S3RequestSnapshot>(*request_params, auth_params_p, file.path));
+	                            make_shared_ptr<S3RequestSnapshot>(*request_params, auth_params_p, file.path,
+	                                                               weak_ptr<ClientContext>(), true, false, 0,
+	                                                               std::move(multipart_upload_policy)));
 	auto_fallback_to_full_file_download = false;
 	if (flags.OpenForReading() && flags.OpenForWriting()) {
 		throw NotImplementedException("Cannot open an HTTP file for both reading and writing");
@@ -72,7 +75,8 @@ shared_ptr<const HTTPRequestSnapshot> S3FileHandle::CreateRequestSnapshot(const 
 	auto &s3_snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
 	return make_shared_ptr<S3RequestSnapshot>(params, s3_snapshot.auth_params, s3_snapshot.refresh_path,
 	                                          s3_snapshot.client_context, s3_snapshot.credential_refresh_enabled,
-	                                          s3_snapshot.region_redirected, s3_snapshot.credential_generation);
+	                                          s3_snapshot.region_redirected, s3_snapshot.credential_generation,
+	                                          s3_snapshot.multipart_upload_policy);
 }
 
 S3FileHandle::~S3FileHandle() = default;
@@ -182,11 +186,14 @@ unique_ptr<HTTPFileHandle> S3FileSystem::CreateHandle(const OpenFileInfo &file, 
 	auto &http_util = HTTPFSUtil::GetHTTPUtil(opener);
 	auto params = http_util.InitializeParameters(opener, info);
 	S3UploadConfig upload_config;
+	optional<S3MultipartUploadPolicy> multipart_upload_policy;
 	if (flags.OpenForWriting()) {
-		upload_config = S3UploadConfig::ReadFrom(opener);
+		multipart_upload_policy = S3Provider::GetMultipartUploadPolicy(auth_params);
+		upload_config = S3UploadConfig::ReadFrom(opener, *multipart_upload_policy);
 	}
 
-	return make_uniq<S3FileHandle>(*this, file, flags, std::move(params), auth_params, upload_config);
+	return make_uniq<S3FileHandle>(*this, file, flags, std::move(params), auth_params, upload_config,
+	                               std::move(multipart_upload_policy));
 }
 
 void S3FileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cache_entry) {
@@ -218,10 +225,11 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 		if (context && refresh_enabled) {
 			weak_context = context->shared_from_this();
 		}
-		request_session->TryPublish(captured.snapshot, make_shared_ptr<S3RequestSnapshot>(
-		                                                   *request_params, snapshot.auth_params, snapshot.refresh_path,
-		                                                   std::move(weak_context), refresh_enabled,
-		                                                   snapshot.region_redirected, snapshot.credential_generation));
+		request_session->TryPublish(
+		    captured.snapshot,
+		    make_shared_ptr<S3RequestSnapshot>(*request_params, snapshot.auth_params, snapshot.refresh_path,
+		                                       std::move(weak_context), refresh_enabled, snapshot.region_redirected,
+		                                       snapshot.credential_generation, snapshot.multipart_upload_policy));
 	}
 	HTTPFileHandle::Initialize(opener);
 }

--- a/test/sql/copy/s3/download_config.test
+++ b/test/sql/copy/s3/download_config.test
@@ -101,13 +101,14 @@ SELECT i FROM "http://test-bucket-public.{DUCKDB_S3_ENDPOINT}/root-dir/test_defa
 1
 2
 
-# Incorrect path style throws error
-statement ok
-SET s3_url_style='handwritten';
-
+# Incorrect path style is rejected by the setting
 statement error
-COPY test TO 's3://test-bucket-public/root-dir/test2.parquet';
+SET s3_url_style='handwritten';
 ----
+Invalid Input Error: Invalid S3 URL style 'handwritten': expected 'vhost', 'virtual', 'path', or an empty string
+
+statement ok
+SET s3_url_style='vhost';
 
 # 404
 statement error

--- a/test/sql/copy/s3/download_config.test
+++ b/test/sql/copy/s3/download_config.test
@@ -108,7 +108,7 @@ SET s3_url_style='handwritten';
 Invalid Input Error: Invalid S3 URL style 'handwritten': expected 'vhost', 'virtual', 'path', or an empty string
 
 statement ok
-SET s3_url_style='vhost';
+SET s3_url_style='path';
 
 # 404
 statement error

--- a/test/sql/secrets/create_secret_binding.test
+++ b/test/sql/secrets/create_secret_binding.test
@@ -73,6 +73,24 @@ CREATE SECRET s3_url_style_virtual (
     URL_STYLE VIRTUAL
 )
 
+statement error
+CREATE SECRET s3_url_style_invalid (
+    TYPE S3,
+    PROVIDER config,
+    URL_STYLE 'handwritten'
+)
+----
+Invalid Input Error: Invalid S3 URL style 'handwritten': expected 'vhost', 'virtual', 'path', or an empty string
+
+statement error
+CREATE SECRET s3_url_style_default (
+    TYPE S3,
+    PROVIDER config,
+    URL_STYLE 'default'
+)
+----
+Invalid Input Error: Invalid S3 URL style 'default': expected 'vhost', 'virtual', 'path', or an empty string
+
 query II
 SELECT name, regexp_extract(secret_string, 'url_style=([^;]*)', 1)
 FROM duckdb_secrets(redact=false)

--- a/test/sql/secrets/create_secret_r2_serialization.test
+++ b/test/sql/secrets/create_secret_r2_serialization.test
@@ -24,7 +24,7 @@ CREATE OR REPLACE PERSISTENT SECRET s1 (
     REGION 'meregion',
     SESSION_TOKEN 'mesesh',
     ENDPOINT 'meendpoint',
-    URL_STYLE 'mahstyle',
+    URL_STYLE 'virtual',
     USE_SSL true,
     URL_COMPATIBILITY_MODE true
 )

--- a/test/sql/secrets/create_secret_s3_serialization.test
+++ b/test/sql/secrets/create_secret_s3_serialization.test
@@ -22,7 +22,7 @@ CREATE OR REPLACE PERSISTENT SECRET s1 (
     REGION 'meregion',
     SESSION_TOKEN 'mesesh',
     ENDPOINT 'meendpoint',
-    URL_STYLE 'mahstyle',
+    URL_STYLE 'virtual',
     USE_SSL true,
     URL_COMPATIBILITY_MODE true
 )
@@ -36,7 +36,7 @@ CREATE OR REPLACE PERSISTENT SECRET s2 (
     KEY_ID 'mekey',
     SECRET 'mesecret',
     SESSION_TOKEN 'mesesh',
-    URL_STYLE 'mahstyle',
+    URL_STYLE 'virtual',
     USE_SSL 1,
     URL_COMPATIBILITY_MODE 1
 )
@@ -49,7 +49,7 @@ CREATE OR REPLACE PERSISTENT SECRET s3 (
     KEY_ID 'mekey',
     SECRET 'mesecret',
     SESSION_TOKEN 'mesesh',
-    URL_STYLE 'mahstyle',
+    URL_STYLE 'virtual',
     USE_SSL true,
     URL_COMPATIBILITY_MODE true
 )

--- a/test/unittest/s3/mock_s3_server.cpp
+++ b/test/unittest/s3/mock_s3_server.cpp
@@ -547,11 +547,22 @@ public:
 		string completed_object;
 		completed_object.reserve(completed_size);
 		idx_t previous_part_number = 0;
-		for (const auto &manifest_part : manifest) {
+		idx_t fixed_part_size = 0;
+		for (idx_t part_index = 0; part_index < manifest.size(); part_index++) {
+			const auto &manifest_part = manifest[part_index];
 			auto uploaded_part = uploaded_parts.find(manifest_part.part_number);
 			if (manifest_part.part_number <= previous_part_number || uploaded_part == uploaded_parts.end() ||
 			    manifest_part.etag != uploaded_part->second.etag) {
 				return false;
+			}
+			if (config.upload.geometry == MockS3MultipartGeometry::FIXED_EQUAL) {
+				auto part_size = uploaded_part->second.body.size();
+				if (part_index == 0) {
+					fixed_part_size = part_size;
+				} else if ((part_index + 1 < manifest.size() && part_size != fixed_part_size) ||
+				           (part_index + 1 == manifest.size() && part_size > fixed_part_size)) {
+					return false;
+				}
 			}
 			completed_object += uploaded_part->second.body;
 			previous_part_number = manifest_part.part_number;
@@ -733,8 +744,94 @@ public:
 		Record(request, response.status);
 	}
 
+	void HandleObjectPut(const httplib::Request &request, httplib::Response &response) {
+		auto part_number = GetPartNumber(request);
+		unique_ptr<ActivePartUpload> active_upload;
+		if (part_number.IsValid()) {
+			active_upload = make_uniq<ActivePartUpload>(*this, part_number.GetIndex());
+			WaitForPartRelease(part_number.GetIndex());
+		}
+		if (ShouldRejectStaleCredentials(request)) {
+			SendAuthFailure(request, response);
+			return;
+		}
+		if (part_number.IsValid() &&
+		    std::find(config.upload.failed_part_numbers.begin(), config.upload.failed_part_numbers.end(),
+		              part_number.GetIndex()) != config.upload.failed_part_numbers.end()) {
+			SendS3Error400(request, response, false);
+			return;
+		}
+		if (remaining_put_failures.load() > 0) {
+			remaining_put_failures--;
+			SendS3Error400(request, response, config.failures.failure_is_request_timeout);
+			return;
+		}
+		SendPutSuccess(request, response);
+	}
+
+	void HandleObjectPost(const httplib::Request &request, httplib::Response &response) {
+		if (ShouldRejectStaleCredentials(request)) {
+			SendAuthFailure(request, response);
+			return;
+		}
+		if (request.target.find("uploads") != string::npos && remaining_post_failures.load() > 0) {
+			remaining_post_failures--;
+			if (config.failures.transient_post_status == 400) {
+				SendS3Error400(request, response, config.failures.failure_is_request_timeout);
+			} else {
+				response.status = config.failures.transient_post_status;
+				response.set_content(
+				    "<Error><Code>TooManyRequests</Code><Message>Injected initialization throttle</Message></Error>",
+				    "application/xml");
+				Record(request, response.status);
+			}
+			return;
+		}
+		if (request.target.find("uploadId") != string::npos && remaining_completion_faults.load() > 0) {
+			remaining_completion_faults--;
+			SendCompletionFault(request, response);
+			return;
+		}
+		SendMultipartPost(request, response);
+	}
+
+	void HandleObjectDelete(const httplib::Request &request, httplib::Response &response) {
+		if (ShouldRejectStaleCredentials(request)) {
+			SendAuthFailure(request, response);
+			return;
+		}
+		auto upload_id = GetParameter(request, "uploadId");
+		if (!upload_id.empty()) {
+			if (config.upload.abort_behavior == MockS3MultipartAbortBehavior::ERROR) {
+				SendS3Error400(request, response, false);
+				return;
+			}
+			if (upload_id != config.upload.upload_id) {
+				response.status = 404;
+				response.set_content("<Error><Code>NoSuchUpload</Code></Error>", "application/xml");
+				Record(request, response.status);
+				return;
+			}
+			{
+				annotated_lock_guard<annotated_mutex> lock(upload_lock);
+				uploaded_parts.clear();
+			}
+			response.status = 204;
+			Record(request, response.status);
+			return;
+		}
+		if (remaining_delete_failures.load() > 0) {
+			remaining_delete_failures--;
+			SendS3Error400(request, response, config.failures.failure_is_request_timeout);
+			return;
+		}
+		response.status = 204;
+		Record(request, response.status);
+	}
+
 	void RegisterRoutes() {
 		const string path = StringUtil::Format("/%s/%s", config.object.bucket, config.object.key);
+		const string proxy_path = "https?://[^/]+" + path;
 		const string bucket_path = StringUtil::Format("/%s", config.object.bucket);
 		const string bucket_path_with_slash = bucket_path + "/";
 		server.set_post_routing_handler([this](const httplib::Request &, httplib::Response &response) {
@@ -993,54 +1090,17 @@ public:
 		server.Get(bucket_path_with_slash, list_objects);
 
 		server.Put(path, [this](const httplib::Request &request, httplib::Response &response) {
-			auto part_number = GetPartNumber(request);
-			unique_ptr<ActivePartUpload> active_upload;
-			if (part_number.IsValid()) {
-				active_upload = make_uniq<ActivePartUpload>(*this, part_number.GetIndex());
-				WaitForPartRelease(part_number.GetIndex());
-			}
-			if (ShouldRejectStaleCredentials(request)) {
-				SendAuthFailure(request, response);
-				return;
-			}
-			if (part_number.IsValid() &&
-			    std::find(config.upload.failed_part_numbers.begin(), config.upload.failed_part_numbers.end(),
-			              part_number.GetIndex()) != config.upload.failed_part_numbers.end()) {
-				SendS3Error400(request, response, false);
-				return;
-			}
-			if (remaining_put_failures.load() > 0) {
-				remaining_put_failures--;
-				SendS3Error400(request, response, config.failures.failure_is_request_timeout);
-				return;
-			}
-			SendPutSuccess(request, response);
+			HandleObjectPut(request, response);
+		});
+		server.Put(proxy_path, [this](const httplib::Request &request, httplib::Response &response) {
+			HandleObjectPut(request, response);
 		});
 
 		server.Post(path, [this](const httplib::Request &request, httplib::Response &response) {
-			if (ShouldRejectStaleCredentials(request)) {
-				SendAuthFailure(request, response);
-				return;
-			}
-			if (request.target.find("uploads") != string::npos && remaining_post_failures.load() > 0) {
-				remaining_post_failures--;
-				if (config.failures.transient_post_status == 400) {
-					SendS3Error400(request, response, config.failures.failure_is_request_timeout);
-				} else {
-					response.status = config.failures.transient_post_status;
-					response.set_content("<Error><Code>TooManyRequests</Code><Message>Injected initialization "
-					                     "throttle</Message></Error>",
-					                     "application/xml");
-					Record(request, response.status);
-				}
-				return;
-			}
-			if (request.target.find("uploadId") != string::npos && remaining_completion_faults.load() > 0) {
-				remaining_completion_faults--;
-				SendCompletionFault(request, response);
-				return;
-			}
-			SendMultipartPost(request, response);
+			HandleObjectPost(request, response);
+		});
+		server.Post(proxy_path, [this](const httplib::Request &request, httplib::Response &response) {
+			HandleObjectPost(request, response);
 		});
 
 		auto bulk_delete = [this](const httplib::Request &request, httplib::Response &response) {
@@ -1054,37 +1114,10 @@ public:
 		server.Post(bucket_path_with_slash, bulk_delete);
 
 		server.Delete(path, [this](const httplib::Request &request, httplib::Response &response) {
-			if (ShouldRejectStaleCredentials(request)) {
-				SendAuthFailure(request, response);
-				return;
-			}
-			auto upload_id = GetParameter(request, "uploadId");
-			if (!upload_id.empty()) {
-				if (config.upload.abort_behavior == MockS3MultipartAbortBehavior::ERROR) {
-					SendS3Error400(request, response, false);
-					return;
-				}
-				if (upload_id != config.upload.upload_id) {
-					response.status = 404;
-					response.set_content("<Error><Code>NoSuchUpload</Code></Error>", "application/xml");
-					Record(request, response.status);
-					return;
-				}
-				{
-					annotated_lock_guard<annotated_mutex> lock(upload_lock);
-					uploaded_parts.clear();
-				}
-				response.status = 204;
-				Record(request, response.status);
-				return;
-			}
-			if (remaining_delete_failures.load() > 0) {
-				remaining_delete_failures--;
-				SendS3Error400(request, response, config.failures.failure_is_request_timeout);
-				return;
-			}
-			response.status = 204;
-			Record(request, response.status);
+			HandleObjectDelete(request, response);
+		});
+		server.Delete(proxy_path, [this](const httplib::Request &request, httplib::Response &response) {
+			HandleObjectDelete(request, response);
 		});
 	}
 

--- a/test/unittest/s3/mock_s3_server.cpp
+++ b/test/unittest/s3/mock_s3_server.cpp
@@ -749,7 +749,18 @@ public:
 			response.headers.erase(marker.first, marker.second);
 		});
 
-		server.set_pre_routing_handler([this, path](const httplib::Request &request, httplib::Response &response) {
+		server.set_pre_routing_handler([this, path, bucket_path, bucket_path_with_slash](
+		                                   const httplib::Request &request, httplib::Response &response) {
+			if (request.method == "POST" && request.target.find("delete") != string::npos &&
+			    (StringUtil::EndsWith(request.path, bucket_path) ||
+			     StringUtil::EndsWith(request.path, bucket_path_with_slash))) {
+				if (ShouldRejectStaleCredentials(request)) {
+					SendAuthFailure(request, response);
+				} else {
+					SendBulkDeleteSuccess(request, response);
+				}
+				return httplib::Server::HandlerResponse::Handled;
+			}
 			if (request.method != "HEAD" || request.path != path) {
 				return httplib::Server::HandlerResponse::Unhandled;
 			}

--- a/test/unittest/s3/mock_s3_server.hpp
+++ b/test/unittest/s3/mock_s3_server.hpp
@@ -37,6 +37,8 @@ enum class MockS3MultipartCompletionBehavior : uint8_t {
 
 enum class MockS3MultipartAbortBehavior : uint8_t { SUCCESS, ERROR };
 
+enum class MockS3MultipartGeometry : uint8_t { FLEXIBLE, FIXED_EQUAL };
+
 struct MockS3ObjectConfig {
 	string bucket = "refresh-bucket";
 	string key = "object.bin";
@@ -146,6 +148,7 @@ struct MockS3UploadConfig {
 	//! HTTP status sent before disconnecting a multipart-completion response body
 	int completion_disconnect_status = 200;
 	MockS3MultipartAbortBehavior abort_behavior = MockS3MultipartAbortBehavior::SUCCESS;
+	MockS3MultipartGeometry geometry = MockS3MultipartGeometry::FLEXIBLE;
 };
 
 struct MockS3ServerConfig {

--- a/test/unittest/s3/s3_refresh_test.cpp
+++ b/test/unittest/s3/s3_refresh_test.cpp
@@ -4,6 +4,7 @@
 #include "s3/s3_test_helper.hpp"
 
 #include "create_secret_functions.hpp"
+#include "crypto.hpp"
 #include "http/httpfs_client.hpp"
 #include "s3/s3fs.hpp"
 
@@ -12,6 +13,7 @@
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/client_context_file_opener.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 
 #include <atomic>
@@ -456,6 +458,79 @@ static void RunRefreshPublicationScenario(const string &client_implementation, b
 	S3TestHelper::AssertSingleRefresh(test_id);
 }
 
+static void RunEndpointModeRefreshScenario(const string &initial_endpoint, const string &initial_resolved_endpoint,
+                                           S3EndpointMode initial_mode, const string &refreshed_endpoint,
+                                           const string &refreshed_resolved_endpoint, S3EndpointMode refreshed_mode,
+                                           const string &published_region = string()) {
+	DuckDB db(nullptr);
+	Connection con(db);
+	S3TestHelper::LoadExtension(db);
+	S3TestHelper::RegisterRefreshProvider(db);
+	auto test_id = S3TestHelper::NextTestId();
+	S3TestHelper::RequireQueryOk(con, StringUtil::Format(R"(
+CREATE SECRET refresh_s3_endpoint_mode (
+	TYPE S3,
+	PROVIDER %s,
+	SCOPE 's3://refresh-bucket/',
+	KEY_ID '%s',
+	SECRET '%s',
+	REGION 'us-east-1',
+	ENDPOINT '%s',
+	TEST_ID '%s',
+	REFRESH_INFO MAP {
+		'KEY_ID': '%s',
+		'SECRET': '%s',
+		'ENDPOINT': '%s',
+		'TEST_ID': '%s'
+	}
+))",
+	                                                     S3TestHelper::TEST_PROVIDER, S3TestHelper::STALE_KEY_ID,
+	                                                     S3TestHelper::STALE_SECRET, initial_endpoint, test_id,
+	                                                     S3TestHelper::FRESH_KEY_ID, S3TestHelper::FRESH_SECRET,
+	                                                     refreshed_endpoint, test_id));
+
+	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+	ClientContextFileOpener opener(*con.context);
+	FileOpenerInfo info = {S3TestHelper::S3_PATH};
+	auto auth_params = S3AuthParams::ReadFrom(opener, info);
+	REQUIRE(auth_params.endpoint_mode == initial_mode);
+	auto session = S3RequestExecutor::CreateSession(opener, S3TestHelper::S3_PATH, auth_params);
+	if (!published_region.empty()) {
+		string previous_region;
+		REQUIRE(S3RequestExecutor::SetSessionRegion(*session, published_region, previous_region));
+		REQUIRE(previous_region == "us-east-1");
+	}
+	::AESStateSSLFactory encryption_util;
+	vector<S3EndpointMode> observed_modes;
+	vector<string> observed_endpoints;
+	vector<string> observed_regions;
+	auto response = S3RequestExecutor::RunSession(
+	    encryption_util, *session, S3TestHelper::S3_PATH, RequestType::GET_REQUEST, S3RequestTarget::OBJECT,
+	    [](const ParsedS3Url &) { return S3RequestQuery(); }, "", "", "",
+	    [&](S3RequestData &request_data) {
+		    observed_modes.push_back(request_data.auth_params.endpoint_mode);
+		    observed_endpoints.push_back(request_data.auth_params.endpoint);
+		    observed_regions.push_back(request_data.auth_params.region);
+		    if (observed_modes.size() == 1) {
+			    auto result = make_uniq<HTTPResponse>(HTTPStatusCode::Forbidden_403);
+			    result->body = "<Error><Code>AccessDenied</Code><Message>stale credentials</Message></Error>";
+			    return result;
+		    }
+		    return make_uniq<HTTPResponse>(HTTPStatusCode::OK_200);
+	    });
+	REQUIRE(response);
+	REQUIRE(response->status == HTTPStatusCode::OK_200);
+	REQUIRE(observed_modes == vector<S3EndpointMode> {initial_mode, refreshed_mode});
+	REQUIRE(observed_endpoints == vector<string> {initial_resolved_endpoint, refreshed_resolved_endpoint});
+	auto expected_region = published_region.empty() ? string("us-east-1") : published_region;
+	REQUIRE(observed_regions == vector<string> {expected_region, expected_region});
+	auto &snapshot = session->Capture().snapshot->Cast<S3RequestSnapshot>();
+	REQUIRE(snapshot.auth_params.endpoint_mode == refreshed_mode);
+	REQUIRE(snapshot.auth_params.endpoint == refreshed_resolved_endpoint);
+	S3TestHelper::RequireQueryOk(con, "COMMIT");
+	S3TestHelper::AssertSingleRefresh(test_id);
+}
+
 static void RunConfiguredHeaderRefreshScenario(const string &client_implementation, bool refresh_to_reserved_header) {
 	MockS3ServerConfig config;
 	config.object.bucket = S3TestHelper::BUCKET;
@@ -629,6 +704,19 @@ TEST_CASE("S3 credential refresh composes with a concurrent region publication",
 	}
 	SECTION("curl") {
 		RunRefreshPublicationScenario("curl", false, true);
+	}
+}
+
+TEST_CASE("S3 credential refresh reconstructs endpoint provenance", "[httpfs][s3][refresh][endpoint]") {
+	SECTION("explicit to automatic") {
+		RunEndpointModeRefreshScenario("s3.dualstack.us-east-1.amazonaws.com", "s3.dualstack.us-east-1.amazonaws.com",
+		                               S3EndpointMode::EXPLICIT, "s3.amazonaws.com", "s3.us-east-1.amazonaws.com",
+		                               S3EndpointMode::AUTOMATIC);
+	}
+	SECTION("automatic to explicit") {
+		RunEndpointModeRefreshScenario("s3.amazonaws.com", "s3.eu-west-1.amazonaws.com", S3EndpointMode::AUTOMATIC,
+		                               "s3.dualstack.us-east-1.amazonaws.com", "s3.dualstack.us-east-1.amazonaws.com",
+		                               S3EndpointMode::EXPLICIT, "eu-west-1");
 	}
 }
 

--- a/test/unittest/s3/s3_refresh_test.cpp
+++ b/test/unittest/s3/s3_refresh_test.cpp
@@ -480,6 +480,7 @@ CREATE SECRET refresh_s3_endpoint_mode (
 	REFRESH_INFO MAP {
 		'KEY_ID': '%s',
 		'SECRET': '%s',
+		'REGION': 'us-east-1',
 		'ENDPOINT': '%s',
 		'TEST_ID': '%s'
 	}

--- a/test/unittest/s3/s3_request_test.cpp
+++ b/test/unittest/s3/s3_request_test.cpp
@@ -727,11 +727,13 @@ TEST_CASE("S3 URL style validation happens before request dispatch", "[httpfs][s
 	S3TestHelper::RequireQueryOk(con, "ROLLBACK");
 
 	DBConfig::GetConfig(*db.instance).SetOptionByName("s3_url_style", Value("handwritten"));
-	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
-	REQUIRE_THROWS(fs.OpenFile(string(S3TestHelper::S3_PATH) + "?s3_url_style=path",
-	                           FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO));
+	Connection invalid_con(db);
+	S3TestHelper::RequireQueryOk(invalid_con, "BEGIN TRANSACTION");
+	auto &invalid_fs = FileSystem::GetFileSystem(*invalid_con.context);
+	REQUIRE_THROWS(invalid_fs.OpenFile(string(S3TestHelper::S3_PATH) + "?s3_url_style=path",
+	                                   FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO));
 	REQUIRE(server.Observations().empty());
-	S3TestHelper::RequireQueryOk(con, "ROLLBACK");
+	S3TestHelper::RequireQueryOk(invalid_con, "ROLLBACK");
 }
 
 TEST_CASE("S3 URL query settings are resolved independently of the HTTP client", "[httpfs][s3][url]") {

--- a/test/unittest/s3/s3_request_test.cpp
+++ b/test/unittest/s3/s3_request_test.cpp
@@ -8,6 +8,7 @@
 #include "crypto.hpp"
 #include "s3/s3_provider.hpp"
 #include "s3/s3_request.hpp"
+#include "s3/s3_settings.hpp"
 #include "s3/s3_url.hpp"
 #include "s3/s3fs.hpp"
 
@@ -526,6 +527,43 @@ TEST_CASE("S3 provider policy resolves URL aliases and default scopes", "[httpfs
 		REQUIRE(error.find("s3n://") != string::npos);
 		REQUIRE(error.find("gs://") != string::npos);
 	}
+}
+
+TEST_CASE("S3 provider selects multipart upload policy", "[httpfs][s3][provider][upload]") {
+	static constexpr idx_t MIB = 1024ULL * 1024ULL;
+	static constexpr idx_t GIB = 1024ULL * MIB;
+	const S3MultipartUploadPolicy adaptive_policy {S3MultipartPartSizeStrategy::ADAPTIVE, 5ULL * MIB, 5ULL * GIB, 10000,
+	                                               optional_idx()};
+	const S3MultipartUploadPolicy fixed_policy {S3MultipartPartSizeStrategy::FIXED, 8ULL * MIB, 5115ULL * MIB, 10000,
+	                                            5115ULL * GIB};
+	auto require_policy = [](S3ProviderType provider_type, const string &endpoint,
+	                         const S3MultipartUploadPolicy &expected, bool scheme_is_alias = false) {
+		S3AuthParams auth_params;
+		auth_params.provider_type = provider_type;
+		auth_params.scheme_is_alias = scheme_is_alias;
+		auth_params.endpoint = endpoint;
+		INFO(endpoint);
+		auto policy = S3Provider::GetMultipartUploadPolicy(auth_params);
+		REQUIRE(policy.part_size_strategy == expected.part_size_strategy);
+		REQUIRE(policy.minimum_part_size == expected.minimum_part_size);
+		REQUIRE(policy.maximum_part_size == expected.maximum_part_size);
+		REQUIRE(policy.maximum_part_count == expected.maximum_part_count);
+		REQUIRE(policy.maximum_object_size == expected.maximum_object_size);
+	};
+
+	require_policy(S3ProviderType::R2, "localhost:9000", fixed_policy);
+	require_policy(S3ProviderType::S3, "account.r2.cloudflarestorage.com", fixed_policy);
+	require_policy(S3ProviderType::S3, "account.eu.r2.cloudflarestorage.com", fixed_policy);
+	require_policy(S3ProviderType::S3, "ACCOUNT.FEDRAMP.R2.CLOUDFLARESTORAGE.COM:443/path", fixed_policy);
+	require_policy(S3ProviderType::S3, "account.us.r2.cloudflarestorage.com", fixed_policy, true);
+
+	require_policy(S3ProviderType::S3, "s3.amazonaws.com", adaptive_policy);
+	require_policy(S3ProviderType::GCS, "account.r2.cloudflarestorage.com", adaptive_policy);
+	require_policy(S3ProviderType::S3, "r2.cloudflarestorage.com", adaptive_policy);
+	require_policy(S3ProviderType::S3, "account.r2.cloudflarestorage.com.example.com", adaptive_policy);
+	require_policy(S3ProviderType::S3, "evilr2.cloudflarestorage.com", adaptive_policy);
+	require_policy(S3ProviderType::S3, "objects.example.com", adaptive_policy);
+	require_policy(S3ProviderType::S3, "a.b.r2.cloudflarestorage.com", adaptive_policy);
 }
 
 TEST_CASE("S3 endpoint provenance controls AWS endpoint derivation", "[httpfs][s3][provider][endpoint]") {

--- a/test/unittest/s3/s3_request_test.cpp
+++ b/test/unittest/s3/s3_request_test.cpp
@@ -433,6 +433,47 @@ CREATE SECRET %s (
 	REQUIRE(bulk_delete_requests == 2);
 }
 
+static void RunBulkDeleteEndpointModeIdentityScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.auth.stale_key_id = "NEVER_STALE";
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	S3TestHelper::LoadExtension(db);
+	S3TestHelper::RequireQueryOk(con,
+	                             StringUtil::Format("SET httpfs_client_implementation='%s'", client_implementation));
+	S3TestHelper::RequireQueryOk(con, "SET httpfs_connection_caching=false");
+	S3TestHelper::RequireQueryOk(con, StringUtil::Format("SET http_proxy='http://%s'", server.Endpoint()));
+	S3TestHelper::RequireQueryOk(con, R"(
+CREATE SECRET delete_endpoint_mode (
+	TYPE S3,
+	SCOPE 's3://refresh-bucket/',
+	KEY_ID 'FRESH_KEY',
+	SECRET 'S3TestHelper::FRESH_SECRET',
+	REGION 'us-east-1',
+	USE_SSL false,
+	URL_STYLE 'path'
+))");
+
+	auto automatic_path = "s3://refresh-bucket/a/object.bin";
+	auto explicit_path = "s3://refresh-bucket/b/object.bin?s3_endpoint=s3.us-east-1.amazonaws.com";
+	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	fs.RemoveFiles({automatic_path, explicit_path});
+	S3TestHelper::RequireQueryOk(con, "COMMIT");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	idx_t bulk_delete_requests = 0;
+	for (const auto &observation : observations) {
+		if (observation.method == "POST" && StringUtil::EndsWith(observation.target, "?delete=")) {
+			bulk_delete_requests++;
+		}
+	}
+	REQUIRE(bulk_delete_requests == 2);
+}
+
 static void RunGCSListAuthErrorScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
 	config.auth.stale_authorization = "Bearer gcs-test-token";
@@ -451,10 +492,11 @@ static void RunGCSListAuthErrorScenario(const string &client_implementation) {
 	REQUIRE(result->GetError().find("Authentication Failure - GCS authentication failed") != string::npos);
 }
 
-static S3AuthParams ReadSecretAuthParams(Connection &con, KeyValueSecret &secret) {
+static S3AuthParams ReadSecretAuthParams(Connection &con, KeyValueSecret &secret,
+                                         const string &path = "s3://bucket/key") {
 	ClientContextFileOpener opener(*con.context);
 	S3KeyValueReader secret_reader {KeyValueSecretReader(secret, opener)};
-	return S3AuthParams::ReadFrom(secret_reader, "s3://bucket/key");
+	return S3AuthParams::ReadFrom(secret_reader, path);
 }
 
 } // namespace
@@ -486,10 +528,178 @@ TEST_CASE("S3 provider policy resolves URL aliases and default scopes", "[httpfs
 	}
 }
 
+TEST_CASE("S3 endpoint provenance controls AWS endpoint derivation", "[httpfs][s3][provider][endpoint]") {
+	SECTION("automatic endpoints retain the existing region defaults") {
+		S3AuthParams anonymous;
+		anonymous.SetEndpoint("  ");
+		S3Provider::InitializeAuthParams(anonymous);
+		REQUIRE(anonymous.endpoint_mode == S3EndpointMode::AUTOMATIC);
+		REQUIRE(anonymous.region.empty());
+		REQUIRE(anonymous.endpoint == "s3.amazonaws.com");
+
+		S3AuthParams credentialed;
+		credentialed.SetEndpoint("s3.amazonaws.com");
+		credentialed.access_key_id = "key";
+		S3Provider::InitializeAuthParams(credentialed);
+		REQUIRE(credentialed.endpoint_mode == S3EndpointMode::AUTOMATIC);
+		REQUIRE(credentialed.region == "us-east-1");
+		REQUIRE(credentialed.endpoint == "s3.us-east-1.amazonaws.com");
+	}
+
+	SECTION("explicit endpoints keep their host") {
+		for (const auto &endpoint : {"s3.dualstack.us-east-1.amazonaws.com", "s3-fips.us-east-1.amazonaws.com",
+		                             "s3.eu-west-1.amazonaws.com", "storage.example.com"}) {
+			S3AuthParams auth_params;
+			auth_params.SetEndpoint(endpoint);
+			S3Provider::InitializeAuthParams(auth_params);
+			INFO(endpoint);
+			REQUIRE(auth_params.endpoint_mode == S3EndpointMode::EXPLICIT);
+			REQUIRE(auth_params.endpoint == endpoint);
+			REQUIRE(auth_params.region.empty());
+			auth_params.SetRegion("ap-southeast-2");
+			REQUIRE(auth_params.endpoint == endpoint);
+		}
+	}
+
+	SECTION("AWS-shaped explicit endpoints retain the old credentialed region fallback") {
+		S3AuthParams dualstack;
+		dualstack.SetEndpoint("s3.dualstack.us-east-1.amazonaws.com");
+		dualstack.access_key_id = "key";
+		S3Provider::InitializeAuthParams(dualstack);
+		REQUIRE(dualstack.region == "us-east-1");
+		REQUIRE(dualstack.endpoint == "s3.dualstack.us-east-1.amazonaws.com");
+
+		S3AuthParams fips;
+		fips.SetEndpoint("s3-fips.us-east-1.amazonaws.com");
+		fips.access_key_id = "key";
+		S3Provider::InitializeAuthParams(fips);
+		REQUIRE(fips.region.empty());
+		REQUIRE(fips.endpoint == "s3-fips.us-east-1.amazonaws.com");
+	}
+
+	SECTION("endpoint mode participates in authentication identity") {
+		S3AuthParams automatic;
+		automatic.region = "us-east-1";
+		S3Provider::InitializeAuthParams(automatic);
+		S3AuthParams explicit_endpoint;
+		explicit_endpoint.region = "us-east-1";
+		explicit_endpoint.SetEndpoint("s3.us-east-1.amazonaws.com");
+		S3Provider::InitializeAuthParams(explicit_endpoint);
+		REQUIRE(automatic.endpoint == explicit_endpoint.endpoint);
+		REQUIRE_FALSE(automatic == explicit_endpoint);
+	}
+}
+
+TEST_CASE("S3 provider endpoint precedence is preserved", "[httpfs][s3][provider][endpoint][secret]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	S3TestHelper::LoadExtension(db);
+	S3TestHelper::RequireQueryOk(con, "SET s3_endpoint='setting.example.com'");
+
+	SECTION("GCS ignores the endpoint setting") {
+		KeyValueSecret secret({"gcs://"}, Identifier("gcs"), Identifier("config"), Identifier("gcs_default"));
+		auto auth_params = ReadSecretAuthParams(con, secret, "gcs://bucket/key");
+		REQUIRE(auth_params.endpoint == "storage.googleapis.com");
+		REQUIRE(auth_params.endpoint_mode == S3EndpointMode::AUTOMATIC);
+	}
+
+	SECTION("GCS accepts a secret endpoint") {
+		KeyValueSecret secret({"gcs://"}, Identifier("gcs"), Identifier("config"), Identifier("gcs_explicit"));
+		secret.secret_map["endpoint"] = "gcs.example.com";
+		auto auth_params = ReadSecretAuthParams(con, secret, "gcs://bucket/key");
+		REQUIRE(auth_params.endpoint == "gcs.example.com");
+		REQUIRE(auth_params.endpoint_mode == S3EndpointMode::EXPLICIT);
+	}
+}
+
+TEST_CASE("S3 URL styles share one validation policy", "[httpfs][s3][provider][url-style]") {
+	for (const auto &url_style : {"", "vhost", "virtual"}) {
+		INFO(url_style);
+		REQUIRE(S3Provider::ParseURLStyle(url_style) == S3URLStyle::VIRTUAL_HOSTED);
+	}
+	REQUIRE(S3Provider::ParseURLStyle("path") == S3URLStyle::PATH);
+	for (const auto &url_style : {"default", "VHOST", "handwritten"}) {
+		INFO(url_style);
+		REQUIRE_THROWS(S3Provider::ParseURLStyle(url_style));
+	}
+
+	SECTION("defensive URL parsing rejects invalid runtime state") {
+		S3AuthParams auth_params;
+		auth_params.url_style = "handwritten";
+		REQUIRE_THROWS(S3Provider::FinalizeAuthParams(auth_params));
+		REQUIRE_THROWS(S3Url::Parse("s3://bucket/key", auth_params));
+		REQUIRE_THROWS(S3Url::Resolve("s3://bucket/key?s3_url_style=path", auth_params));
+	}
+
+	SECTION("URL query values remain case-sensitive") {
+		S3AuthParams auth_params;
+		S3Provider::InitializeAuthParams(auth_params);
+		REQUIRE_THROWS(S3Url::Resolve("s3://bucket/key?s3_url_style=VHOST", auth_params));
+	}
+
+	SECTION("compatibility mode keeps query-looking key text literal") {
+		S3AuthParams auth_params;
+		auth_params.s3_url_compatibility_mode = true;
+		S3Provider::InitializeAuthParams(auth_params);
+		auto parsed = S3Url::Resolve("s3://bucket/key?s3_url_style=handwritten", auth_params);
+		REQUIRE(parsed.query_param.empty());
+		REQUIRE(parsed.key == "key?s3_url_style=handwritten");
+	}
+
+	SECTION("dotted buckets use path style over TLS") {
+		S3AuthParams auth_params;
+		auth_params.url_style = "virtual";
+		S3Provider::InitializeAuthParams(auth_params);
+		auto parsed = S3Url::Parse("s3://bucket.with.dots/key", auth_params);
+		REQUIRE(parsed.host == "s3.amazonaws.com");
+		REQUIRE(parsed.path == "/bucket.with.dots/key");
+	}
+}
+
+TEST_CASE("S3 URL style validation happens before request dispatch", "[httpfs][s3][url-style][request]") {
+	MockS3ServerConfig config;
+	config.auth.stale_key_id = "NEVER_STALE";
+	MockS3Server server(std::move(config));
+	DuckDB db(nullptr);
+	Connection con(db);
+	S3TestHelper::LoadExtension(db);
+	S3TestHelper::RequireQueryOk(con, StringUtil::Format("SET s3_endpoint='%s'", server.Endpoint()));
+	S3TestHelper::RequireQueryOk(con, "SET s3_region='us-east-1'");
+	S3TestHelper::RequireQueryOk(con, "SET s3_use_ssl=false");
+
+	for (const auto &url_style : {"", "vhost", "virtual", "path"}) {
+		auto result = con.Query(StringUtil::Format("SET s3_url_style='%s'", url_style));
+		INFO(url_style);
+		REQUIRE(result);
+		REQUIRE_FALSE(result->HasError());
+	}
+	for (const auto &url_style : {"default", "VHOST", "handwritten"}) {
+		auto result = con.Query(StringUtil::Format("SET s3_url_style='%s'", url_style));
+		INFO(url_style);
+		REQUIRE(result);
+		REQUIRE(result->HasError());
+	}
+
+	S3TestHelper::RequireQueryOk(con, "SET s3_url_style='path'");
+	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	REQUIRE_THROWS(fs.OpenFile(string(S3TestHelper::S3_PATH) + "?s3_url_style=VHOST",
+	                           FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO));
+	REQUIRE(server.Observations().empty());
+	S3TestHelper::RequireQueryOk(con, "ROLLBACK");
+
+	DBConfig::GetConfig(*db.instance).SetOptionByName("s3_url_style", Value("handwritten"));
+	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+	REQUIRE_THROWS(fs.OpenFile(string(S3TestHelper::S3_PATH) + "?s3_url_style=path",
+	                           FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO));
+	REQUIRE(server.Observations().empty());
+	S3TestHelper::RequireQueryOk(con, "ROLLBACK");
+}
+
 TEST_CASE("S3 URL query settings are resolved independently of the HTTP client", "[httpfs][s3][url]") {
 	SECTION("query credentials initialize the AWS region and endpoint") {
 		S3AuthParams auth_params;
-		auth_params.endpoint = "s3.amazonaws.com";
+		auth_params.SetEndpoint("s3.amazonaws.com");
 		auto parsed_url = S3Url::Resolve(
 		    "s3://bucket/key?s3_access_key_id=hello+world&s3_secret_access_key=secret%2Bvalue", auth_params);
 		REQUIRE(auth_params.access_key_id == "hello world");
@@ -502,21 +712,34 @@ TEST_CASE("S3 URL query settings are resolved independently of the HTTP client",
 	SECTION("routing overrides are reflected in the parsed URL") {
 		S3AuthParams auth_params;
 		auth_params.region = "us-west-2";
-		auth_params.endpoint = "s3.us-west-2.amazonaws.com";
+		auth_params.SetEndpoint("s3.us-west-2.amazonaws.com");
 		auto parsed_url = S3Url::Resolve("s3://bucket/key?s3_region=eu-west-1&s3_endpoint=s3.amazonaws.com&"
 		                                 "s3_use_ssl=false&s3_url_style=path",
 		                                 auth_params);
 		REQUIRE(auth_params.region == "eu-west-1");
 		REQUIRE(auth_params.endpoint == "s3.eu-west-1.amazonaws.com");
+		REQUIRE(auth_params.endpoint_mode == S3EndpointMode::AUTOMATIC);
 		REQUIRE(parsed_url.http_proto == "http://");
 		REQUIRE(parsed_url.host == "s3.eu-west-1.amazonaws.com");
 		REQUIRE(parsed_url.path == "/bucket/key");
 	}
 
+	SECTION("an endpoint override can switch from automatic to explicit") {
+		S3AuthParams auth_params;
+		auth_params.region = "us-east-1";
+		S3Provider::InitializeAuthParams(auth_params);
+		REQUIRE(auth_params.endpoint_mode == S3EndpointMode::AUTOMATIC);
+		auto parsed_url =
+		    S3Url::Resolve("s3://bucket/key?s3_endpoint=s3.dualstack.us-east-1.amazonaws.com", auth_params);
+		REQUIRE(auth_params.endpoint_mode == S3EndpointMode::EXPLICIT);
+		REQUIRE(auth_params.endpoint == "s3.dualstack.us-east-1.amazonaws.com");
+		REQUIRE(parsed_url.host == "bucket.s3.dualstack.us-east-1.amazonaws.com");
+	}
+
 	SECTION("empty GCS routing overrides restore provider defaults") {
 		S3AuthParams auth_params;
 		auth_params.provider_type = S3ProviderType::GCS;
-		auth_params.endpoint = "storage.googleapis.com";
+		auth_params.SetEndpoint("storage.googleapis.com");
 		auth_params.url_style = "path";
 		auto parsed_url = S3Url::Resolve("gcs://bucket/key?s3_endpoint=&s3_url_style=", auth_params);
 		REQUIRE(auth_params.endpoint == "storage.googleapis.com");
@@ -528,14 +751,14 @@ TEST_CASE("S3 URL query settings are resolved independently of the HTTP client",
 	SECTION("empty R2 endpoints fail instead of routing to AWS") {
 		S3AuthParams auth_params;
 		auth_params.provider_type = S3ProviderType::R2;
-		auth_params.endpoint = "account.r2.cloudflarestorage.com";
+		auth_params.SetEndpoint("account.r2.cloudflarestorage.com");
 		auth_params.url_style = "path";
 		REQUIRE_THROWS(S3Url::Resolve("r2://bucket/key?s3_endpoint=", auth_params));
 	}
 
 	SECTION("empty values are accepted") {
 		S3AuthParams auth_params;
-		auth_params.endpoint = "s3.amazonaws.com";
+		auth_params.SetEndpoint("s3.amazonaws.com");
 		S3Url::Resolve("s3://bucket/key?s3_access_key_id&s3_secret_access_key=", auth_params);
 		REQUIRE(auth_params.access_key_id.empty());
 		REQUIRE(auth_params.secret_access_key.empty());
@@ -543,13 +766,13 @@ TEST_CASE("S3 URL query settings are resolved independently of the HTTP client",
 
 	SECTION("duplicate decoded keys are rejected") {
 		S3AuthParams auth_params;
-		auth_params.endpoint = "s3.amazonaws.com";
+		auth_params.SetEndpoint("s3.amazonaws.com");
 		REQUIRE_THROWS(S3Url::Resolve("s3://bucket/key?s3_region=one&s3%5Fregion=two", auth_params));
 	}
 
 	SECTION("query keys remain case-sensitive") {
 		S3AuthParams auth_params;
-		auth_params.endpoint = "s3.amazonaws.com";
+		auth_params.SetEndpoint("s3.amazonaws.com");
 		REQUIRE_THROWS(S3Url::Resolve("s3://bucket/key?S3_region=one", auth_params));
 	}
 
@@ -589,6 +812,12 @@ TEST_CASE("S3 URL compatibility mode reads canonical and legacy secret keys", "[
 		S3TestHelper::RequireQueryOk(con, "SET s3_url_compatibility_mode=true");
 		KeyValueSecret secret({"s3://"}, Identifier("s3"), Identifier("config"), Identifier("setting"));
 		REQUIRE(ReadSecretAuthParams(con, secret).s3_url_compatibility_mode);
+	}
+
+	SECTION("invalid legacy URL style") {
+		KeyValueSecret secret({"s3://"}, Identifier("s3"), Identifier("config"), Identifier("invalid_url_style"));
+		secret.secret_map["url_style"] = "handwritten";
+		REQUIRE_THROWS(ReadSecretAuthParams(con, secret));
 	}
 }
 
@@ -723,7 +952,7 @@ TEST_CASE("S3 rejects configured header conflicts before request dispatch", "[ht
 	http_params.extra_headers["hOsT"] = "override";
 	S3AuthParams auth_params;
 	auth_params.region = "us-east-1";
-	auth_params.endpoint = "s3.amazonaws.com";
+	auth_params.SetEndpoint("s3.amazonaws.com");
 	auth_params.access_key_id = "key";
 	auth_params.secret_access_key = "secret";
 	auto snapshot = make_shared_ptr<S3RequestSnapshot>(http_params, auth_params, "s3://bucket/key",
@@ -814,7 +1043,7 @@ TEST_CASE("S3 request error context belongs to the final attempt", "[httpfs][s3]
 	S3AuthParams auth_params;
 	auth_params.provider_type = S3ProviderType::S3;
 	auth_params.region = "request-region";
-	auth_params.endpoint = "s3.request-region.amazonaws.com";
+	auth_params.SetEndpoint("s3.request-region.amazonaws.com");
 	auto snapshot = make_shared_ptr<S3RequestSnapshot>(http_params, auth_params, "s3://bucket/key",
 	                                                   weak_ptr<ClientContext>(), false);
 	HTTPRequestSession session(snapshot);
@@ -1118,6 +1347,15 @@ TEST_CASE("S3 bulk delete preserves selected secret identity", "[httpfs][s3][del
 	}
 	SECTION("curl") {
 		RunBulkDeleteSecretIdentityScenario("curl");
+	}
+}
+
+TEST_CASE("S3 bulk delete preserves endpoint provenance", "[httpfs][s3][delete][endpoint]") {
+	SECTION("httplib") {
+		RunBulkDeleteEndpointModeIdentityScenario("httplib");
+	}
+	SECTION("curl") {
+		RunBulkDeleteEndpointModeIdentityScenario("curl");
 	}
 }
 

--- a/test/unittest/s3/s3_upload_config_test.cpp
+++ b/test/unittest/s3/s3_upload_config_test.cpp
@@ -1,72 +1,196 @@
 #include "catch.hpp"
 
+#include "s3/s3_auth.hpp"
 #include "s3/s3_settings.hpp"
 
+#include "duckdb/common/array.hpp"
 #include "duckdb/common/limits.hpp"
 #include "duckdb/storage/storage_info.hpp"
 
 namespace duckdb {
 
+namespace {
+
+static constexpr idx_t MIB = 1024ULL * 1024ULL;
+static constexpr idx_t GIB = 1024ULL * MIB;
+
+static S3MultipartUploadPolicy GetUploadPolicy(S3ProviderType provider_type) {
+	S3AuthParams auth_params;
+	auth_params.provider_type = provider_type;
+	return S3Provider::GetMultipartUploadPolicy(auth_params);
+}
+
+} // namespace
+
 TEST_CASE("S3 upload config uses adaptive part sizes", "[httpfs][s3][upload]") {
+	auto policy = GetUploadPolicy(S3ProviderType::S3);
+
 	SECTION("default schedule") {
-		auto config =
-		    S3UploadConfig::Create(S3UploadConfig::DEFAULT_MAX_FILESIZE, S3UploadConfig::DEFAULT_MAX_PARTS_PER_FILE);
+		auto config = S3UploadConfig::Create(S3UploadConfig::DEFAULT_MAX_FILESIZE,
+		                                     S3UploadConfig::DEFAULT_MAX_PARTS_PER_FILE, policy);
 		REQUIRE(config.max_file_size == S3UploadConfig::DEFAULT_MAX_FILESIZE);
 		REQUIRE(config.max_parts == S3UploadConfig::DEFAULT_MAX_PARTS_PER_FILE);
-		REQUIRE(config.initial_part_size == S3UploadConfig::MIN_MULTIPART_PART_SIZE);
+		REQUIRE(config.initial_part_size == policy.minimum_part_size);
+		REQUIRE(config.maximum_part_size == policy.maximum_part_size);
 		REQUIRE(config.growth_interval == 910);
-		REQUIRE(config.PartSize(0) == S3UploadConfig::MIN_MULTIPART_PART_SIZE);
-		REQUIRE(config.PartSize(909) == S3UploadConfig::MIN_MULTIPART_PART_SIZE);
-		REQUIRE(config.PartSize(910) == 2 * S3UploadConfig::MIN_MULTIPART_PART_SIZE);
-		REQUIRE(config.PartSize(1819) == 2 * S3UploadConfig::MIN_MULTIPART_PART_SIZE);
-		REQUIRE(config.PartSize(1820) == 4 * S3UploadConfig::MIN_MULTIPART_PART_SIZE);
-		REQUIRE(config.PartSize(9100) == S3UploadConfig::MAX_MULTIPART_PART_SIZE);
-		REQUIRE(config.PartSize(9999) == S3UploadConfig::MAX_MULTIPART_PART_SIZE);
+		REQUIRE(config.TargetPartSize(0) == policy.minimum_part_size);
+		REQUIRE(config.TargetPartSize(909) == policy.minimum_part_size);
+		REQUIRE(config.TargetPartSize(910) == 2 * policy.minimum_part_size);
+		REQUIRE(config.TargetPartSize(1819) == 2 * policy.minimum_part_size);
+		REQUIRE(config.TargetPartSize(1820) == 4 * policy.minimum_part_size);
+		REQUIRE(config.TargetPartSize(9100) == policy.maximum_part_size);
+		REQUIRE(config.TargetPartSize(9999) == policy.maximum_part_size);
 	}
 
 	SECTION("small part budget") {
-		auto config = S3UploadConfig::Create(16ULL * 1024ULL * 1024ULL, 11);
-		REQUIRE(config.initial_part_size == S3UploadConfig::MIN_MULTIPART_PART_SIZE);
+		auto config = S3UploadConfig::Create(16ULL * MIB, 11, policy);
+		REQUIRE(config.initial_part_size == policy.minimum_part_size);
 		REQUIRE(config.growth_interval == 1);
-		REQUIRE(config.PartSize(0) == 5ULL * 1024ULL * 1024ULL);
-		REQUIRE(config.PartSize(1) == 10ULL * 1024ULL * 1024ULL);
-		REQUIRE(config.PartSize(10) == S3UploadConfig::MAX_MULTIPART_PART_SIZE);
+		REQUIRE(config.TargetPartSize(0) == 5ULL * MIB);
+		REQUIRE(config.TargetPartSize(1) == 10ULL * MIB);
+		REQUIRE(config.TargetPartSize(10) == policy.maximum_part_size);
 		REQUIRE(config.HasPartCapacity(10));
 		REQUIRE_FALSE(config.HasPartCapacity(11));
 	}
 
 	SECTION("initial size is block aligned") {
-		auto minimum_config = S3UploadConfig::Create(16ULL * 1024ULL * 1024ULL, 11);
+		auto minimum_config = S3UploadConfig::Create(16ULL * MIB, 11, policy);
 		uint64_t minimum_capacity = 0;
 		for (idx_t part_index = 0; part_index < minimum_config.max_parts; part_index++) {
-			minimum_capacity += minimum_config.PartSize(part_index);
+			minimum_capacity += minimum_config.TargetPartSize(part_index);
 		}
-		auto config = S3UploadConfig::Create(minimum_capacity + 1, 11);
-		REQUIRE(config.initial_part_size == S3UploadConfig::MIN_MULTIPART_PART_SIZE + Storage::DEFAULT_BLOCK_SIZE +
-		                                        Storage::DEFAULT_BLOCK_HEADER_SIZE);
+		auto config = S3UploadConfig::Create(minimum_capacity + 1, 11, policy);
+		REQUIRE(config.initial_part_size ==
+		        policy.minimum_part_size + Storage::DEFAULT_BLOCK_SIZE + Storage::DEFAULT_BLOCK_HEADER_SIZE);
 	}
 
 	SECTION("maximum supported schedule") {
-		const auto maximum_file_size =
-		    NumericCast<uint64_t>(S3UploadConfig::MAX_MULTIPART_PART_SIZE) * S3UploadConfig::MAX_MULTIPART_PARTS;
-		auto config = S3UploadConfig::Create(maximum_file_size, S3UploadConfig::MAX_MULTIPART_PARTS);
-		REQUIRE(config.initial_part_size == S3UploadConfig::MAX_MULTIPART_PART_SIZE);
-		REQUIRE(config.PartSize(0) == S3UploadConfig::MAX_MULTIPART_PART_SIZE);
+		const auto maximum_file_size = NumericCast<uint64_t>(policy.maximum_part_size) * policy.maximum_part_count;
+		auto config = S3UploadConfig::Create(maximum_file_size, policy.maximum_part_count, policy);
+		REQUIRE(config.initial_part_size == policy.maximum_part_size);
+		REQUIRE(config.TargetPartSize(0) == policy.maximum_part_size);
 
-		auto single_part = S3UploadConfig::Create(S3UploadConfig::MAX_MULTIPART_PART_SIZE, 1);
-		REQUIRE(single_part.initial_part_size == S3UploadConfig::MAX_MULTIPART_PART_SIZE);
+		auto single_part = S3UploadConfig::Create(policy.maximum_part_size, 1, policy);
+		REQUIRE(single_part.initial_part_size == policy.maximum_part_size);
 		REQUIRE(single_part.HasPartCapacity(0));
 		REQUIRE_FALSE(single_part.HasPartCapacity(1));
 	}
 
+	SECTION("direct parts retain the adaptive maximum") {
+		auto config = S3UploadConfig::Create(16ULL * MIB, 11, policy);
+		REQUIRE(config.TargetPartSize(0) == 5ULL * MIB);
+		REQUIRE(config.DirectPartSize(0, 7ULL * MIB) == 7ULL * MIB);
+		REQUIRE(config.DirectPartSize(0, policy.maximum_part_size + MIB) == policy.maximum_part_size);
+	}
+
+	SECTION("maximum policy part count") {
+		policy.maximum_part_count = NumericLimits<idx_t>::Maximum();
+		auto config = S3UploadConfig::Create(1, policy.maximum_part_count, policy);
+		auto expected_interval = policy.maximum_part_count / S3UploadConfig::PART_SIZE_TIERS +
+		                         (policy.maximum_part_count % S3UploadConfig::PART_SIZE_TIERS != 0);
+		REQUIRE(config.growth_interval == expected_interval);
+		REQUIRE(config.TargetPartSize(0) == policy.minimum_part_size);
+	}
+
 	SECTION("invalid limits") {
-		const auto maximum_file_size =
-		    NumericCast<uint64_t>(S3UploadConfig::MAX_MULTIPART_PART_SIZE) * S3UploadConfig::MAX_MULTIPART_PARTS;
-		REQUIRE_THROWS(S3UploadConfig::Create(0, 1));
-		REQUIRE_THROWS(S3UploadConfig::Create(1, 0));
-		REQUIRE_THROWS(S3UploadConfig::Create(1, S3UploadConfig::MAX_MULTIPART_PARTS + 1));
-		REQUIRE_THROWS(S3UploadConfig::Create(maximum_file_size + 1, S3UploadConfig::MAX_MULTIPART_PARTS));
-		REQUIRE_THROWS(S3UploadConfig::Create(NumericLimits<uint64_t>::Maximum(), S3UploadConfig::MAX_MULTIPART_PARTS));
+		const auto maximum_file_size = NumericCast<uint64_t>(policy.maximum_part_size) * policy.maximum_part_count;
+		REQUIRE_THROWS(S3UploadConfig::Create(0, 1, policy));
+		REQUIRE_THROWS(S3UploadConfig::Create(1, 0, policy));
+		REQUIRE_THROWS(S3UploadConfig::Create(1, policy.maximum_part_count + 1, policy));
+		REQUIRE_THROWS(S3UploadConfig::Create(maximum_file_size + 1, policy.maximum_part_count, policy));
+		REQUIRE_THROWS(S3UploadConfig::Create(NumericLimits<uint64_t>::Maximum(), policy.maximum_part_count, policy));
+	}
+}
+
+TEST_CASE("S3 upload config validates multipart policies", "[httpfs][s3][upload]") {
+	auto policy = GetUploadPolicy(S3ProviderType::S3);
+
+	SECTION("minimum part size") {
+		policy.minimum_part_size = 0;
+		REQUIRE_THROWS(S3UploadConfig::Create(1, 1, policy));
+	}
+	SECTION("ordered part sizes") {
+		policy.maximum_part_size = policy.minimum_part_size - 1;
+		REQUIRE_THROWS(S3UploadConfig::Create(1, 1, policy));
+	}
+	SECTION("maximum part count") {
+		policy.maximum_part_count = 0;
+		REQUIRE_THROWS(S3UploadConfig::Create(1, 1, policy));
+	}
+	SECTION("maximum object size") {
+		policy.maximum_object_size = 0;
+		REQUIRE_THROWS(S3UploadConfig::Create(1, 1, policy));
+	}
+	SECTION("adaptive part alignment") {
+		policy.minimum_part_size++;
+		REQUIRE_THROWS(S3UploadConfig::Create(1, 1, policy));
+	}
+	SECTION("part-size strategy") {
+		policy.part_size_strategy = static_cast<S3MultipartPartSizeStrategy>(99);
+		REQUIRE_THROWS(S3UploadConfig::Create(1, 1, policy));
+	}
+}
+
+TEST_CASE("Fixed multipart upload policies use their own limits", "[httpfs][s3][upload]") {
+	S3MultipartUploadPolicy policy {S3MultipartPartSizeStrategy::FIXED, 3ULL * MIB, 25ULL * MIB, 10, optional_idx()};
+	auto config = S3UploadConfig::Create(12ULL * MIB, 1, policy);
+	REQUIRE(config.initial_part_size == 12ULL * MIB);
+	REQUIRE(config.TargetPartSize(0) == 12ULL * MIB);
+	REQUIRE(config.TargetPartSize(9) == 12ULL * MIB);
+	REQUIRE(config.DirectPartSize(0, 20ULL * MIB) == 12ULL * MIB);
+
+	SECTION("terminal tier") {
+		auto terminal = S3UploadConfig::Create(25ULL * MIB, 1, policy);
+		REQUIRE(terminal.initial_part_size == 25ULL * MIB);
+	}
+
+	SECTION("doubling does not overflow") {
+		policy.minimum_part_size = NumericLimits<idx_t>::Maximum() / 2 + 1;
+		policy.maximum_part_size = NumericLimits<idx_t>::Maximum();
+		auto maximum = S3UploadConfig::Create(NumericLimits<uint64_t>::Maximum(), 1, policy);
+		REQUIRE(maximum.initial_part_size == NumericLimits<idx_t>::Maximum());
+	}
+}
+
+TEST_CASE("R2 upload config uses fixed part sizes", "[httpfs][s3][upload]") {
+	auto policy = GetUploadPolicy(S3ProviderType::R2);
+
+	SECTION("default schedule") {
+		auto config = S3UploadConfig::Create(S3UploadConfig::DEFAULT_MAX_FILESIZE,
+		                                     S3UploadConfig::DEFAULT_MAX_PARTS_PER_FILE, policy);
+		REQUIRE(config.part_size_strategy == S3MultipartPartSizeStrategy::FIXED);
+		REQUIRE(config.initial_part_size == 8 * MIB);
+		REQUIRE(config.TargetPartSize(0) == 8 * MIB);
+		REQUIRE(config.TargetPartSize(config.max_parts - 1) == 8 * MIB);
+		REQUIRE(config.DirectPartSize(0, 16 * MIB) == 8 * MIB);
+	}
+
+	SECTION("part size tiers") {
+		static constexpr array<idx_t, 11> PART_SIZES = {8 * MIB,    16 * MIB,   32 * MIB,  64 * MIB,
+		                                                128 * MIB,  256 * MIB,  512 * MIB, 1024 * MIB,
+		                                                2048 * MIB, 4096 * MIB, 5115 * MIB};
+		uint64_t lower_bound = 1;
+		for (auto part_size : PART_SIZES) {
+			auto lower_config = S3UploadConfig::Create(lower_bound, 1, policy);
+			auto upper_config = S3UploadConfig::Create(part_size, 1, policy);
+			INFO(part_size);
+			REQUIRE(lower_config.initial_part_size == part_size);
+			REQUIRE(upper_config.initial_part_size == part_size);
+			REQUIRE(lower_config.TargetPartSize(0) == part_size);
+			REQUIRE(lower_config.TargetPartSize(1) == part_size);
+			lower_bound = NumericCast<uint64_t>(part_size) + 1;
+		}
+	}
+
+	SECTION("exact limits") {
+		REQUIRE(policy.maximum_part_size == 5115 * MIB);
+		REQUIRE(policy.maximum_object_size == 5115ULL * GIB);
+
+		auto maximum = S3UploadConfig::Create(policy.maximum_object_size.GetIndex(), 1024, policy);
+		REQUIRE(maximum.initial_part_size == policy.maximum_part_size);
+		REQUIRE_THROWS(
+		    S3UploadConfig::Create(policy.maximum_object_size.GetIndex() + 1, policy.maximum_part_count, policy));
+		REQUIRE_THROWS(S3UploadConfig::Create(policy.maximum_object_size.GetIndex(), 1023, policy));
 	}
 }
 

--- a/test/unittest/s3/s3_upload_test.cpp
+++ b/test/unittest/s3/s3_upload_test.cpp
@@ -30,9 +30,9 @@ public:
 		return string();
 	}
 
-	static unique_ptr<FileHandle> OpenWriter(Connection &con) {
+	static unique_ptr<FileHandle> OpenWriter(Connection &con, const string &path = S3TestHelper::S3_PATH) {
 		auto &fs = FileSystem::GetFileSystem(*con.context);
-		return fs.OpenFile(S3TestHelper::S3_PATH, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+		return fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
 	}
 
 	static void Configure(DuckDB &db, Connection &con, MockS3Server &server, const string &client_implementation,
@@ -42,6 +42,99 @@ public:
 			S3TestHelper::RequireQueryOk(con, "SET s3_uploader_max_filesize='50GB'");
 		}
 		S3TestHelper::RequireQueryOk(con, "SET http_retries=0");
+	}
+
+	static void ConfigureFixed(DuckDB &db, Connection &con, MockS3Server &server, const string &client_implementation,
+	                           bool s3_routed) {
+		S3TestHelper::LoadExtension(db);
+		S3TestHelper::RequireQueryOk(
+		    con, StringUtil::Format("SET httpfs_client_implementation='%s'", client_implementation));
+		S3TestHelper::RequireQueryOk(con, "SET httpfs_connection_caching=false");
+		S3TestHelper::RequireQueryOk(con, "SET httpfs_enable_credential_refresh=false");
+		S3TestHelper::RequireQueryOk(con, "SET http_retries=0");
+		auto endpoint = s3_routed ? "account.eu.r2.cloudflarestorage.com" : server.Endpoint();
+		auto secret_type = s3_routed ? "S3" : "R2";
+		auto scope = s3_routed ? "s3://refresh-bucket/" : "r2://refresh-bucket/";
+		S3TestHelper::RequireQueryOk(con, StringUtil::Format(R"(
+CREATE SECRET fixed_upload (
+	TYPE %s,
+	SCOPE '%s',
+	KEY_ID 'R2_KEY',
+	SECRET 'R2_SECRET',
+	REGION 'us-east-1',
+	ENDPOINT '%s',
+	USE_SSL false,
+	URL_STYLE 'path'
+))",
+		                                                     secret_type, scope, endpoint));
+		if (s3_routed) {
+			S3TestHelper::RequireQueryOk(con, StringUtil::Format("SET http_proxy='http://%s'", server.Endpoint()));
+		}
+	}
+
+	static void RunUploadPolicyRefreshRejected(const string &client_implementation, bool initial_fixed) {
+		MockS3ServerConfig config;
+		config.object.bucket = S3TestHelper::BUCKET;
+		config.object.key = S3TestHelper::OBJECT_KEY;
+		config.auth.stale_key_id = S3TestHelper::STALE_KEY_ID;
+		config.auth.refresh_target = MockS3RefreshTarget::MULTIPART_INITIATE_POST;
+		MockS3Server server(std::move(config));
+
+		DuckDB db(nullptr);
+		Connection con(db);
+		S3TestHelper::LoadExtension(db);
+		S3TestHelper::RegisterRefreshProvider(db);
+		auto test_id = S3TestHelper::NextTestId();
+		S3TestHelper::RequireQueryOk(
+		    con, StringUtil::Format("SET httpfs_client_implementation='%s'", client_implementation));
+		S3TestHelper::RequireQueryOk(con, "SET httpfs_connection_caching=false");
+		S3TestHelper::RequireQueryOk(con, "SET httpfs_enable_credential_refresh=true");
+		S3TestHelper::RequireQueryOk(con, "SET http_retries=0");
+		S3TestHelper::RequireQueryOk(con, "SET s3_region='us-east-1'");
+		S3TestHelper::RequireQueryOk(con, "SET s3_use_ssl=false");
+		S3TestHelper::RequireQueryOk(con, "SET s3_url_style='path'");
+		S3TestHelper::RequireQueryOk(con, "SET s3_uploader_max_filesize='50GB'");
+		S3TestHelper::RequireQueryOk(con, StringUtil::Format("SET http_proxy='http://%s'", server.Endpoint()));
+
+		const string r2_endpoint = "account.eu.r2.cloudflarestorage.com";
+		auto initial_endpoint = initial_fixed ? r2_endpoint : server.Endpoint();
+		auto refreshed_endpoint = initial_fixed ? server.Endpoint() : r2_endpoint;
+		S3TestHelper::RequireQueryOk(con, StringUtil::Format(R"(
+CREATE SECRET refresh_upload_policy (
+	TYPE S3,
+	PROVIDER %s,
+	SCOPE 's3://refresh-bucket/',
+	KEY_ID '%s',
+	SECRET '%s',
+	ENDPOINT '%s',
+	TEST_ID '%s',
+	REFRESH_INFO MAP {
+		'KEY_ID': '%s',
+		'SECRET': '%s',
+		'ENDPOINT': '%s',
+		'TEST_ID': '%s'
+	}
+))",
+		                                                     S3TestHelper::TEST_PROVIDER, S3TestHelper::STALE_KEY_ID,
+		                                                     S3TestHelper::STALE_SECRET, initial_endpoint, test_id,
+		                                                     S3TestHelper::FRESH_KEY_ID, S3TestHelper::FRESH_SECRET,
+		                                                     refreshed_endpoint, test_id));
+
+		S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+		auto handle = OpenWriter(con);
+		string payload(10ULL * 1024ULL * 1024ULL + 1, 'x');
+		auto error = RequireError(
+		    [&]() { handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()), payload.size()); });
+		handle.reset();
+		S3TestHelper::RequireQueryOk(con, "ROLLBACK");
+
+		auto observations = server.Observations();
+		INFO(error);
+		INFO(MockS3DescribeObservations(observations));
+		REQUIRE(StringUtil::Contains(error, "different multipart upload policy"));
+		REQUIRE(S3TestHelper::CountObservations(observations, "POST", S3TestHelper::STALE_KEY_ID, 403) == 1);
+		REQUIRE_FALSE(S3TestHelper::HasRequestWithKey(observations, S3TestHelper::FRESH_KEY_ID));
+		S3TestHelper::AssertSingleRefresh(test_id);
 	}
 
 	static idx_t Count(const vector<MockS3RequestObservation> &observations, const string &method,
@@ -629,6 +722,207 @@ public:
 		RequirePartSizes(observations, {5ULL * 1024ULL * 1024ULL, 10ULL * 1024ULL * 1024ULL, 1ULL * 1024ULL * 1024ULL});
 	}
 
+	static void RunFixedFragmented(const string &client_implementation) {
+		MockS3ServerConfig config;
+		config.object.bucket = S3TestHelper::BUCKET;
+		config.object.key = S3TestHelper::OBJECT_KEY;
+		config.auth.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+		config.upload.geometry = MockS3MultipartGeometry::FIXED_EQUAL;
+		MockS3Server server(std::move(config));
+
+		DuckDB db(nullptr);
+		Connection con(db);
+		ConfigureFixed(db, con, server, client_implementation, false);
+
+		auto payload = CreatePayload(2 * FIXED_PART_SIZE + 3);
+		const vector<idx_t> write_sizes {1, FIXED_PART_SIZE - 2, 3, FIXED_PART_SIZE, 1};
+		idx_t offset = 0;
+		S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+		auto handle = OpenWriter(con, R2_PATH);
+		for (auto write_size : write_sizes) {
+			handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()) + offset, write_size);
+			offset += write_size;
+		}
+		REQUIRE(offset == payload.size());
+		handle->Close();
+		handle.reset();
+		S3TestHelper::RequireQueryOk(con, "COMMIT");
+
+		auto observations = server.Observations();
+		INFO(MockS3DescribeObservations(observations));
+		REQUIRE(server.UploadedObject() == payload);
+		RequirePartSizes(observations, {FIXED_PART_SIZE, FIXED_PART_SIZE, 3});
+	}
+
+	static void RunFixedOversized(const string &client_implementation, bool s3_routed) {
+		MockS3ServerConfig config;
+		config.object.bucket = S3TestHelper::BUCKET;
+		config.object.key = S3TestHelper::OBJECT_KEY;
+		config.auth.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+		config.upload.geometry = MockS3MultipartGeometry::FIXED_EQUAL;
+		MockS3Server server(std::move(config));
+
+		DuckDB db(nullptr);
+		Connection con(db);
+		ConfigureFixed(db, con, server, client_implementation, s3_routed);
+
+		auto payload = CreatePayload(3 * FIXED_PART_SIZE);
+		S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+		auto handle = OpenWriter(con, s3_routed ? S3TestHelper::S3_PATH : R2_PATH);
+		handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()), payload.size());
+		try {
+			handle->Close();
+		} catch (...) {
+			INFO(MockS3DescribeObservations(server.Observations()));
+			throw;
+		}
+		handle.reset();
+		S3TestHelper::RequireQueryOk(con, "COMMIT");
+
+		auto observations = server.Observations();
+		INFO(MockS3DescribeObservations(observations));
+		REQUIRE(server.UploadedObject() == payload);
+		RequirePartSizes(observations, {FIXED_PART_SIZE, FIXED_PART_SIZE, FIXED_PART_SIZE});
+	}
+
+	static void RunFixedConcurrentWrites(const string &client_implementation) {
+		MockS3ServerConfig config;
+		config.object.bucket = S3TestHelper::BUCKET;
+		config.object.key = S3TestHelper::OBJECT_KEY;
+		config.auth.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+		config.upload.geometry = MockS3MultipartGeometry::FIXED_EQUAL;
+		config.upload.blocked_part_numbers = {1, 2};
+		MockS3Server server(std::move(config));
+
+		DuckDB db(nullptr);
+		Connection con(db);
+		ConfigureFixed(db, con, server, client_implementation, false);
+		auto write_size = FIXED_PART_SIZE + 1;
+		auto payload = CreatePayload(2 * write_size);
+		S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+		auto handle = OpenWriter(con, R2_PATH);
+		std::exception_ptr first_error;
+		std::exception_ptr second_error;
+		std::thread first([&]() {
+			try {
+				handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()), write_size, 0);
+			} catch (...) {
+				first_error = std::current_exception();
+			}
+		});
+		auto part_1_started = server.WaitForPartUpload(1);
+		std::thread second([&]() {
+			try {
+				handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()) + write_size, write_size,
+				              write_size);
+			} catch (...) {
+				second_error = std::current_exception();
+			}
+		});
+		auto part_2_started = server.WaitForPartUpload(2);
+		auto maximum_concurrency = server.MaximumConcurrentPartUploads();
+		server.ReleasePartUpload(2);
+		auto part_2_completed_first = WaitForPartStatus(server, 2, 200);
+		auto part_1_completed_early = HasPartStatus(server, 1, 200);
+		server.ReleasePartUpload(1);
+		first.join();
+		second.join();
+		if (first_error) {
+			std::rethrow_exception(first_error);
+		}
+		if (second_error) {
+			std::rethrow_exception(second_error);
+		}
+		handle->Close();
+		handle.reset();
+		S3TestHelper::RequireQueryOk(con, "COMMIT");
+
+		auto observations = server.Observations();
+		INFO(MockS3DescribeObservations(observations));
+		REQUIRE(part_1_started);
+		REQUIRE(part_2_started);
+		REQUIRE(maximum_concurrency == 2);
+		REQUIRE(part_2_completed_first);
+		REQUIRE_FALSE(part_1_completed_early);
+		REQUIRE(server.UploadedObject() == payload);
+		RequirePartSizes(observations, {FIXED_PART_SIZE, FIXED_PART_SIZE, 2});
+	}
+
+	static void RunMockRejectsInvalidFixedGeometry(const string &client_implementation, bool final_is_larger) {
+		MockS3ServerConfig config;
+		config.object.bucket = S3TestHelper::BUCKET;
+		config.object.key = S3TestHelper::OBJECT_KEY;
+		config.auth.refresh_target = MockS3RefreshTarget::HEAD;
+		config.upload.initial_published_object = "published before invalid upload";
+		config.upload.geometry = MockS3MultipartGeometry::FIXED_EQUAL;
+		MockS3Server server(std::move(config));
+
+		DuckDB db(nullptr);
+		Connection con(db);
+		Configure(db, con, server, client_implementation);
+		vector<idx_t> write_sizes;
+		vector<idx_t> expected_sizes;
+		if (final_is_larger) {
+			write_sizes = {5ULL * 1024ULL * 1024ULL, 6ULL * 1024ULL * 1024ULL};
+			expected_sizes = write_sizes;
+		} else {
+			S3TestHelper::RequireQueryOk(con, "SET s3_uploader_max_parts_per_file=11");
+			S3TestHelper::RequireQueryOk(con, "SET s3_uploader_max_filesize='16MiB'");
+			write_sizes = {5ULL * 1024ULL * 1024ULL, 5ULL * 1024ULL * 1024ULL, 5ULL * 1024ULL * 1024ULL,
+			               1ULL * 1024ULL * 1024ULL};
+			expected_sizes = {5ULL * 1024ULL * 1024ULL, 10ULL * 1024ULL * 1024ULL, 1ULL * 1024ULL * 1024ULL};
+		}
+		idx_t payload_size = 0;
+		for (auto write_size : write_sizes) {
+			payload_size += write_size;
+		}
+		auto payload = CreatePayload(payload_size);
+		idx_t offset = 0;
+		S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+		auto handle = OpenWriter(con);
+		for (auto write_size : write_sizes) {
+			handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()) + offset, write_size);
+			offset += write_size;
+		}
+		auto error = RequireError([&]() { handle->Close(); });
+		handle.reset();
+		S3TestHelper::RequireQueryOk(con, "ROLLBACK");
+
+		auto observations = server.Observations();
+		INFO(error);
+		INFO(MockS3DescribeObservations(observations));
+		REQUIRE(StringUtil::Contains(error, "InvalidPart"));
+		REQUIRE(server.UploadedObject() == "published before invalid upload");
+		RequirePartSizes(observations, expected_sizes);
+		REQUIRE(Count(observations, "POST", "uploadId") == 1);
+		REQUIRE(Count(observations, "DELETE", "uploadId") == 1);
+	}
+
+	static void RunFixedConfigRejectedBeforeHTTP(const string &client_implementation) {
+		MockS3ServerConfig config;
+		config.object.bucket = S3TestHelper::BUCKET;
+		config.object.key = S3TestHelper::OBJECT_KEY;
+		MockS3Server server(std::move(config));
+
+		DuckDB db(nullptr);
+		Connection con(db);
+		ConfigureFixed(db, con, server, client_implementation, false);
+
+		S3TestHelper::RequireQueryOk(con, "SET s3_uploader_max_filesize='5116GiB'");
+		S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+		auto object_limit_error = RequireError([&]() { OpenWriter(con, R2_PATH); });
+		REQUIRE(StringUtil::Contains(object_limit_error, "maximum object size"));
+		S3TestHelper::RequireQueryOk(con, "ROLLBACK");
+
+		S3TestHelper::RequireQueryOk(con, "SET s3_uploader_max_filesize='5115GiB'");
+		S3TestHelper::RequireQueryOk(con, "SET s3_uploader_max_parts_per_file=1023");
+		S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+		auto part_limit_error = RequireError([&]() { OpenWriter(con, R2_PATH); });
+		REQUIRE(StringUtil::Contains(part_limit_error, "s3_uploader_max_parts_per_file"));
+		S3TestHelper::RequireQueryOk(con, "ROLLBACK");
+		REQUIRE(server.Observations().empty());
+	}
+
 	static void RunExactFileSizeLimit(const string &client_implementation) {
 		MockS3ServerConfig config;
 		config.object.bucket = S3TestHelper::BUCKET;
@@ -836,6 +1130,27 @@ public:
 		REQUIRE(Count(observations, "POST") == 0);
 	}
 
+	static void RunFixed(const string &client_implementation) {
+		SECTION("native R2 fragmented writes have a short final part") {
+			RunFixedFragmented(client_implementation);
+		}
+		SECTION("native R2 concurrent writes retain fixed geometry") {
+			RunFixedConcurrentWrites(client_implementation);
+		}
+		SECTION("S3-routed R2 splits an oversized write into equal parts") {
+			RunFixedOversized(client_implementation, true);
+		}
+		SECTION("fixed geometry mock rejects unequal non-final parts") {
+			RunMockRejectsInvalidFixedGeometry(client_implementation, false);
+		}
+		SECTION("fixed geometry mock rejects a larger final part") {
+			RunMockRejectsInvalidFixedGeometry(client_implementation, true);
+		}
+		SECTION("R2 configuration limits fail before HTTP") {
+			RunFixedConfigRejectedBeforeHTTP(client_implementation);
+		}
+	}
+
 	static void Run(const string &client_implementation) {
 		SECTION("empty PUT") {
 			RunEmpty(client_implementation);
@@ -912,7 +1227,9 @@ public:
 	}
 
 public:
-	static constexpr idx_t INITIAL_PART_SIZE = S3UploadConfig::MIN_MULTIPART_PART_SIZE;
+	static constexpr idx_t INITIAL_PART_SIZE = 5ULL * 1024ULL * 1024ULL;
+	static constexpr idx_t FIXED_PART_SIZE = 8ULL * 1024ULL * 1024ULL;
+	static constexpr const char *R2_PATH = "r2://refresh-bucket/object.bin";
 };
 
 } // namespace
@@ -923,6 +1240,26 @@ TEST_CASE("S3 upload request geometry", "[httpfs][s3][upload]") {
 	}
 	SECTION("httplib") {
 		S3UploadTest::Run("httplib");
+	}
+}
+
+TEST_CASE("R2 upload request geometry", "[httpfs][s3][upload][r2]") {
+	SECTION("curl") {
+		S3UploadTest::RunFixed("curl");
+	}
+	SECTION("httplib") {
+		S3UploadTest::RunFixed("httplib");
+	}
+}
+
+TEST_CASE("S3 upload policy is stable across credential refresh", "[httpfs][s3][upload][refresh]") {
+	for (const auto &client_implementation : {"curl", "httplib"}) {
+		DYNAMIC_SECTION(client_implementation << " rejects adaptive-to-fixed refresh") {
+			S3UploadTest::RunUploadPolicyRefreshRejected(client_implementation, false);
+		}
+		DYNAMIC_SECTION(client_implementation << " rejects fixed-to-adaptive refresh") {
+			S3UploadTest::RunUploadPolicyRefreshRejected(client_implementation, true);
+		}
 	}
 }
 

--- a/test/unittest/s3/scheme_alias_isolation_test.cpp
+++ b/test/unittest/s3/scheme_alias_isolation_test.cpp
@@ -90,6 +90,7 @@ TEST_CASE("a required endpoint may arrive from any source, but must arrive", "[h
 			S3Provider::InitializeAuthParams(params);
 			auto parsed = S3Url::Resolve(string(test_case.url) + "?s3_endpoint=storage.example.com", params);
 			REQUIRE(params.endpoint == "storage.example.com");
+			REQUIRE(params.endpoint_mode == S3EndpointMode::EXPLICIT);
 			REQUIRE(parsed.host == "bucket.storage.example.com");
 		}
 	}
@@ -98,7 +99,7 @@ TEST_CASE("a required endpoint may arrive from any source, but must arrive", "[h
 		for (auto &test_case : CASES) {
 			for (const auto &cleared : {"", "%20"}) {
 				auto params = make_params(test_case);
-				params.endpoint = "storage.example.com";
+				params.SetEndpoint("storage.example.com");
 				S3Provider::InitializeAuthParams(params);
 				REQUIRE_THROWS(S3Url::Resolve(string(test_case.url) + "?s3_endpoint=" + cleared, params));
 			}


### PR DESCRIPTION
This PR tracks whether an S3 endpoint is automatic or explicitly configured, so region updates no longer overwrite custom, dualstack, or FIPS endpoints. It also validates S3 URL styles consistently across secrets, settings, and URL parameters before sending a request.

EDIT: also added fixed-size part upload policy for R2.