### PR TITLE
Compatibility fixes

### DIFF
--- a/src/include/s3/s3_provider.hpp
+++ b/src/include/s3/s3_provider.hpp
@@ -70,6 +70,7 @@ struct S3Provider {
 	static S3URLStyle ParseURLStyle(const string &url_style);
 	static S3AuthType GetAuthType(const S3AuthParams &auth_params);
 	static S3MultipartUploadPolicy GetMultipartUploadPolicy(const S3AuthParams &auth_params);
+	static idx_t GetBulkDeleteMaxBatchSize(const S3AuthParams &auth_params);
 	static string GetBadRequestError(const S3AuthParams &auth_params, const string &correct_region = "");
 	static string GetAuthError(const S3AuthParams &auth_params);
 };

--- a/src/include/s3/s3_upload_session.hpp
+++ b/src/include/s3/s3_upload_session.hpp
@@ -144,10 +144,10 @@ private:
 	void CompleteMultipartUpload();
 
 	//! S3 upload and cleanup requests.
-	string Upload(const_data_ptr_t data, idx_t size, const S3RequestQuery &query);
+	unique_ptr<HTTPResponse> RunUploadRequest(const_data_ptr_t data, idx_t size, const S3RequestQuery &query,
+	                                          S3RequestContext &request_context);
+	void UploadObject(const_data_ptr_t data, idx_t size);
 	void UploadPart(PreparedPart &part);
-	void UploadSingle(BufferedPart &buffered_part);
-	void UploadEmpty();
 	shared_ptr<const ErrorData> AbortMultipartUpload(const string &upload_id);
 
 	//! Request diagnostics.

--- a/src/include/s3/s3fs.hpp
+++ b/src/include/s3/s3fs.hpp
@@ -145,7 +145,7 @@ protected:
 
 private:
 	unique_ptr<HTTPResponse> RunS3BulkDeleteRequest(HTTPRequestSession &session, const string &secret_lookup_url,
-	                                                const string &body, string &result,
+	                                                const string &body, idx_t key_count, string &result,
 	                                                optional_ptr<S3RequestContext> request_context = nullptr);
 
 public:

--- a/src/s3/s3_delete.cpp
+++ b/src/s3/s3_delete.cpp
@@ -201,7 +201,7 @@ static string GetS3DeleteContentMD5(const string &body) {
 
 unique_ptr<HTTPResponse> S3FileSystem::RunS3BulkDeleteRequest(HTTPRequestSession &session,
                                                               const string &secret_lookup_url, const string &body,
-                                                              string &result,
+                                                              idx_t key_count, string &result,
                                                               optional_ptr<S3RequestContext> request_context) {
 	auto payload_hash =
 	    S3RequestUtil::GetPayloadHash(GetEncryptionUtil(), const_data_ptr_cast(body.data()), body.length());
@@ -213,6 +213,13 @@ unique_ptr<HTTPResponse> S3FileSystem::RunS3BulkDeleteRequest(HTTPRequestSession
 	    },
 	    payload_hash, "application/xml", content_md5,
 	    [&](S3RequestData &request_data) {
+		    auto maximum_key_count = S3Provider::GetBulkDeleteMaxBatchSize(request_data.auth_params);
+		    if (key_count > maximum_key_count) {
+			    throw IOException(
+			        "Cannot send S3 bulk delete with %llu keys because the current provider policy allows "
+			        "at most %llu keys per request",
+			        key_count, maximum_key_count);
+		    }
 		    result.clear();
 		    auto &params = request_data.http_params->Cast<HTTPFSParams>();
 		    return RunPostRequest(request_data.http_url, request_data.headers, params, result,
@@ -253,23 +260,22 @@ void S3FileSystem::RemoveFiles(const vector<string> &paths, optional_ptr<FileOpe
 		batch.secret_lookup_paths.push_back(path);
 	}
 
-	constexpr idx_t MAX_KEYS_PER_REQUEST = 1000;
-
 	for (auto &batch_entry : delete_batches) {
 		auto &batch = batch_entry.second;
 		const vector<string> &keys = batch.keys;
 		const vector<string> &secret_lookup_paths = batch.secret_lookup_paths;
 		auto &url_info = batch.url_info;
+		auto maximum_key_count = S3Provider::GetBulkDeleteMaxBatchSize(url_info.auth_params);
 		auto delete_session =
 		    S3RequestExecutor::CreateSession(opener, secret_lookup_paths.front(), url_info.auth_params);
 
-		for (idx_t batch_start = 0; batch_start < keys.size(); batch_start += MAX_KEYS_PER_REQUEST) {
-			auto batch_end = MinValue<idx_t>(batch_start + MAX_KEYS_PER_REQUEST, keys.size());
+		for (idx_t batch_start = 0; batch_start < keys.size(); batch_start += maximum_key_count) {
+			auto batch_end = MinValue<idx_t>(batch_start + maximum_key_count, keys.size());
 			auto body = S3XMLWriter::WriteDeleteObjectsRequest(keys, batch_start, batch_end);
 			string result;
 			S3RequestContext request_context;
-			auto res = RunS3BulkDeleteRequest(*delete_session, secret_lookup_paths[batch_start], body, result,
-			                                  request_context);
+			auto res = RunS3BulkDeleteRequest(*delete_session, secret_lookup_paths[batch_start], body,
+			                                  batch_end - batch_start, result, request_context);
 
 			if (res->HasRequestError()) {
 				throw IOException("S3 bulk delete request for \"%s\" could not be completed: %s",

--- a/src/s3/s3_provider.cpp
+++ b/src/s3/s3_provider.cpp
@@ -376,6 +376,11 @@ static bool EndpointIsR2(const string &endpoint) {
 	return jurisdiction == "eu" || jurisdiction == "us" || jurisdiction == "fedramp";
 }
 
+static bool UsesR2CompatibilityProfile(const S3AuthParams &auth_params) {
+	return auth_params.provider_type == S3ProviderType::R2 ||
+	       (auth_params.provider_type == S3ProviderType::S3 && EndpointIsR2(auth_params.endpoint));
+}
+
 static S3MultipartUploadPolicy DefaultMultipartUploadPolicy() {
 	static constexpr idx_t MIB = 1024ULL * 1024ULL;
 	static constexpr idx_t GIB = 1024ULL * MIB;
@@ -391,11 +396,14 @@ static S3MultipartUploadPolicy R2MultipartUploadPolicy() {
 }
 
 S3MultipartUploadPolicy S3Provider::GetMultipartUploadPolicy(const S3AuthParams &auth_params) {
-	if (auth_params.provider_type == S3ProviderType::R2 ||
-	    (auth_params.provider_type == S3ProviderType::S3 && EndpointIsR2(auth_params.endpoint))) {
+	if (UsesR2CompatibilityProfile(auth_params)) {
 		return R2MultipartUploadPolicy();
 	}
 	return DefaultMultipartUploadPolicy();
+}
+
+idx_t S3Provider::GetBulkDeleteMaxBatchSize(const S3AuthParams &auth_params) {
+	return UsesR2CompatibilityProfile(auth_params) ? 700 : 1000;
 }
 
 string S3Provider::GetBadRequestError(const S3AuthParams &auth_params, const string &correct_region) {

--- a/src/s3/s3_upload_session.cpp
+++ b/src/s3/s3_upload_session.cpp
@@ -455,19 +455,22 @@ void S3UploadSession::ThrowIfFailed() DUCKDB_EXCLUDES(state_lock) {
 	}
 }
 
-string S3UploadSession::Upload(const_data_ptr_t data, idx_t size, const S3RequestQuery &query) {
-	S3RequestContext request_context;
+unique_ptr<HTTPResponse> S3UploadSession::RunUploadRequest(const_data_ptr_t data, idx_t size,
+                                                           const S3RequestQuery &query,
+                                                           S3RequestContext &request_context) {
 	auto response = s3fs.get().PutRequest(*request_session, path, data, size, query, request_context);
 	if (response->HasRequestError()) {
 		throw IOException("S3 upload request for \"%s\" could not be completed", request_context.display_url);
 	}
-	if (response->status != HTTPStatusCode::OK_200) {
+	return response;
+}
+
+void S3UploadSession::UploadObject(const_data_ptr_t data, idx_t size) {
+	S3RequestContext request_context;
+	auto response = RunUploadRequest(data, size, S3RequestQuery(), request_context);
+	if (response->status != HTTPStatusCode::OK_200 && response->status != HTTPStatusCode::Created_201) {
 		throw GetStatusError(*response, request_context, "uploading to");
 	}
-	if (!response->headers.HasHeader("ETag")) {
-		throw IOException("Unexpected response when uploading to S3");
-	}
-	return response->headers.GetHeaderValue("ETag");
 }
 
 void S3UploadSession::UploadPart(PreparedPart &part) {
@@ -475,7 +478,18 @@ void S3UploadSession::UploadPart(PreparedPart &part) {
 	ThrowIfFailed();
 	D_ASSERT(upload_id);
 	S3RequestQuery query {{"partNumber", to_string(part.part_number)}, {"uploadId", *upload_id}};
-	auto etag = Upload(part.data, part.size, query);
+	S3RequestContext request_context;
+	auto response = RunUploadRequest(part.data, part.size, query, request_context);
+	if (response->status != HTTPStatusCode::OK_200) {
+		throw GetStatusError(*response, request_context, "uploading to");
+	}
+	if (!response->headers.HasHeader("ETag")) {
+		throw IOException("Unexpected response when uploading to S3");
+	}
+	auto etag = response->headers.GetHeaderValue("ETag");
+	if (etag.empty()) {
+		throw IOException("Unexpected response when uploading to S3");
+	}
 	StorePartETag(part.part_number, std::move(etag));
 }
 
@@ -495,15 +509,6 @@ void S3UploadSession::StorePartETag(idx_t part_number, string etag) DUCKDB_EXCLU
 	if (failure.primary_error) {
 		ThrowFailure(failure);
 	}
-}
-
-void S3UploadSession::UploadSingle(BufferedPart &buffered_part_p) {
-	Upload(buffered_part_p.Ptr(), buffered_part_p.size, S3RequestQuery());
-}
-
-void S3UploadSession::UploadEmpty() {
-	const_data_ptr_t empty = nullptr;
-	Upload(empty, 0, S3RequestQuery());
 }
 
 S3UploadSession::MultipartSnapshot S3UploadSession::GetMultipartSnapshot() DUCKDB_EXCLUDES(state_lock) {
@@ -603,9 +608,9 @@ void S3UploadSession::Finalize() {
 		}
 		if (!multipart_upload) {
 			if (!local_buffered_part) {
-				UploadEmpty();
+				UploadObject(nullptr, 0);
 			} else {
-				UploadSingle(*local_buffered_part);
+				UploadObject(local_buffered_part->Ptr(), local_buffered_part->size);
 			}
 		} else {
 			if (local_buffered_part) {

--- a/src/s3/s3_xml_response.cpp
+++ b/src/s3/s3_xml_response.cpp
@@ -131,9 +131,6 @@ private:
 	static constexpr const char *UTF8_BOM = "\xEF\xBB\xBF";
 	static constexpr const char *XML_NAMESPACE = "http://www.w3.org/XML/1998/namespace";
 	static constexpr const char *XMLNS_NAMESPACE = "http://www.w3.org/2000/xmlns/";
-	static constexpr const char *S3_NAMESPACE = "http://s3.amazonaws.com/doc/2006-03-01/";
-	static constexpr const char *GCS_S3_NAMESPACE = "http://doc.s3.amazonaws.com/2006-03-01";
-	static constexpr const char *GCS_STORAGE_NAMESPACE = "http://doc.storage.googleapis.com/2010-03-01";
 	static constexpr idx_t MAX_NESTING_DEPTH = 256;
 
 	bool HasPrefix(const char *prefix) const {
@@ -622,13 +619,6 @@ private:
 
 	enum class ChildTextResult : uint8_t { MISSING, FOUND, INVALID };
 
-	bool HasSupportedNamespace() const {
-		const auto &namespace_uri = root.namespace_uri;
-		return namespace_uri.empty() || namespace_uri == S3_NAMESPACE || namespace_uri == GCS_S3_NAMESPACE ||
-		       namespace_uri == string(GCS_S3_NAMESPACE) + "/" || namespace_uri == GCS_STORAGE_NAMESPACE ||
-		       namespace_uri == string(GCS_STORAGE_NAMESPACE) + "/";
-	}
-
 	static ChildTextResult GetChildText(const S3XMLNode &parent, const string &namespace_uri, const string &local_name,
 	                                    string &result) {
 		idx_t matches = 0;
@@ -654,9 +644,6 @@ private:
 	}
 
 	void InterpretResponse(S3XMLResponse &response) const {
-		if (!HasSupportedNamespace()) {
-			return;
-		}
 		if (root.local_name == "InitiateMultipartUploadResult") {
 			if (GetChildText(root, root.namespace_uri, "UploadId", response.upload_id) == ChildTextResult::FOUND &&
 			    !response.upload_id.empty()) {
@@ -688,7 +675,7 @@ private:
 	}
 
 	bool InterpretListObjectsV2(S3ListObjectsV2Result &result) const {
-		if (!HasSupportedNamespace() || root.local_name != "ListBucketResult") {
+		if (root.local_name != "ListBucketResult") {
 			return false;
 		}
 		if (!GetOptionalChildText(root, root.namespace_uri, "NextContinuationToken", result.continuation_token)) {
@@ -727,7 +714,7 @@ private:
 	}
 
 	bool InterpretDeleteObjects(S3DeleteObjectsResult &result) const {
-		if (!HasSupportedNamespace() || root.local_name != "DeleteResult") {
+		if (root.local_name != "DeleteResult") {
 			return false;
 		}
 		for (const auto &child : root.children) {

--- a/test/unittest/s3/mock_s3_server.cpp
+++ b/test/unittest/s3/mock_s3_server.cpp
@@ -110,6 +110,14 @@ static idx_t CountDeleteKeys(const string &body) {
 	return result;
 }
 
+static void SetETagHeader(httplib::Response &response, MockS3ETagBehavior behavior, const string &value) {
+	if (behavior == MockS3ETagBehavior::VALUE) {
+		response.set_header("ETag", value);
+	} else if (behavior == MockS3ETagBehavior::EMPTY) {
+		response.set_header("ETag", "");
+	}
+}
+
 static string GetParameter(const httplib::Request &request, const string &parameter) {
 	if (!request.has_param(parameter)) {
 		return string();
@@ -491,17 +499,18 @@ public:
 		Record(request, response.status);
 	}
 
-	void SendPutSuccess(const httplib::Request &request, httplib::Response &response) {
-		response.status = 200;
+	void SendPutResponse(const httplib::Request &request, httplib::Response &response) {
 		auto part_number = GetPartNumber(request);
+		auto &response_config = part_number.IsValid() ? config.upload.multipart_part_put : config.upload.object_put;
+		response.status = response_config.status;
 		if (part_number.IsValid()) {
 			auto part = part_number.GetIndex();
 			auto etag = StringUtil::Format("\"mock-part-%llu\"", part);
-			response.set_header("ETag", etag);
+			SetETagHeader(response, response_config.etag, etag);
 			annotated_lock_guard<annotated_mutex> lock(upload_lock);
 			uploaded_parts[part] = {std::move(etag), request.body};
 		} else {
-			response.set_header("ETag", "\"httpfs-refresh-test-upload-etag\"");
+			SetETagHeader(response, response_config.etag, "\"httpfs-refresh-test-upload-etag\"");
 			annotated_lock_guard<annotated_mutex> lock(upload_lock);
 			uploaded_object = request.body;
 		}
@@ -787,7 +796,7 @@ public:
 			SendS3Error400(request, response, config.failures.failure_is_request_timeout);
 			return;
 		}
-		SendPutSuccess(request, response);
+		SendPutResponse(request, response);
 	}
 
 	void HandleObjectPost(const httplib::Request &request, httplib::Response &response) {

--- a/test/unittest/s3/mock_s3_server.cpp
+++ b/test/unittest/s3/mock_s3_server.cpp
@@ -100,6 +100,16 @@ static idx_t CountHeader(const httplib::Request &request, const string &header) 
 	return result;
 }
 
+static idx_t CountDeleteKeys(const string &body) {
+	idx_t result = 0;
+	idx_t position = 0;
+	while ((position = body.find("<Object>", position)) != string::npos) {
+		result++;
+		position += strlen("<Object>");
+	}
+	return result;
+}
+
 static string GetParameter(const httplib::Request &request, const string &parameter) {
 	if (!request.has_param(parameter)) {
 		return string();
@@ -411,6 +421,7 @@ public:
 		observation.part_number = GetPartNumber(request);
 		observation.body_size = request.body.size();
 		observation.body_digest = MockS3BodyDigest::Compute(request.body);
+		observation.delete_key_count = CountDeleteKeys(request.body);
 		observation.user_agent_count = CountHeader(request, "User-Agent");
 		observation.session_header_count = CountHeader(request, "X-HTTPFS-Session");
 		observation.status = status;
@@ -698,7 +709,17 @@ public:
 		active_part_uploads--;
 	}
 
-	void SendBulkDeleteSuccess(const httplib::Request &request, httplib::Response &response) const {
+	void SendBulkDeleteResponse(const httplib::Request &request, httplib::Response &response) const {
+		auto key_count = CountDeleteKeys(request.body);
+		if (config.bulk_delete.maximum_key_count.IsValid() &&
+		    key_count > config.bulk_delete.maximum_key_count.GetIndex()) {
+			response.status = 500;
+			response.set_content("<Error><Code>InternalError</Code><Message>DeleteObjects batch is too large</Message>"
+			                     "</Error>",
+			                     "application/xml");
+			Record(request, response.status);
+			return;
+		}
 		response.status = 200;
 		response.set_content("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
 		                     "<DeleteResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"></DeleteResult>",
@@ -834,6 +855,8 @@ public:
 		const string proxy_path = "https?://[^/]+" + path;
 		const string bucket_path = StringUtil::Format("/%s", config.object.bucket);
 		const string bucket_path_with_slash = bucket_path + "/";
+		const string proxy_bucket_path = "https?://[^/]+" + bucket_path;
+		const string proxy_bucket_path_with_slash = proxy_bucket_path + "/";
 		server.set_post_routing_handler([this](const httplib::Request &, httplib::Response &response) {
 			if (!response.has_header("X-Mock-Successful-Short-Response")) {
 				return;
@@ -846,18 +869,7 @@ public:
 			response.headers.erase(marker.first, marker.second);
 		});
 
-		server.set_pre_routing_handler([this, path, bucket_path, bucket_path_with_slash](
-		                                   const httplib::Request &request, httplib::Response &response) {
-			if (request.method == "POST" && request.target.find("delete") != string::npos &&
-			    (StringUtil::EndsWith(request.path, bucket_path) ||
-			     StringUtil::EndsWith(request.path, bucket_path_with_slash))) {
-				if (ShouldRejectStaleCredentials(request)) {
-					SendAuthFailure(request, response);
-				} else {
-					SendBulkDeleteSuccess(request, response);
-				}
-				return httplib::Server::HandlerResponse::Handled;
-			}
+		server.set_pre_routing_handler([this, path](const httplib::Request &request, httplib::Response &response) {
 			if (request.method != "HEAD" || request.path != path) {
 				return httplib::Server::HandlerResponse::Unhandled;
 			}
@@ -1108,10 +1120,12 @@ public:
 				SendAuthFailure(request, response);
 				return;
 			}
-			SendBulkDeleteSuccess(request, response);
+			SendBulkDeleteResponse(request, response);
 		};
 		server.Post(bucket_path, bulk_delete);
 		server.Post(bucket_path_with_slash, bulk_delete);
+		server.Post(proxy_bucket_path, bulk_delete);
+		server.Post(proxy_bucket_path_with_slash, bulk_delete);
 
 		server.Delete(path, [this](const httplib::Request &request, httplib::Response &response) {
 			HandleObjectDelete(request, response);
@@ -1303,14 +1317,15 @@ string MockS3DescribeObservations(const vector<MockS3RequestObservation> &observ
 		}
 		result += StringUtil::Format(
 		    "%s %s status=%d key=%s region=%s range=%s if_match=%s version_id=%s target=%s upload_id=%s "
-		    "part_number=%s body_size=%llu body_digest=%s published=%s sse=%s kms_key_id=%s user_agent=%s "
+		    "part_number=%s body_size=%llu delete_key_count=%llu body_digest=%s published=%s sse=%s "
+		    "kms_key_id=%s user_agent=%s "
 		    "session_header=%s",
 		    observation.method, observation.path, observation.status, observation.key_id, observation.region,
 		    observation.range, observation.if_match, observation.version_id, observation.target, observation.upload_id,
 		    observation.part_number.IsValid() ? std::to_string(observation.part_number.GetIndex()) : string(),
-		    observation.body_size, observation.body_digest, observation.multipart_upload_published ? "true" : "false",
-		    observation.server_side_encryption, observation.kms_key_id, observation.user_agent,
-		    observation.session_header);
+		    observation.body_size, observation.delete_key_count, observation.body_digest,
+		    observation.multipart_upload_published ? "true" : "false", observation.server_side_encryption,
+		    observation.kms_key_id, observation.user_agent, observation.session_header);
 	}
 	return result;
 }

--- a/test/unittest/s3/mock_s3_server.cpp
+++ b/test/unittest/s3/mock_s3_server.cpp
@@ -765,12 +765,20 @@ public:
 
 	void SendMalformedListObjectsSuccess(const httplib::Request &request, httplib::Response &response) const {
 		response.status = 200;
-		response.set_content("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-		                     "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">"
-		                     "<Name>refresh-bucket</Name>"
-		                     "<Contents><Key>partial-fake-object.bin</Key><ETag>&quot;fake&quot;</ETag><Size>1</Size>"
-		                     "</Contents>",
-		                     "application/xml");
+		if (config.failures.malformed_list_behavior == MockS3MalformedListBehavior::FOREIGN_NAMESPACE_KEY) {
+			response.set_content("<native:ListBucketResult xmlns:native=\"urn:native\" xmlns:foreign=\"urn:foreign\">"
+			                     "<native:Contents><foreign:Key>partial-fake-object.bin</foreign:Key>"
+			                     "</native:Contents></native:ListBucketResult>",
+			                     "application/xml");
+		} else {
+			response.set_content(
+			    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+			    "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">"
+			    "<Name>refresh-bucket</Name>"
+			    "<Contents><Key>partial-fake-object.bin</Key><ETag>&quot;fake&quot;</ETag><Size>1</Size>"
+			    "</Contents>",
+			    "application/xml");
+		}
 		Record(request, response.status);
 	}
 

--- a/test/unittest/s3/mock_s3_server.hpp
+++ b/test/unittest/s3/mock_s3_server.hpp
@@ -39,6 +39,8 @@ enum class MockS3MultipartAbortBehavior : uint8_t { SUCCESS, ERROR };
 
 enum class MockS3MultipartGeometry : uint8_t { FLEXIBLE, FIXED_EQUAL };
 
+enum class MockS3ETagBehavior : uint8_t { VALUE, EMPTY, OMIT };
+
 struct MockS3ObjectConfig {
 	string bucket = "refresh-bucket";
 	string key = "object.bin";
@@ -137,7 +139,16 @@ struct MockS3FullGetConfig {
 	bool block_until_released = false;
 };
 
+struct MockS3PutResponseConfig {
+	int status = 200;
+	MockS3ETagBehavior etag = MockS3ETagBehavior::VALUE;
+};
+
 struct MockS3UploadConfig {
+	//! PUT response behavior
+	MockS3PutResponseConfig object_put;
+	MockS3PutResponseConfig multipart_part_put;
+
 	//! Existing object preserved when an upload is abandoned
 	string initial_published_object;
 	//! Multipart upload ID returned by the mock server

--- a/test/unittest/s3/mock_s3_server.hpp
+++ b/test/unittest/s3/mock_s3_server.hpp
@@ -19,6 +19,8 @@ enum class MockS3RefreshTarget : uint8_t {
 
 enum class MockS3RangeBehavior : uint8_t { NORMAL, IGNORE_RANGE, TRUNCATE_TRANSFER, SHORT_SUCCESS };
 
+enum class MockS3MalformedListBehavior : uint8_t { TRUNCATED_XML, FOREIGN_NAMESPACE_KEY };
+
 enum class MockS3MultipartInitializationBehavior : uint8_t {
 	SUCCESS,
 	NAMESPACED_ESCAPED_SUCCESS,
@@ -85,6 +87,7 @@ struct MockS3FailureConfig {
 	idx_t transient_400_lists = 0;
 	//! Answer this many leading ListObjectsV2 requests with malformed HTTP 200 bodies
 	idx_t malformed_success_lists = 0;
+	MockS3MalformedListBehavior malformed_list_behavior = MockS3MalformedListBehavior::TRUNCATED_XML;
 	//! Number of object PUTs to fail with a 400 before succeeding
 	idx_t transient_put_failures = 0;
 	//! Number of object GETs to fail with a 400 before succeeding

--- a/test/unittest/s3/mock_s3_server.hpp
+++ b/test/unittest/s3/mock_s3_server.hpp
@@ -110,6 +110,11 @@ struct MockS3ListConfig {
 	bool paginate = false;
 };
 
+struct MockS3BulkDeleteConfig {
+	//! Reject DeleteObjects requests containing more than this many keys
+	optional_idx maximum_key_count;
+};
+
 struct MockS3RangeConfig {
 	MockS3RangeBehavior behavior = MockS3RangeBehavior::NORMAL;
 	//! Number of leading range GETs affected by transient range behaviors
@@ -157,6 +162,7 @@ struct MockS3ServerConfig {
 	MockS3MetadataConfig metadata;
 	MockS3FailureConfig failures;
 	MockS3ListConfig list;
+	MockS3BulkDeleteConfig bulk_delete;
 	MockS3RangeConfig range;
 	MockS3FullGetConfig full_get;
 	MockS3UploadConfig upload;
@@ -181,6 +187,7 @@ struct MockS3RequestObservation {
 	string body_digest;
 	optional_idx part_number;
 	idx_t body_size = 0;
+	idx_t delete_key_count = 0;
 	idx_t user_agent_count = 0;
 	idx_t session_header_count = 0;
 	int status = 0;

--- a/test/unittest/s3/s3_refresh_test.cpp
+++ b/test/unittest/s3/s3_refresh_test.cpp
@@ -182,6 +182,60 @@ static void RunBulkDeleteEndpointRefreshScenario(const string &client_implementa
 	REQUIRE(S3TestHelper::CountObservations(fresh_observations, "POST", S3TestHelper::STALE_KEY_ID, 200) == 1);
 }
 
+static void RunBulkDeleteR2PolicyRefreshScenario(const string &client_implementation, idx_t key_count) {
+	MockS3ServerConfig config;
+	config.auth.stale_key_id = S3TestHelper::STALE_KEY_ID;
+	config.auth.refresh_target = MockS3RefreshTarget::BULK_DELETE_POST;
+	config.bulk_delete.maximum_key_count = 700;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto test_id = S3TestHelper::ConfigureEndpointRefresh(db, con, "objects.example.com",
+	                                                      "account.r2.cloudflarestorage.com", client_implementation,
+	                                                      true, StringUtil::Format("http://%s", server.Endpoint()));
+
+	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+	string error;
+	try {
+		auto &fs = FileSystem::GetFileSystem(*con.context);
+		fs.RemoveFiles(S3TestHelper::CreateBulkDeletePaths("s3", key_count));
+	} catch (std::exception &ex) {
+		error = ex.what();
+	}
+	INFO(error);
+	if (key_count <= 700) {
+		REQUIRE(error.empty());
+		S3TestHelper::RequireQueryOk(con, "COMMIT");
+	} else {
+		REQUIRE(error.find("Cannot send S3 bulk delete with 1000 keys") != string::npos);
+		REQUIRE(error.find("at most 700 keys per request") != string::npos);
+		S3TestHelper::RequireQueryOk(con, "ROLLBACK");
+	}
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	idx_t stale_requests = 0;
+	idx_t fresh_requests = 0;
+	for (const auto &observation : observations) {
+		if (observation.method != "POST" || !StringUtil::EndsWith(observation.target, "?delete=")) {
+			continue;
+		}
+		if (observation.key_id == S3TestHelper::STALE_KEY_ID) {
+			stale_requests++;
+			REQUIRE(observation.status == 403);
+			REQUIRE(observation.delete_key_count == key_count);
+		} else if (observation.key_id == S3TestHelper::FRESH_KEY_ID) {
+			fresh_requests++;
+			REQUIRE(observation.status == 200);
+			REQUIRE(observation.delete_key_count == key_count);
+		}
+	}
+	REQUIRE(stale_requests == 1);
+	REQUIRE(fresh_requests == (key_count <= 700 ? 1 : 0));
+	S3TestHelper::AssertSingleRefresh(test_id);
+}
+
 static void RunDeleteRefreshScenario(const string &client_implementation, bool connection_caching) {
 	auto observations = RunRefreshScenario(MockS3RefreshTarget::DELETE_OBJECT, client_implementation,
 	                                       connection_caching, [](Connection &con, const string &) {
@@ -738,6 +792,17 @@ TEST_CASE("HTTPFS bulk delete follows a refreshed S3 endpoint", "[httpfs][s3][re
 	}
 	SECTION("curl") {
 		RunBulkDeleteEndpointRefreshScenario("curl");
+	}
+}
+
+TEST_CASE("HTTPFS bulk delete revalidates R2 limits after endpoint refresh", "[httpfs][s3][refresh][delete]") {
+	for (const string client_implementation : {"httplib", "curl"}) {
+		DYNAMIC_SECTION(client_implementation << " accepts a compatible prepared batch") {
+			RunBulkDeleteR2PolicyRefreshScenario(client_implementation, 700);
+		}
+		DYNAMIC_SECTION(client_implementation << " rejects an oversized prepared batch before dispatch") {
+			RunBulkDeleteR2PolicyRefreshScenario(client_implementation, 1000);
+		}
 	}
 }
 

--- a/test/unittest/s3/s3_request_test.cpp
+++ b/test/unittest/s3/s3_request_test.cpp
@@ -661,6 +661,65 @@ CREATE SECRET delete_endpoint_mode (
 	REQUIRE(bulk_delete_requests == 2);
 }
 
+enum class BulkDeleteProviderProfile : uint8_t { S3, R2_SCHEME, R2_ENDPOINT };
+
+static void RunBulkDeleteBatchLimitScenario(const string &client_implementation, BulkDeleteProviderProfile profile) {
+	const bool uses_r2_profile = profile != BulkDeleteProviderProfile::S3;
+	const auto key_count = uses_r2_profile ? 701 : 1000;
+
+	MockS3ServerConfig config;
+	config.auth.stale_key_id = "NEVER_STALE";
+	config.bulk_delete.maximum_key_count = uses_r2_profile ? 700 : 1000;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	S3TestHelper::LoadExtension(db);
+	S3TestHelper::RequireQueryOk(con,
+	                             StringUtil::Format("SET httpfs_client_implementation='%s'", client_implementation));
+	S3TestHelper::RequireQueryOk(con, "SET httpfs_connection_caching=false");
+	S3TestHelper::RequireQueryOk(con, "SET enable_global_s3_configuration=false");
+
+	const auto uses_r2_endpoint = profile == BulkDeleteProviderProfile::R2_ENDPOINT;
+	auto endpoint = uses_r2_endpoint ? "account.r2.cloudflarestorage.com" : server.Endpoint();
+	if (uses_r2_endpoint) {
+		S3TestHelper::RequireQueryOk(con, StringUtil::Format("SET http_proxy='http://%s'", server.Endpoint()));
+	}
+	auto secret_type = profile == BulkDeleteProviderProfile::R2_SCHEME ? "R2" : "S3";
+	auto scheme = profile == BulkDeleteProviderProfile::R2_SCHEME ? "r2" : "s3";
+	auto region = uses_r2_profile ? "auto" : "us-east-1";
+	S3TestHelper::RequireQueryOk(con, StringUtil::Format(R"(
+CREATE SECRET delete_batch_limit (
+	TYPE %s,
+	KEY_ID 'FRESH_KEY',
+	SECRET 'FRESH_SECRET',
+	REGION '%s',
+	ENDPOINT '%s',
+	USE_SSL false,
+	URL_STYLE 'path'
+))",
+	                                                     secret_type, region, endpoint));
+
+	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	fs.RemoveFiles(S3TestHelper::CreateBulkDeletePaths(scheme, key_count));
+	S3TestHelper::RequireQueryOk(con, "COMMIT");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	vector<idx_t> observed_batch_sizes;
+	for (const auto &observation : observations) {
+		if (observation.method == "POST" && StringUtil::EndsWith(observation.target, "?delete=")) {
+			observed_batch_sizes.push_back(observation.delete_key_count);
+		}
+	}
+	if (uses_r2_profile) {
+		REQUIRE(observed_batch_sizes == vector<idx_t> {700, 1});
+	} else {
+		REQUIRE(observed_batch_sizes == vector<idx_t> {1000});
+	}
+}
+
 static void RunGCSListAuthErrorScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
 	config.auth.stale_authorization = "Bearer gcs-test-token";
@@ -750,6 +809,28 @@ TEST_CASE("S3 provider selects multipart upload policy", "[httpfs][s3][provider]
 	require_policy(S3ProviderType::S3, "evilr2.cloudflarestorage.com", adaptive_policy);
 	require_policy(S3ProviderType::S3, "objects.example.com", adaptive_policy);
 	require_policy(S3ProviderType::S3, "a.b.r2.cloudflarestorage.com", adaptive_policy);
+}
+
+TEST_CASE("S3 provider selects bulk delete limits", "[httpfs][s3][provider][delete]") {
+	auto require_limit = [](S3ProviderType provider_type, const string &endpoint, idx_t expected) {
+		S3AuthParams auth_params;
+		auth_params.provider_type = provider_type;
+		auth_params.endpoint = endpoint;
+		INFO(endpoint);
+		REQUIRE(S3Provider::GetBulkDeleteMaxBatchSize(auth_params) == expected);
+	};
+
+	require_limit(S3ProviderType::R2, "localhost:9000", 700);
+	require_limit(S3ProviderType::S3, "account.r2.cloudflarestorage.com", 700);
+	require_limit(S3ProviderType::S3, "account.eu.r2.cloudflarestorage.com", 700);
+	require_limit(S3ProviderType::S3, "ACCOUNT.FEDRAMP.R2.CLOUDFLARESTORAGE.COM:443/path", 700);
+
+	require_limit(S3ProviderType::S3, "s3.amazonaws.com", 1000);
+	require_limit(S3ProviderType::GCS, "account.r2.cloudflarestorage.com", 1000);
+	require_limit(S3ProviderType::S3, "r2.cloudflarestorage.com", 1000);
+	require_limit(S3ProviderType::S3, "account.r2.cloudflarestorage.com.example.com", 1000);
+	require_limit(S3ProviderType::S3, "evilr2.cloudflarestorage.com", 1000);
+	require_limit(S3ProviderType::S3, "a.b.r2.cloudflarestorage.com", 1000);
 }
 
 TEST_CASE("S3 endpoint provenance controls AWS endpoint derivation", "[httpfs][s3][provider][endpoint]") {
@@ -1893,6 +1974,20 @@ TEST_CASE("S3 bulk delete preserves endpoint provenance", "[httpfs][s3][delete][
 	}
 	SECTION("curl") {
 		RunBulkDeleteEndpointModeIdentityScenario("curl");
+	}
+}
+
+TEST_CASE("S3 bulk delete follows provider batch limits", "[httpfs][s3][delete][provider]") {
+	for (const string client_implementation : {"httplib", "curl"}) {
+		DYNAMIC_SECTION(client_implementation << " keeps the S3 batch limit") {
+			RunBulkDeleteBatchLimitScenario(client_implementation, BulkDeleteProviderProfile::S3);
+		}
+		DYNAMIC_SECTION(client_implementation << " applies the R2 scheme batch limit") {
+			RunBulkDeleteBatchLimitScenario(client_implementation, BulkDeleteProviderProfile::R2_SCHEME);
+		}
+		DYNAMIC_SECTION(client_implementation << " recognizes the R2 endpoint batch limit") {
+			RunBulkDeleteBatchLimitScenario(client_implementation, BulkDeleteProviderProfile::R2_ENDPOINT);
+		}
 	}
 }
 

--- a/test/unittest/s3/s3_retry_test.cpp
+++ b/test/unittest/s3/s3_retry_test.cpp
@@ -638,6 +638,27 @@ static void RunMalformedListRecoveryTest(const string &client_implementation, bo
 	RequireIdenticalFreshListAttempts(observations, 3);
 }
 
+static void RunNamespaceMismatchListRecoveryTest(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.failures.malformed_success_lists = 1;
+	config.failures.malformed_list_behavior = MockS3MalformedListBehavior::FOREIGN_NAMESPACE_KEY;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureListRetryTest(db, con, server, client_implementation, 1);
+
+	auto result = con.Query("SELECT file FROM glob('s3://refresh-bucket/*.bin') ORDER BY file");
+	REQUIRE(result);
+	auto observations = server.Observations();
+	INFO((result->HasError() ? result->GetError() : string()));
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE_FALSE(result->HasError());
+	REQUIRE(result->RowCount() == 1);
+	REQUIRE(result->GetValue(0, 0).ToString() == "s3://refresh-bucket/object.bin");
+	RequireIdenticalFreshListAttempts(observations, 2);
+}
+
 static void RunMalformedPaginatedListRecoveryTest() {
 	MockS3ServerConfig config;
 	config.failures.malformed_success_lists = 2;
@@ -874,6 +895,12 @@ TEST_CASE("S3 glob retries malformed successful ListObjectsV2 responses", "[http
 	}
 	SECTION("replays the exact paginated request") {
 		RunMalformedPaginatedListRecoveryTest();
+	}
+	SECTION("httplib rejects required fields from a foreign namespace") {
+		RunNamespaceMismatchListRecoveryTest("httplib");
+	}
+	SECTION("curl rejects required fields from a foreign namespace") {
+		RunNamespaceMismatchListRecoveryTest("curl");
 	}
 }
 

--- a/test/unittest/s3/s3_test_helper.cpp
+++ b/test/unittest/s3/s3_test_helper.cpp
@@ -222,6 +222,12 @@ CREATE SECRET refresh_s3 (
 
 void S3TestHelper::ConfigureEndpointRefresh(DuckDB &db, Connection &con, MockS3Server &stale_server,
                                             MockS3Server &fresh_server, const string &client_implementation) {
+	ConfigureEndpointRefresh(db, con, stale_server.Endpoint(), fresh_server.Endpoint(), client_implementation, false);
+}
+
+string S3TestHelper::ConfigureEndpointRefresh(DuckDB &db, Connection &con, const string &initial_endpoint,
+                                              const string &refreshed_endpoint, const string &client_implementation,
+                                              bool refresh_credentials, const string &http_proxy) {
 	auto test_id = NextTestId();
 
 	LoadExtension(db);
@@ -233,6 +239,12 @@ void S3TestHelper::ConfigureEndpointRefresh(DuckDB &db, Connection &con, MockS3S
 	RequireQueryOk(con, "SET s3_region='us-east-1'");
 	RequireQueryOk(con, "SET s3_use_ssl=false");
 	RequireQueryOk(con, "SET s3_url_style='path'");
+	if (!http_proxy.empty()) {
+		RequireQueryOk(con, StringUtil::Format("SET http_proxy='%s'", http_proxy));
+	}
+
+	auto refreshed_key_id = refresh_credentials ? FRESH_KEY_ID : STALE_KEY_ID;
+	auto refreshed_secret = refresh_credentials ? FRESH_SECRET : STALE_SECRET;
 
 	RequireQueryOk(con, StringUtil::Format(R"(
 CREATE SECRET refresh_s3 (
@@ -251,9 +263,9 @@ CREATE SECRET refresh_s3 (
 	}
 ))",
 	                                       S3TestHelper::TEST_PROVIDER, S3TestHelper::STALE_KEY_ID,
-	                                       S3TestHelper::STALE_SECRET, stale_server.Endpoint(), test_id,
-	                                       S3TestHelper::STALE_KEY_ID, S3TestHelper::STALE_SECRET,
-	                                       fresh_server.Endpoint(), test_id));
+	                                       S3TestHelper::STALE_SECRET, initial_endpoint, test_id, refreshed_key_id,
+	                                       refreshed_secret, refreshed_endpoint, test_id));
+	return test_id;
 }
 
 void S3TestHelper::AssertSingleRefresh(const string &test_id) {
@@ -311,6 +323,15 @@ void S3TestHelper::RequireCompletionIdentity(const vector<MockS3RequestObservati
 		REQUIRE(completion.body_digest == completions.front().body_digest);
 		REQUIRE(completion.upload_id == completions.front().upload_id);
 	}
+}
+
+vector<string> S3TestHelper::CreateBulkDeletePaths(const string &scheme, idx_t count) {
+	vector<string> result;
+	result.reserve(count);
+	for (idx_t i = 0; i < count; i++) {
+		result.push_back(StringUtil::Format("%s://%s/object-%llu.bin", scheme, BUCKET, i));
+	}
+	return result;
 }
 
 void S3TestHelper::WriteMultipartPayload(Connection &con) {

--- a/test/unittest/s3/s3_test_helper.hpp
+++ b/test/unittest/s3/s3_test_helper.hpp
@@ -30,6 +30,9 @@ public:
 	                               bool refresh_enabled = true);
 	static void ConfigureEndpointRefresh(DuckDB &db, Connection &con, MockS3Server &stale_server,
 	                                     MockS3Server &fresh_server, const string &client_implementation);
+	static string ConfigureEndpointRefresh(DuckDB &db, Connection &con, const string &initial_endpoint,
+	                                       const string &refreshed_endpoint, const string &client_implementation,
+	                                       bool refresh_credentials, const string &http_proxy = "");
 	static void AssertSingleRefresh(const string &test_id);
 	static void AssertNoRefresh(const string &test_id);
 	static bool HasRequestWithKey(const vector<MockS3RequestObservation> &observations, const string &key_id);
@@ -39,6 +42,7 @@ public:
 	CompletionObservations(const vector<MockS3RequestObservation> &observations);
 	static void RequireCompletionIdentity(const vector<MockS3RequestObservation> &observations,
 	                                      idx_t expected_attempts);
+	static vector<string> CreateBulkDeletePaths(const string &scheme, idx_t count);
 	static void WriteMultipartPayload(Connection &con);
 	static void WriteSinglePutPayload(Connection &con);
 

--- a/test/unittest/s3/s3_upload_test.cpp
+++ b/test/unittest/s3/s3_upload_test.cpp
@@ -425,6 +425,113 @@ CREATE SECRET refresh_upload_policy (
 		}
 	}
 
+	static void RunCompatibleObjectPutResponse(const string &client_implementation, int status, string payload) {
+		MockS3ServerConfig config;
+		config.object.bucket = S3TestHelper::BUCKET;
+		config.object.key = S3TestHelper::OBJECT_KEY;
+		config.auth.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+		config.upload.object_put.status = status;
+		config.upload.object_put.etag = MockS3ETagBehavior::OMIT;
+		MockS3Server server(std::move(config));
+
+		DuckDB db(nullptr);
+		Connection con(db);
+		Configure(db, con, server, client_implementation);
+
+		S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+		auto handle = OpenWriter(con);
+		if (!payload.empty()) {
+			handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()), payload.size());
+		}
+		handle->Close();
+		handle.reset();
+		S3TestHelper::RequireQueryOk(con, "COMMIT");
+
+		auto observations = server.Observations();
+		INFO(MockS3DescribeObservations(observations));
+		REQUIRE(server.UploadedObject() == payload);
+		REQUIRE(Count(observations, "PUT") == 1);
+		REQUIRE(Count(observations, "POST") == 0);
+		for (const auto &observation : observations) {
+			if (observation.method == "PUT") {
+				REQUIRE(observation.status == status);
+				REQUIRE_FALSE(observation.part_number.IsValid());
+			}
+		}
+	}
+
+	static void RunUnsupportedObjectPutResponse(const string &client_implementation) {
+		MockS3ServerConfig config;
+		config.object.bucket = S3TestHelper::BUCKET;
+		config.object.key = S3TestHelper::OBJECT_KEY;
+		config.auth.refresh_target = MockS3RefreshTarget::DELETE_OBJECT;
+		config.upload.object_put.status = 204;
+		config.upload.object_put.etag = MockS3ETagBehavior::OMIT;
+		MockS3Server server(std::move(config));
+
+		DuckDB db(nullptr);
+		Connection con(db);
+		Configure(db, con, server, client_implementation);
+
+		S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+		auto handle = OpenWriter(con);
+		string payload = "unsupported single PUT response";
+		handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()), payload.size());
+		auto error = RequireError([&]() { handle->Close(); });
+		handle.reset();
+		S3TestHelper::RequireQueryOk(con, "ROLLBACK");
+
+		auto observations = server.Observations();
+		INFO(error);
+		INFO(MockS3DescribeObservations(observations));
+		REQUIRE(StringUtil::Contains(error, "204"));
+		REQUIRE(Count(observations, "PUT") == 1);
+		REQUIRE(Count(observations, "POST") == 0);
+	}
+
+	static void RunUnsupportedPartPutResponse(const string &client_implementation, int status,
+	                                          MockS3ETagBehavior etag) {
+		MockS3ServerConfig config;
+		config.object.bucket = S3TestHelper::BUCKET;
+		config.object.key = S3TestHelper::OBJECT_KEY;
+		config.auth.refresh_target = MockS3RefreshTarget::HEAD;
+		config.upload.multipart_part_put.status = status;
+		config.upload.multipart_part_put.etag = etag;
+		MockS3Server server(std::move(config));
+
+		DuckDB db(nullptr);
+		Connection con(db);
+		Configure(db, con, server, client_implementation);
+
+		S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+		auto handle = OpenWriter(con);
+		auto payload = CreateMultipartPayload();
+		auto first_error = RequireError(
+		    [&]() { handle->Write(QueryContext(*con.context), data_ptr_cast(payload.data()), payload.size()); });
+		auto second_error = RequireError([&]() { handle->Close(); });
+		REQUIRE(second_error == first_error);
+		handle.reset();
+		S3TestHelper::RequireQueryOk(con, "ROLLBACK");
+
+		auto observations = server.Observations();
+		INFO(first_error);
+		INFO(MockS3DescribeObservations(observations));
+		if (status == 200) {
+			REQUIRE(StringUtil::Contains(first_error, "Unexpected response when uploading to S3"));
+		} else {
+			REQUIRE(StringUtil::Contains(first_error, to_string(status)));
+		}
+		REQUIRE(Count(observations, "POST", "uploads") == 1);
+		REQUIRE(Count(observations, "PUT", "partNumber") == 1);
+		REQUIRE(Count(observations, "POST", "uploadId") == 0);
+		REQUIRE(Count(observations, "DELETE", "uploadId") == 1);
+		for (const auto &observation : observations) {
+			if (observation.method == "PUT" && observation.part_number.IsValid()) {
+				REQUIRE(observation.status == status);
+			}
+		}
+	}
+
 	static void RunMultipart(const string &client_implementation) {
 		const string upload_id = "upload-baseline-id";
 		MockS3ServerConfig config;
@@ -1298,6 +1405,27 @@ CREATE SECRET refresh_upload_policy (
 		}
 		SECTION("single PUT") {
 			RunSinglePut(client_implementation);
+		}
+		SECTION("empty PUT accepts 201 without an ETag") {
+			RunCompatibleObjectPutResponse(client_implementation, 201, "");
+		}
+		SECTION("single PUT accepts 201 without an ETag") {
+			RunCompatibleObjectPutResponse(client_implementation, 201, "compatible single PUT response");
+		}
+		SECTION("single PUT accepts 200 without an ETag") {
+			RunCompatibleObjectPutResponse(client_implementation, 200, "single PUT without an ETag");
+		}
+		SECTION("single PUT rejects unsupported 204 responses") {
+			RunUnsupportedObjectPutResponse(client_implementation);
+		}
+		SECTION("multipart parts reject 201 responses") {
+			RunUnsupportedPartPutResponse(client_implementation, 201, MockS3ETagBehavior::VALUE);
+		}
+		SECTION("multipart parts reject missing ETags") {
+			RunUnsupportedPartPutResponse(client_implementation, 200, MockS3ETagBehavior::OMIT);
+		}
+		SECTION("multipart parts reject empty ETags") {
+			RunUnsupportedPartPutResponse(client_implementation, 200, MockS3ETagBehavior::EMPTY);
 		}
 		SECTION("multipart upload") {
 			RunMultipart(client_implementation);

--- a/test/unittest/s3/s3_xml_response_test.cpp
+++ b/test/unittest/s3/s3_xml_response_test.cpp
@@ -30,6 +30,22 @@ TEST_CASE("S3 XML responses follow text and namespace semantics", "[httpfs][s3][
 		REQUIRE(response.type == S3XMLResponseType::MULTIPART_INITIALIZATION);
 		CHECK(response.upload_id == "opaque-id");
 	}
+	SECTION("unknown default namespaces are accepted") {
+		const string input = "<InitiateMultipartUploadResult xmlns=\"urn:example:storage\">"
+		                     "<UploadId>native-id</UploadId></InitiateMultipartUploadResult>";
+		S3XMLResponse response;
+		REQUIRE(S3XMLResponseParser::TryParse(input, response));
+		REQUIRE(response.type == S3XMLResponseType::MULTIPART_INITIALIZATION);
+		CHECK(response.upload_id == "native-id");
+	}
+	SECTION("unknown prefixed namespaces are accepted") {
+		const string input = "<native:CompleteMultipartUploadResult xmlns:native=\"urn:example:storage\">"
+		                     "<native:ETag>native-etag</native:ETag></native:CompleteMultipartUploadResult>";
+		S3XMLResponse response;
+		REQUIRE(S3XMLResponseParser::TryParse(input, response));
+		REQUIRE(response.type == S3XMLResponseType::MULTIPART_COMPLETION);
+		CHECK(response.etag == "native-etag");
+	}
 	SECTION("default namespaces are inherited") {
 		const string input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
 		                     "<CompleteMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">"
@@ -78,7 +94,11 @@ TEST_CASE("S3 XML responses reject malformed XML", "[httpfs][s3][xml]") {
 	      "<CompleteMultipartUploadResult><ETag>&#x110000;</ETag></CompleteMultipartUploadResult>",
 	      "<CompleteMultipartUploadResult duplicate=\"a\" duplicate=\"b\"><ETag>etag</ETag>"
 	      "</CompleteMultipartUploadResult>",
+	      "<CompleteMultipartUploadResult xmlns:a=\"urn:attribute\" xmlns:b=\"urn:attribute\" a:value=\"one\" "
+	      "b:value=\"two\"><ETag>etag</ETag></CompleteMultipartUploadResult>",
 	      "<s3:CompleteMultipartUploadResult><s3:ETag>etag</s3:ETag></s3:CompleteMultipartUploadResult>",
+	      "<s3:CompleteMultipartUploadResult xmlns:s3=\"\"><s3:ETag>etag</s3:ETag>"
+	      "</s3:CompleteMultipartUploadResult>",
 	      "<CompleteMultipartUploadResult><ETag>etag</CompleteMultipartUploadResult></ETag>",
 	      "<CompleteMultipartUploadResult/><OtherRoot/>",
 	      "<!DOCTYPE CompleteMultipartUploadResult><CompleteMultipartUploadResult/>",
@@ -119,9 +139,7 @@ TEST_CASE("S3 XML responses reject malformed XML", "[httpfs][s3][xml]") {
 
 TEST_CASE("S3 XML success responses require the expected contract", "[httpfs][s3][xml]") {
 	for (const auto &input :
-	     {"<s3:InitiateMultipartUploadResult xmlns:s3=\"urn:not-s3\"><s3:UploadId>id</s3:UploadId>"
-	      "</s3:InitiateMultipartUploadResult>",
-	      "<InitiateMultipartUploadResult><Wrapper><UploadId>nested</UploadId></Wrapper>"
+	     {"<InitiateMultipartUploadResult><Wrapper><UploadId>nested</UploadId></Wrapper>"
 	      "</InitiateMultipartUploadResult>",
 	      "<InitiateMultipartUploadResult><UploadId>first</UploadId><UploadId>second</UploadId>"
 	      "</InitiateMultipartUploadResult>",
@@ -131,6 +149,21 @@ TEST_CASE("S3 XML success responses require the expected contract", "[httpfs][s3
 		S3XMLResponse response;
 		REQUIRE(S3XMLResponseParser::TryParse(input, response));
 		CHECK(response.type == S3XMLResponseType::UNKNOWN);
+	}
+
+	SECTION("required fields must use the root namespace") {
+		for (const auto &input :
+		     {"<native:InitiateMultipartUploadResult xmlns:native=\"urn:native\" xmlns:foreign=\"urn:foreign\">"
+		      "<foreign:UploadId>foreign-id</foreign:UploadId></native:InitiateMultipartUploadResult>",
+		      "<native:CompleteMultipartUploadResult xmlns:native=\"urn:native\" xmlns:foreign=\"urn:foreign\">"
+		      "<foreign:ETag>foreign-etag</foreign:ETag></native:CompleteMultipartUploadResult>",
+		      "<native:InitiateMultipartUploadResult xmlns:native=\"urn:native\">"
+		      "<native:UploadId xmlns:native=\"urn:foreign\">rebound</native:UploadId>"
+		      "</native:InitiateMultipartUploadResult>"}) {
+			S3XMLResponse response;
+			REQUIRE(S3XMLResponseParser::TryParse(input, response));
+			CHECK(response.type == S3XMLResponseType::UNKNOWN);
+		}
 	}
 }
 
@@ -150,6 +183,29 @@ TEST_CASE("S3 XML errors are extracted without guessing malformed bodies", "[htt
 		REQUIRE(S3XMLResponseParser::TryParseError("<Error><Code>RequestTimeout</Code></Error>", error));
 		CHECK(error.code == "RequestTimeout");
 		CHECK(error.message.empty());
+	}
+	SECTION("unknown namespaces retain optional and duplicate field handling") {
+		S3XMLError missing_code;
+		REQUIRE(S3XMLResponseParser::TryParseError(
+		    "<Error xmlns=\"urn:example:storage\"><Message>missing code</Message></Error>", missing_code));
+		CHECK(missing_code.code.empty());
+		CHECK(missing_code.message == "missing code");
+
+		S3XMLError duplicate_code;
+		REQUIRE(S3XMLResponseParser::TryParseError(
+		    "<native:Error xmlns:native=\"urn:example:storage\"><native:Code>first</native:Code>"
+		    "<native:Code>second</native:Code><native:Message>kept</native:Message></native:Error>",
+		    duplicate_code));
+		CHECK(duplicate_code.code.empty());
+		CHECK(duplicate_code.message == "kept");
+
+		S3XMLError foreign_code;
+		REQUIRE(S3XMLResponseParser::TryParseError(
+		    "<native:Error xmlns:native=\"urn:example:storage\" xmlns:foreign=\"urn:foreign\">"
+		    "<foreign:Code>ignored</foreign:Code><native:Message>native</native:Message></native:Error>",
+		    foreign_code));
+		CHECK(foreign_code.code.empty());
+		CHECK(foreign_code.message == "native");
 	}
 	SECTION("malformed and unrelated XML are not errors") {
 		S3XMLError error;
@@ -196,11 +252,10 @@ TEST_CASE("S3 ListObjectsV2 XML is parsed into one typed result", "[httpfs][s3][
 	}
 
 	SECTION("only children in the root namespace are interpreted") {
-		const string input =
-		    "<s3:ListBucketResult xmlns:s3=\"http://s3.amazonaws.com/doc/2006-03-01/\" xmlns:x=\"urn:x\">"
-		    "<x:Contents><x:Key>ignored</x:Key></x:Contents>"
-		    "<s3:Contents><x:Key>also-ignored</x:Key><s3:Key>kept</s3:Key></s3:Contents>"
-		    "<s3:Unknown><s3:Key>not-a-record</s3:Key></s3:Unknown></s3:ListBucketResult>";
+		const string input = "<s3:ListBucketResult xmlns:s3=\"urn:example:storage\" xmlns:x=\"urn:x\">"
+		                     "<x:Contents><x:Key>ignored</x:Key></x:Contents>"
+		                     "<s3:Contents><x:Key>also-ignored</x:Key><s3:Key>kept</s3:Key></s3:Contents>"
+		                     "<s3:Unknown><s3:Key>not-a-record</s3:Key></s3:Unknown></s3:ListBucketResult>";
 		S3ListObjectsV2Result result;
 		REQUIRE(S3XMLResponseParser::TryParseListObjectsV2(input, result));
 		REQUIRE(result.objects.size() == 1);
@@ -214,6 +269,9 @@ TEST_CASE("S3 ListObjectsV2 XML is parsed into one typed result", "[httpfs][s3][
 		      "<ListBucketResult><Contents><Key>one</Key><Key>two</Key></Contents></ListBucketResult>",
 		      "<ListBucketResult><Contents><Key><Nested/></Key></Contents></ListBucketResult>",
 		      "<ListBucketResult><Contents><Key>one</Key><Size>1</Size><Size>2</Size></Contents></ListBucketResult>",
+		      "<native:ListBucketResult xmlns:native=\"urn:native\" xmlns:foreign=\"urn:foreign\">"
+		      "<native:Contents><foreign:Key>foreign</foreign:Key></native:Contents>"
+		      "</native:ListBucketResult>",
 		      "<ListBucketResult><NextContinuationToken>one</NextContinuationToken>"
 		      "<NextContinuationToken>two</NextContinuationToken></ListBucketResult>",
 		      "<ListBucketResult><Contents><Key>truncated</Key></Contents>"}) {
@@ -241,6 +299,8 @@ TEST_CASE("S3 DeleteObjects XML preserves all object errors", "[httpfs][s3][xml]
 		REQUIRE(S3XMLResponseParser::TryParseDeleteObjects(
 		    "<DeleteResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"/>", result));
 		CHECK(result.errors.empty());
+		REQUIRE(S3XMLResponseParser::TryParseDeleteObjects("<DeleteResult xmlns=\"urn:example:storage\"/>", result));
+		CHECK(result.errors.empty());
 
 		const string input = "<g:DeleteResult xmlns:g=\"http://doc.s3.amazonaws.com/2006-03-01\">"
 		                     "<g:Error><g:Key>first&amp;key</g:Key><g:Code>AccessDenied</g:Code>"
@@ -255,6 +315,14 @@ TEST_CASE("S3 DeleteObjects XML preserves all object errors", "[httpfs][s3][xml]
 		CHECK(result.errors[1].key == "second");
 		CHECK(result.errors[1].code == "InternalError");
 		CHECK(result.errors[1].message.empty());
+
+		const string native_input =
+		    "<native:DeleteResult xmlns:native=\"urn:example:storage\">"
+		    "<native:Error><native:Key>native-key</native:Key><native:Code>AccessDenied</native:Code>"
+		    "</native:Error></native:DeleteResult>";
+		REQUIRE(S3XMLResponseParser::TryParseDeleteObjects(native_input, result));
+		REQUIRE(result.errors.size() == 1);
+		CHECK(result.errors[0].key == "native-key");
 	}
 
 	SECTION("required fields and malformed documents are rejected") {
@@ -264,6 +332,9 @@ TEST_CASE("S3 DeleteObjects XML preserves all object errors", "[httpfs][s3][xml]
 		                          "<DeleteResult><Error><Key>key</Key><Code/></Error></DeleteResult>",
 		                          "<DeleteResult><Error><Key>key</Key><Key>other</Key><Code>Denied</Code></Error>"
 		                          "</DeleteResult>",
+		                          "<native:DeleteResult xmlns:native=\"urn:native\" xmlns:foreign=\"urn:foreign\">"
+		                          "<native:Error><foreign:Key>key</foreign:Key><native:Code>Denied</native:Code>"
+		                          "</native:Error></native:DeleteResult>",
 		                          "<DeleteResult><Error><Key>key</Key><Code>Denied</Code>"}) {
 			S3DeleteObjectsResult result;
 			CHECK_FALSE(S3XMLResponseParser::TryParseDeleteObjects(input, result));


### PR DESCRIPTION
This adds a few compatibility fixes for S3-compatible storage providers. It limits R2 bulk deletes to 700 objects, accepts 201 and missing ETags for single-object PUTs, and accepts well-formed provider-specific XML namespaces.