### PR TITLE
S3 endpoint normalization

### DIFF
--- a/src/http/httpfs_curl_client.cpp
+++ b/src/http/httpfs_curl_client.cpp
@@ -97,6 +97,7 @@ CURLHandle::CURLHandle(const string &token, const string &cert_path) {
 		curl_easy_setopt(curl, CURLOPT_CAINFO, cert_path.c_str());
 	}
 	curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_AUTO_CLIENT_CERT | CURLSSLOPT_NATIVE_CA);
+	curl_easy_setopt(curl, CURLOPT_PATH_AS_IS, 1L);
 }
 
 CURLHandle::~CURLHandle() {
@@ -361,8 +362,10 @@ private:
 
 public:
 	HTTPFSCurlClient(HTTPFSParams &http_params, const string &proto_host_port) : HTTPClient(proto_host_port) {
-		string normalized_path = NormalizePathToBeAdded(proto_host_port);
-		curl_url_set(curl_base_url.Get(), CURLUPART_URL, normalized_path.c_str(), 0);
+		auto result = curl_url_set(curl_base_url.Get(), CURLUPART_URL, proto_host_port.c_str(), 0);
+		if (result != CURLUE_OK) {
+			throw IOException("Failed to initialize curl URL: %s", curl_url_strerror(result));
+		}
 		stored_bearer_token = "";
 		stored_cert_file_path = "";
 		Initialize(http_params);
@@ -372,19 +375,6 @@ public:
 	}
 
 public:
-	static string NormalizePathToBeAdded(string added_path) {
-		while (added_path.size() > 2) {
-			if (StringUtil::StartsWith(added_path, "//")) {
-				added_path = added_path.substr(1);
-			} else if (StringUtil::StartsWith(added_path, "./")) {
-				added_path = added_path.substr(1);
-			} else {
-				break;
-			}
-		}
-
-		return added_path;
-	}
 	void Initialize(HTTPParams &http_p) override {
 		auto &http_params = http_p.Cast<HTTPFSParams>();
 		ClientConfigurator::Configure(*this, http_params);
@@ -410,9 +400,7 @@ public:
 			curl_easy_setopt(*curl, CURLOPT_NOBODY, 0L);
 			curl_easy_setopt(*curl, CURLOPT_HTTPGET, 1L);
 			CURLURLHandle url(curl_base_url);
-
-			string normalized_path = NormalizePathToBeAdded(info.path);
-			curl_url_set(url.Get(), CURLUPART_URL, normalized_path.c_str(), 0);
+			SetRequestURL(url, info.url, info.path);
 
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
 			curl_easy_setopt(*curl, CURLOPT_CURLU, url.Get());
@@ -440,9 +428,7 @@ public:
 		CURLcode res;
 		{
 			CURLURLHandle url(curl_base_url);
-
-			string normalized_path = NormalizePathToBeAdded(info.path);
-			curl_url_set(url.Get(), CURLUPART_URL, normalized_path.c_str(), 0);
+			SetRequestURL(url, info.url, info.path);
 
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
 			curl_easy_setopt(*curl, CURLOPT_CURLU, url.Get());
@@ -485,9 +471,7 @@ public:
 			curl_easy_setopt(*curl, CURLOPT_HTTPGET, 0L);
 
 			CURLURLHandle url(curl_base_url);
-
-			string normalized_path = NormalizePathToBeAdded(info.path);
-			curl_url_set(url.Get(), CURLUPART_URL, normalized_path.c_str(), 0);
+			SetRequestURL(url, info.url, info.path);
 
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
 			curl_easy_setopt(*curl, CURLOPT_CURLU, url.Get());
@@ -518,9 +502,7 @@ public:
 		CURLcode res;
 		{
 			CURLURLHandle url(curl_base_url);
-
-			string normalized_path = NormalizePathToBeAdded(info.path);
-			curl_url_set(url.Get(), CURLUPART_URL, normalized_path.c_str(), 0);
+			SetRequestURL(url, info.url, info.path);
 
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
 			curl_easy_setopt(*curl, CURLOPT_CURLU, url.Get());
@@ -549,9 +531,7 @@ public:
 		CURLcode res;
 		{
 			CURLURLHandle url(curl_base_url);
-
-			string normalized_path = NormalizePathToBeAdded(info.path);
-			curl_url_set(url.Get(), CURLUPART_URL, normalized_path.c_str(), 0);
+			SetRequestURL(url, info.url, info.path);
 
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
 			curl_easy_setopt(*curl, CURLOPT_CURLU, url.Get());
@@ -587,9 +567,7 @@ public:
 		CURLcode res;
 		{
 			CURLURLHandle url(curl_base_url);
-
-			string normalized_path = NormalizePathToBeAdded(info.path);
-			curl_url_set(url.Get(), CURLUPART_URL, normalized_path.c_str(), 0);
+			SetRequestURL(url, info.url, info.path);
 
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
 			curl_easy_setopt(*curl, CURLOPT_CURLU, url.Get());
@@ -631,6 +609,15 @@ public:
 	}
 
 private:
+	static void SetRequestURL(CURLURLHandle &url, const string &request_url, const string &request_path) {
+		// A leading '//' is a network-path reference to the URL API, so set the complete URL in that case.
+		const auto &url_part = StringUtil::StartsWith(request_path, "//") ? request_url : request_path;
+		auto result = curl_url_set(url.Get(), CURLUPART_URL, url_part.c_str(), CURLU_PATH_AS_IS);
+		if (result != CURLUE_OK) {
+			throw IOException("Failed to construct curl request URL: %s", curl_url_strerror(result));
+		}
+	}
+
 	static CURLRequestHeaders TransformHeadersCurl(const HTTPHeaders &header_map, const HTTPParams &params) {
 		auto &httpfs_params = params.Cast<HTTPFSParams>();
 

--- a/src/include/s3/s3_auth.hpp
+++ b/src/include/s3/s3_auth.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "s3/s3_endpoint.hpp"
 #include "s3/s3_provider.hpp"
 
 #include "duckdb/common/file_opener.hpp"
@@ -59,9 +60,15 @@ private:
 
 struct S3AuthParams {
 public:
+	//! Construction and secret lookup
 	static S3AuthParams ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info);
 	static S3AuthParams ReadFrom(S3KeyValueReader &secret_reader, const string &file_path);
+
+	//! Endpoint resolution
 	void SetEndpoint(string endpoint_p);
+	const NormalizedS3Endpoint &GetEndpoint() const;
+
+	//! Refresh and session identity
 	void SetRegion(string region_p);
 	bool operator==(const S3AuthParams &other) const;
 
@@ -78,7 +85,6 @@ public:
 	string oauth2_bearer_token;
 
 	//! Endpoint and URL behavior
-	string endpoint;
 	S3EndpointMode endpoint_mode = S3EndpointMode::AUTOMATIC;
 	string url_style;
 	bool use_ssl = true;
@@ -88,6 +94,13 @@ public:
 	string kms_key_id;
 	bool requester_pays = false;
 	string user_project;
+
+private:
+	friend struct S3Provider;
+
+	//! Selected endpoint text before finalization and its normalized value afterwards
+	string endpoint_source;
+	NormalizedS3Endpoint endpoint;
 };
 
 struct AWSEnvironmentCredentialsProvider {

--- a/src/include/s3/s3_endpoint.hpp
+++ b/src/include/s3/s3_endpoint.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/optional_idx.hpp"
+
+namespace duckdb {
+
+struct S3Provider;
+
+class NormalizedS3Endpoint {
+	friend struct S3Provider;
+
+public:
+	NormalizedS3Endpoint() = default;
+
+public:
+	//! Construction and comparison
+	static NormalizedS3Endpoint Parse(const string &endpoint, bool fallback_use_ssl);
+	bool operator==(const NormalizedS3Endpoint &other) const;
+
+	//! Endpoint properties
+	bool IsEmpty() const;
+	bool IsIPv6() const;
+	bool UsesSSL() const;
+	const string &GetHost() const;
+	const string &GetBasePath() const;
+	string GetAuthority() const;
+	string GetProtocol() const;
+	string GetCanonicalValue() const;
+
+private:
+	enum class Scheme : uint8_t { HTTP, HTTPS };
+
+private:
+	//! Provider finalization helpers
+	bool IsDefaultPort() const;
+	void SetHost(string host_p);
+
+private:
+	//! Endpoint authority and scheme
+	string host;
+	optional_idx port;
+	Scheme scheme = Scheme::HTTPS;
+	bool is_ipv6 = false;
+
+	//! Request path prefix
+	string base_path;
+};
+
+} // namespace duckdb

--- a/src/include/s3/s3_request.hpp
+++ b/src/include/s3/s3_request.hpp
@@ -90,7 +90,7 @@ struct S3RequestData {
 
 struct S3RequestUtil {
 	static HTTPHeaders CreateHeaders(EncryptionUtil &encryption_util, const ParsedS3Url &parsed_url,
-	                                 const S3RequestQuery &query, RequestType request_type,
+	                                 S3RequestTarget target, const S3RequestQuery &query, RequestType request_type,
 	                                 const S3AuthParams &auth_params, string date_now = "", string datetime_now = "",
 	                                 string payload_hash = "", string content_type = "", string content_md5 = "",
 	                                 const unordered_map<string, string> &extra_headers = {},

--- a/src/include/s3/s3_url.hpp
+++ b/src/include/s3/s3_url.hpp
@@ -4,20 +4,41 @@
 
 namespace duckdb {
 
-struct ParsedS3Url {
-public:
-	string GetHTTPUrl(const string &http_query_string = "") const;
-	string GetBucketPath() const;
+class ParsedS3Url {
+	friend struct S3Url;
+
+private:
+	ParsedS3Url() = default;
 
 public:
-	string http_proto;
+	//! Logical S3 URL
+	const string &GetPrefix() const;
+	const string &GetBucket() const;
+	const string &GetKey() const;
+	const string &GetQueryString() const;
+
+	//! HTTP request target
+	string GetHTTPUrl(const string &http_query_string = "") const;
+	string GetBucketHTTPUrl(const string &http_query_string = "") const;
+	const string &GetHost() const;
+	const string &GetEncodedPath() const;
+	const string &GetEncodedBucketPath() const;
+
+private:
+	string BuildHTTPUrl(const string &request_path, const string &http_query_string) const;
+
+private:
+	//! Logical S3 URL
 	string prefix;
-	string host;
 	string bucket;
 	string key;
-	string path;
-	string query_param;
-	string trimmed_s3_url;
+	string query_string;
+
+	//! HTTP request target
+	string host;
+	string encoded_path;
+	string encoded_bucket_path;
+	bool use_ssl = true;
 };
 
 enum class S3URLEncodeMode : uint8_t { PATH, QUERY_COMPONENT };

--- a/src/s3/CMakeLists.txt
+++ b/src/s3/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(
   httpfs_library
   PRIVATE s3_auth.cpp
           s3_delete.cpp
+          s3_endpoint.cpp
           s3_list.cpp
           s3_provider.cpp
           s3_request.cpp

--- a/src/s3/s3_auth.cpp
+++ b/src/s3/s3_auth.cpp
@@ -1,5 +1,7 @@
 #include "s3/s3_auth.hpp"
 
+#include "duckdb/common/string_util.hpp"
+
 #include <cstdlib>
 
 namespace duckdb {
@@ -53,15 +55,15 @@ S3AuthParams S3AuthParams::ReadFrom(S3KeyValueReader &secret_reader, const strin
 }
 
 void S3AuthParams::SetEndpoint(string new_endpoint) {
-	endpoint = std::move(new_endpoint);
-	auto trimmed_endpoint = endpoint;
+	endpoint_source = std::move(new_endpoint);
+	endpoint = NormalizedS3Endpoint();
+	auto trimmed_endpoint = endpoint_source;
 	StringUtil::Trim(trimmed_endpoint);
-	if (trimmed_endpoint.empty() ||
-	    (provider_type == S3ProviderType::S3 && !scheme_is_alias && endpoint == "s3.amazonaws.com")) {
-		endpoint_mode = S3EndpointMode::AUTOMATIC;
-	} else {
-		endpoint_mode = S3EndpointMode::EXPLICIT;
-	}
+	endpoint_mode = trimmed_endpoint.empty() ? S3EndpointMode::AUTOMATIC : S3EndpointMode::EXPLICIT;
+}
+
+const NormalizedS3Endpoint &S3AuthParams::GetEndpoint() const {
+	return endpoint;
 }
 
 void S3AuthParams::SetRegion(string new_region) {
@@ -73,7 +75,7 @@ bool S3AuthParams::operator==(const S3AuthParams &other) const {
 	return provider_type == other.provider_type && scheme_is_alias == other.scheme_is_alias && region == other.region &&
 	       access_key_id == other.access_key_id && secret_access_key == other.secret_access_key &&
 	       session_token == other.session_token && endpoint == other.endpoint && endpoint_mode == other.endpoint_mode &&
-	       kms_key_id == other.kms_key_id && url_style == other.url_style && use_ssl == other.use_ssl &&
+	       kms_key_id == other.kms_key_id && url_style == other.url_style &&
 	       s3_url_compatibility_mode == other.s3_url_compatibility_mode && requester_pays == other.requester_pays &&
 	       user_project == other.user_project && oauth2_bearer_token == other.oauth2_bearer_token;
 }

--- a/src/s3/s3_delete.cpp
+++ b/src/s3/s3_delete.cpp
@@ -38,9 +38,7 @@ void S3FileSystem::RemoveFile(const string &path, optional_ptr<FileOpener> opene
 
 struct S3DeleteBatchUrlInfo {
 	string prefix;
-	string http_proto;
-	string host;
-	string path;
+	string bucket_http_url;
 	S3AuthParams auth_params;
 };
 
@@ -73,9 +71,7 @@ private:
 
 static void AddDeleteBatchUrlKeyParts(S3DeleteBatchKeyBuilder &key_builder, const S3DeleteBatchUrlInfo &url_info) {
 	key_builder.AddString(url_info.prefix);
-	key_builder.AddString(url_info.http_proto);
-	key_builder.AddString(url_info.host);
-	key_builder.AddString(url_info.path);
+	key_builder.AddString(url_info.bucket_http_url);
 }
 
 static void AddDeleteBatchAuthKeyParts(S3DeleteBatchKeyBuilder &key_builder, const S3AuthParams &auth_params) {
@@ -84,11 +80,10 @@ static void AddDeleteBatchAuthKeyParts(S3DeleteBatchKeyBuilder &key_builder, con
 	key_builder.AddString(auth_params.access_key_id);
 	key_builder.AddString(auth_params.secret_access_key);
 	key_builder.AddString(auth_params.session_token);
-	key_builder.AddString(auth_params.endpoint);
+	key_builder.AddString(auth_params.GetEndpoint().GetCanonicalValue());
 	key_builder.AddIndex(static_cast<idx_t>(auth_params.endpoint_mode));
 	key_builder.AddString(auth_params.kms_key_id);
 	key_builder.AddString(auth_params.url_style);
-	key_builder.AddBool(auth_params.use_ssl);
 	key_builder.AddBool(auth_params.s3_url_compatibility_mode);
 	key_builder.AddBool(auth_params.requester_pays);
 	key_builder.AddString(auth_params.user_project);
@@ -170,12 +165,14 @@ static bool HasRefreshableS3Secret(optional_ptr<FileOpener> opener, const string
 }
 
 static void AddDeleteBatchRefreshKeyParts(S3DeleteBatchKeyBuilder &key_builder, optional_ptr<FileOpener> opener,
-                                          const string &path) {
-	if (S3RequestExecutor::CredentialRefreshEnabled(opener) && HasRefreshableS3Secret(opener, path)) {
+                                          const string &path, const S3AuthParams &auth_params) {
+	auto refreshable = S3RequestExecutor::CredentialRefreshEnabled(opener) && HasRefreshableS3Secret(opener, path);
+	if (refreshable) {
 		key_builder.AddString(GetDeleteBatchLookupDirectory(path));
 	} else {
 		key_builder.AddString("");
 	}
+	key_builder.AddBool(refreshable && auth_params.use_ssl);
 }
 
 static string CreateDeleteBatchKey(const S3DeleteBatchUrlInfo &url_info,
@@ -186,7 +183,7 @@ static string CreateDeleteBatchKey(const S3DeleteBatchUrlInfo &url_info,
 	AddDeleteBatchAuthKeyParts(key_builder, url_info.auth_params);
 	AddDeleteBatchHTTPKeyParts(key_builder, refreshable_http_params);
 	AddDeleteBatchSelectedSecretKeyParts(key_builder, opener, path);
-	AddDeleteBatchRefreshKeyParts(key_builder, opener, path);
+	AddDeleteBatchRefreshKeyParts(key_builder, opener, path, url_info.auth_params);
 	return key_builder.Build();
 }
 
@@ -243,9 +240,7 @@ void S3FileSystem::RemoveFiles(const vector<string> &paths, optional_ptr<FileOpe
 		S3AuthParams auth_params = S3AuthParams::ReadFrom(opener, info);
 		auto parsed_url = S3Url::Resolve(path, auth_params);
 
-		auto bucket_path = parsed_url.GetBucketPath();
-		S3DeleteBatchUrlInfo url_info = {parsed_url.prefix, parsed_url.http_proto, parsed_url.host, bucket_path,
-		                                 auth_params};
+		S3DeleteBatchUrlInfo url_info = {parsed_url.GetPrefix(), parsed_url.GetBucketHTTPUrl(), auth_params};
 		auto refreshable_http_params = S3RequestExecutor::ReadRefreshableHTTPParams(opener, path);
 		auto batch_key = CreateDeleteBatchKey(url_info, refreshable_http_params, opener, path);
 		auto entry = delete_batches.find(batch_key);
@@ -256,7 +251,7 @@ void S3FileSystem::RemoveFiles(const vector<string> &paths, optional_ptr<FileOpe
 		}
 		auto &batch = entry->second;
 
-		batch.keys.push_back(parsed_url.key);
+		batch.keys.push_back(parsed_url.GetKey());
 		batch.secret_lookup_paths.push_back(path);
 	}
 

--- a/src/s3/s3_endpoint.cpp
+++ b/src/s3/s3_endpoint.cpp
@@ -1,0 +1,274 @@
+#include "s3/s3_endpoint.hpp"
+
+#include "duckdb/common/string_util.hpp"
+
+namespace duckdb {
+
+static bool IsValidIPv4Address(const string &address) {
+	idx_t component_count = 0;
+	idx_t position = 0;
+	while (position <= address.size()) {
+		auto separator = address.find('.', position);
+		auto component_end = separator == string::npos ? address.size() : separator;
+		if (component_end == position || component_end - position > 3) {
+			return false;
+		}
+		idx_t value = 0;
+		for (idx_t i = position; i < component_end; i++) {
+			if (!StringUtil::CharacterIsDigit(address[i])) {
+				return false;
+			}
+			value = value * 10 + NumericCast<idx_t>(address[i] - '0');
+		}
+		if (value > 255) {
+			return false;
+		}
+		component_count++;
+		if (separator == string::npos) {
+			break;
+		}
+		position = separator + 1;
+	}
+	return component_count == 4;
+}
+
+static bool IsValidIPv6Section(const string &section, bool allow_ipv4, idx_t &group_count) {
+	if (section.empty()) {
+		return true;
+	}
+	idx_t position = 0;
+	while (position <= section.size()) {
+		auto separator = section.find(':', position);
+		auto group_end = separator == string::npos ? section.size() : separator;
+		if (group_end == position) {
+			return false;
+		}
+		auto group = section.substr(position, group_end - position);
+		if (group.find('.') != string::npos) {
+			if (!allow_ipv4 || separator != string::npos || !IsValidIPv4Address(group)) {
+				return false;
+			}
+			group_count += 2;
+		} else {
+			if (group.size() > 4) {
+				return false;
+			}
+			for (const auto character : group) {
+				if (!StringUtil::CharacterIsHex(character)) {
+					return false;
+				}
+			}
+			group_count++;
+		}
+		if (separator == string::npos) {
+			break;
+		}
+		position = separator + 1;
+	}
+	return true;
+}
+
+static bool IsValidIPv6Address(const string &address) {
+	if (address.empty() || address.find('%') != string::npos) {
+		return false;
+	}
+	auto compression = address.find("::");
+	if (compression != string::npos && address.find("::", compression + 2) != string::npos) {
+		return false;
+	}
+	idx_t group_count = 0;
+	if (compression == string::npos) {
+		return IsValidIPv6Section(address, true, group_count) && group_count == 8;
+	}
+	auto left = address.substr(0, compression);
+	auto right = address.substr(compression + 2);
+	return IsValidIPv6Section(left, false, group_count) && IsValidIPv6Section(right, true, group_count) &&
+	       group_count < 8;
+}
+
+static void ValidateEndpointHost(const string &host) {
+	for (const auto character : host) {
+		if (!StringUtil::CharacterIsAlphaNumeric(character) && character != '-' && character != '.' &&
+		    character != '_') {
+			throw InvalidInputException("Invalid S3 endpoint host");
+		}
+	}
+}
+
+static void ValidateEndpointBasePath(string &base_path) {
+	for (idx_t i = 0; i < base_path.size(); i++) {
+		if (base_path[i] == '\\') {
+			throw InvalidInputException("S3 endpoint paths cannot contain backslashes");
+		}
+		if (base_path[i] == '%' && (i + 2 >= base_path.size() || !StringUtil::CharacterIsHex(base_path[i + 1]) ||
+		                            !StringUtil::CharacterIsHex(base_path[i + 2]))) {
+			throw InvalidInputException("S3 endpoint paths contain an invalid percent escape");
+		}
+	}
+
+	idx_t position = 0;
+	while (position <= base_path.size()) {
+		auto separator = base_path.find('/', position);
+		auto segment_end = separator == string::npos ? base_path.size() : separator;
+		auto segment = base_path.substr(position, segment_end - position);
+		if (segment == "." || segment == "..") {
+			throw InvalidInputException("S3 endpoint paths cannot contain '.' or '..' segments");
+		}
+		if (separator == string::npos) {
+			break;
+		}
+		position = separator + 1;
+	}
+	while (!base_path.empty() && base_path.back() == '/') {
+		base_path.pop_back();
+	}
+}
+
+static optional_idx ParseEndpointPort(const string &port) {
+	if (port.empty()) {
+		throw InvalidInputException("S3 endpoint port cannot be empty");
+	}
+	idx_t result = 0;
+	for (const auto character : port) {
+		if (!StringUtil::CharacterIsDigit(character)) {
+			throw InvalidInputException("Invalid S3 endpoint port '%s'", port);
+		}
+		result = result * 10 + NumericCast<idx_t>(character - '0');
+		if (result > 65535) {
+			throw InvalidInputException("Invalid S3 endpoint port '%s'", port);
+		}
+	}
+	if (result == 0) {
+		throw InvalidInputException("Invalid S3 endpoint port '%s'", port);
+	}
+	return optional_idx(result);
+}
+
+NormalizedS3Endpoint NormalizedS3Endpoint::Parse(const string &endpoint, bool fallback_use_ssl) {
+	NormalizedS3Endpoint result;
+	result.scheme = fallback_use_ssl ? Scheme::HTTPS : Scheme::HTTP;
+	auto input = endpoint;
+	StringUtil::Trim(input);
+	if (input.empty()) {
+		return result;
+	}
+	if (input.find('?') != string::npos || input.find('#') != string::npos) {
+		throw InvalidInputException("S3 endpoints cannot contain a query string or fragment");
+	}
+
+	idx_t authority_start = 0;
+	auto first_slash = input.find('/');
+	auto scheme_end = input.find("://");
+	if (scheme_end != string::npos && (first_slash == string::npos || scheme_end < first_slash)) {
+		auto scheme = StringUtil::Lower(input.substr(0, scheme_end));
+		if (scheme == "http") {
+			result.scheme = Scheme::HTTP;
+		} else if (scheme == "https") {
+			result.scheme = Scheme::HTTPS;
+		} else {
+			throw InvalidInputException("Unsupported S3 endpoint scheme '%s'", scheme);
+		}
+		authority_start = scheme_end + 3;
+	}
+
+	auto path_start = input.find('/', authority_start);
+	auto authority_end = path_start == string::npos ? input.size() : path_start;
+	auto authority = input.substr(authority_start, authority_end - authority_start);
+	if (authority.empty()) {
+		throw InvalidInputException("S3 endpoint authority cannot be empty");
+	}
+	if (authority.find('@') != string::npos) {
+		throw InvalidInputException("S3 endpoints cannot contain user information");
+	}
+
+	if (authority[0] == '[') {
+		auto bracket = authority.find(']');
+		if (bracket == string::npos || bracket == 1 || !IsValidIPv6Address(authority.substr(1, bracket - 1))) {
+			throw InvalidInputException("Invalid bracketed IPv6 S3 endpoint");
+		}
+		result.host = StringUtil::Lower(authority.substr(1, bracket - 1));
+		result.is_ipv6 = true;
+		if (bracket + 1 < authority.size()) {
+			if (authority[bracket + 1] != ':') {
+				throw InvalidInputException("Invalid bracketed IPv6 S3 endpoint authority");
+			}
+			result.port = ParseEndpointPort(authority.substr(bracket + 2));
+		}
+	} else {
+		auto colon = authority.find(':');
+		if (colon != string::npos) {
+			if (authority.find(':', colon + 1) != string::npos) {
+				throw InvalidInputException("IPv6 S3 endpoints must use brackets");
+			}
+			result.host = authority.substr(0, colon);
+			result.port = ParseEndpointPort(authority.substr(colon + 1));
+		} else {
+			result.host = authority;
+		}
+		if (result.host.empty()) {
+			throw InvalidInputException("S3 endpoint host cannot be empty");
+		}
+		ValidateEndpointHost(result.host);
+		result.host = StringUtil::Lower(result.host);
+	}
+
+	if (path_start != string::npos) {
+		result.base_path = input.substr(path_start);
+		ValidateEndpointBasePath(result.base_path);
+	}
+	return result;
+}
+
+bool NormalizedS3Endpoint::operator==(const NormalizedS3Endpoint &other) const {
+	return scheme == other.scheme && base_path == other.base_path && GetAuthority() == other.GetAuthority();
+}
+
+bool NormalizedS3Endpoint::IsEmpty() const {
+	return host.empty();
+}
+
+bool NormalizedS3Endpoint::IsIPv6() const {
+	return is_ipv6;
+}
+
+bool NormalizedS3Endpoint::UsesSSL() const {
+	return scheme == Scheme::HTTPS;
+}
+
+const string &NormalizedS3Endpoint::GetHost() const {
+	return host;
+}
+
+const string &NormalizedS3Endpoint::GetBasePath() const {
+	return base_path;
+}
+
+string NormalizedS3Endpoint::GetAuthority() const {
+	auto result = is_ipv6 ? "[" + host + "]" : host;
+	if (port.IsValid() && !IsDefaultPort()) {
+		result += ":" + std::to_string(port.GetIndex());
+	}
+	return result;
+}
+
+string NormalizedS3Endpoint::GetProtocol() const {
+	return UsesSSL() ? "https://" : "http://";
+}
+
+string NormalizedS3Endpoint::GetCanonicalValue() const {
+	return GetProtocol() + GetAuthority() + base_path;
+}
+
+bool NormalizedS3Endpoint::IsDefaultPort() const {
+	if (!port.IsValid()) {
+		return true;
+	}
+	return port.GetIndex() == (UsesSSL() ? 443 : 80);
+}
+
+void NormalizedS3Endpoint::SetHost(string host_p) {
+	host = StringUtil::Lower(std::move(host_p));
+	is_ipv6 = false;
+}
+
+} // namespace duckdb

--- a/src/s3/s3_list.cpp
+++ b/src/s3/s3_list.cpp
@@ -75,7 +75,7 @@ private:
 	mutable bool finished = false;
 	shared_ptr<HTTPRequestSession> request_session;
 	string shared_path;
-	ParsedS3Url parsed_s3_url;
+	optional<ParsedS3Url> parsed_s3_url;
 	mutable string main_continuation_token;
 	mutable string current_common_prefix;
 	mutable string common_prefix_continuation_token;
@@ -102,7 +102,7 @@ S3GlobResult::S3GlobResult(S3FileSystem &fs_p, const string &glob_pattern_p, opt
 	}
 
 	parsed_s3_url = S3Url::Resolve(glob_pattern, s3_auth_params);
-	auto parsed_glob_url = parsed_s3_url.trimmed_s3_url;
+	auto parsed_glob_url = S3Url::GetDisplayUrl(glob_pattern, s3_auth_params);
 
 	// AWS matches on prefix, not glob pattern, so we take a substring until the first wildcard char for the aws calls
 	auto first_wildcard_pos = parsed_glob_url.find_first_of("*[\\");
@@ -137,10 +137,10 @@ bool S3GlobResult::ExpandNextPath() const {
 }
 
 void S3GlobResult::ScanCurrentCommonPrefix(vector<OpenFileInfo> &s3_keys) const {
-	auto prefix_path = parsed_s3_url.prefix + parsed_s3_url.bucket + '/' + current_common_prefix;
+	auto prefix_path = parsed_s3_url->GetPrefix() + parsed_s3_url->GetBucket() + '/' + current_common_prefix;
 	current_common_prefix = S3Url::Decode(current_common_prefix);
 	auto key_splits = StringUtil::Split(current_common_prefix, "/");
-	auto pattern_splits = StringUtil::Split(parsed_s3_url.key, "/");
+	auto pattern_splits = StringUtil::Split(parsed_s3_url->GetKey(), "/");
 	if (Match(key_splits.begin(), key_splits.end(), pattern_splits.begin(), pattern_splits.end(),
 	          S3GlobMatchMode::PREFIX)) {
 		prefix_path = S3Url::Decode(prefix_path);
@@ -173,7 +173,7 @@ void S3GlobResult::ScanTopLevel(vector<OpenFileInfo> &s3_keys) const {
 }
 
 bool S3GlobResult::ShouldInvestigateRecursiveGlob() const {
-	if (glob_type != GlobType::UNKNOWN || StringUtil::Contains(parsed_s3_url.key, "**")) {
+	if (glob_type != GlobType::UNKNOWN || StringUtil::Contains(parsed_s3_url->GetKey(), "**")) {
 		return false;
 	}
 	Value value;
@@ -220,14 +220,14 @@ void S3GlobResult::SelectNextCommonPrefix() const {
 }
 
 void S3GlobResult::AppendMatchingFiles(vector<OpenFileInfo> &s3_keys) const {
-	auto pattern_splits = StringUtil::Split(parsed_s3_url.key, "/");
+	auto pattern_splits = StringUtil::Split(parsed_s3_url->GetKey(), "/");
 	for (auto &s3_key : s3_keys) {
 		auto key_splits = StringUtil::Split(s3_key.path, "/");
 		if (Match(key_splits.begin(), key_splits.end(), pattern_splits.begin(), pattern_splits.end(),
 		          S3GlobMatchMode::COMPLETE)) {
-			auto result_full_url = parsed_s3_url.prefix + parsed_s3_url.bucket + "/" + s3_key.path;
-			if (!parsed_s3_url.query_param.empty()) {
-				result_full_url += '?' + parsed_s3_url.query_param;
+			auto result_full_url = parsed_s3_url->GetPrefix() + parsed_s3_url->GetBucket() + "/" + s3_key.path;
+			if (!parsed_s3_url->GetQueryString().empty()) {
+				result_full_url += '?' + parsed_s3_url->GetQueryString();
 			}
 			s3_key.path = std::move(result_full_url);
 			auto captured = request_session->Capture();
@@ -303,7 +303,7 @@ struct S3ListRequest {
 		if (max_keys.IsValid()) {
 			request_params.emplace_back("max-keys", to_string(max_keys.GetIndex()));
 		}
-		request_params.emplace_back("prefix", parsed_url.key);
+		request_params.emplace_back("prefix", parsed_url.GetKey());
 		return S3RequestQuery(std::move(request_params));
 	}
 };

--- a/src/s3/s3_provider.cpp
+++ b/src/s3/s3_provider.cpp
@@ -249,11 +249,12 @@ void S3Provider::ReadAuthParams(S3KeyValueReader &secret_reader, const string &f
 	InitializeAuthParams(result);
 }
 
-static bool EndpointIsAWS(const string &endpoint) {
-	if (endpoint.empty()) {
+static bool EndpointIsAWS(const NormalizedS3Endpoint &endpoint) {
+	if (endpoint.IsEmpty()) {
 		return true;
 	}
-	return StringUtil::StartsWith(endpoint, "s3.") && StringUtil::EndsWith(endpoint, ".amazonaws.com");
+	return StringUtil::StartsWith(endpoint.GetHost(), "s3.") &&
+	       StringUtil::EndsWith(endpoint.GetHost(), ".amazonaws.com");
 }
 
 //! Not AWS, so deriving an AWS endpoint would sign a request to the wrong host
@@ -261,78 +262,66 @@ static bool RequiresExplicitEndpoint(const S3AuthParams &auth_params) {
 	return auth_params.scheme_is_alias || auth_params.provider_type == S3ProviderType::R2;
 }
 
-static bool EndpointIsUnresolved(const S3AuthParams &auth_params) {
-	auto endpoint = auth_params.endpoint;
+static bool EndpointIsUnresolved(const string &endpoint_source) {
+	auto endpoint = endpoint_source;
 	StringUtil::Trim(endpoint);
 	return endpoint.empty();
 }
 
-//! Re-applied in both phases: url query parameters can clear these between them
-static void ApplyProviderDefaults(S3AuthParams &auth_params) {
-	if (auth_params.provider_type != S3ProviderType::GCS) {
-		return;
-	}
-	if (EndpointIsUnresolved(auth_params)) {
-		auth_params.endpoint = "storage.googleapis.com";
-		auth_params.endpoint_mode = S3EndpointMode::AUTOMATIC;
-	}
-	if (auth_params.url_style.empty()) {
-		auth_params.url_style = "path";
-	}
-}
-
-static void ApplyDerivedDefaults(S3AuthParams &auth_params) {
+void S3Provider::InitializeAuthParams(S3AuthParams &auth_params) {
 	if (auth_params.provider_type == S3ProviderType::GCS) {
-		if (auth_params.region.empty() && S3Provider::GetAuthType(auth_params) == S3AuthType::SIGV4) {
+		if (EndpointIsUnresolved(auth_params.endpoint_source)) {
+			auth_params.endpoint_source = "storage.googleapis.com";
+			auth_params.endpoint = NormalizedS3Endpoint();
+			auth_params.endpoint_mode = S3EndpointMode::AUTOMATIC;
+		}
+		if (auth_params.url_style.empty()) {
+			auth_params.url_style = "path";
+		}
+		if (auth_params.region.empty() && GetAuthType(auth_params) == S3AuthType::SIGV4) {
 			auth_params.region = "auto";
 		}
-		return;
 	}
-	if (auth_params.provider_type != S3ProviderType::S3 ||
-	    (auth_params.endpoint_mode == S3EndpointMode::EXPLICIT && !EndpointIsAWS(auth_params.endpoint))) {
-		return;
-	}
-	if (auth_params.region.empty()) {
-		if (auth_params.access_key_id.empty()) {
-			if (auth_params.endpoint_mode == S3EndpointMode::AUTOMATIC) {
-				auth_params.endpoint = "s3.amazonaws.com";
-			}
-			return;
-		}
-		auth_params.region = "us-east-1";
-	}
-	if (auth_params.endpoint_mode == S3EndpointMode::AUTOMATIC) {
-		auth_params.endpoint = StringUtil::Format("s3.%s.amazonaws.com", auth_params.region);
-	}
-}
-
-void S3Provider::InitializeAuthParams(S3AuthParams &auth_params) {
-	ApplyProviderDefaults(auth_params);
 	ParseURLStyle(auth_params.url_style);
-	if (RequiresExplicitEndpoint(auth_params) && EndpointIsUnresolved(auth_params)) {
-		// Url query parameters still get to supply one; FinalizeAuthParams rejects it if none did
-		return;
-	}
-	ApplyDerivedDefaults(auth_params);
 }
 
 void S3Provider::FinalizeAuthParams(S3AuthParams &auth_params) {
-	ApplyProviderDefaults(auth_params);
-	ParseURLStyle(auth_params.url_style);
+	InitializeAuthParams(auth_params);
 	if (auth_params.provider_type == S3ProviderType::GCS && auth_params.requester_pays &&
 	    auth_params.user_project.empty()) {
 		throw InvalidInputException(
 		    "GCS Requester Pays requires a billing project; set USER_PROJECT in the GCS secret, "
 		    "set gcs_user_project, or pass gcs_user_project in the URL.");
 	}
-	if (RequiresExplicitEndpoint(auth_params) && EndpointIsUnresolved(auth_params)) {
+	if (RequiresExplicitEndpoint(auth_params) && EndpointIsUnresolved(auth_params.endpoint_source)) {
 		if (auth_params.provider_type == S3ProviderType::R2) {
 			throw IOException("R2 requires an endpoint; provide account_id in the secret or s3_endpoint in the URL");
 		}
 		throw IOException("An aliased URL scheme requires an endpoint; provide ENDPOINT in the secret, set "
 		                  "s3_endpoint, or pass s3_endpoint in the URL");
 	}
-	ApplyDerivedDefaults(auth_params);
+
+	auto endpoint = NormalizedS3Endpoint::Parse(auth_params.endpoint_source, auth_params.use_ssl);
+	if (auth_params.provider_type == S3ProviderType::S3 && !auth_params.scheme_is_alias &&
+	    endpoint.GetHost() == "s3.amazonaws.com" && endpoint.GetBasePath().empty() && endpoint.IsDefaultPort()) {
+		auth_params.endpoint_mode = S3EndpointMode::AUTOMATIC;
+	}
+	if (auth_params.provider_type == S3ProviderType::S3 &&
+	    (auth_params.endpoint_mode == S3EndpointMode::AUTOMATIC || EndpointIsAWS(endpoint))) {
+		if (auth_params.region.empty()) {
+			if (auth_params.access_key_id.empty()) {
+				if (auth_params.endpoint_mode == S3EndpointMode::AUTOMATIC) {
+					endpoint.SetHost("s3.amazonaws.com");
+				}
+			} else {
+				auth_params.region = "us-east-1";
+			}
+		}
+		if (auth_params.endpoint_mode == S3EndpointMode::AUTOMATIC && !auth_params.region.empty()) {
+			endpoint.SetHost(StringUtil::Format("s3.%s.amazonaws.com", auth_params.region));
+		}
+	}
+	auth_params.endpoint = std::move(endpoint);
 }
 
 S3URLStyle S3Provider::ParseURLStyle(const string &url_style) {
@@ -356,11 +345,9 @@ S3AuthType S3Provider::GetAuthType(const S3AuthParams &auth_params) {
 	return S3AuthType::SIGV4;
 }
 
-static bool EndpointIsR2(const string &endpoint) {
+static bool EndpointIsR2(const NormalizedS3Endpoint &endpoint) {
 	static const string R2_ENDPOINT_SUFFIX = ".r2.cloudflarestorage.com";
-	auto host = endpoint.substr(0, endpoint.find('/'));
-	host = host.substr(0, host.find(':'));
-	host = StringUtil::Lower(host);
+	auto &host = endpoint.GetHost();
 	if (!StringUtil::EndsWith(host, R2_ENDPOINT_SUFFIX)) {
 		return false;
 	}
@@ -378,7 +365,7 @@ static bool EndpointIsR2(const string &endpoint) {
 
 static bool UsesR2CompatibilityProfile(const S3AuthParams &auth_params) {
 	return auth_params.provider_type == S3ProviderType::R2 ||
-	       (auth_params.provider_type == S3ProviderType::S3 && EndpointIsR2(auth_params.endpoint));
+	       (auth_params.provider_type == S3ProviderType::S3 && EndpointIsR2(auth_params.GetEndpoint()));
 }
 
 static S3MultipartUploadPolicy DefaultMultipartUploadPolicy() {

--- a/src/s3/s3_request.cpp
+++ b/src/s3/s3_request.cpp
@@ -134,11 +134,11 @@ struct S3HeaderBuilder {
 	};
 
 public:
-	S3HeaderBuilder(EncryptionUtil &encryption_util_p, string url_p, const S3RequestQuery &query_p, string host_p,
-	                string service_p, RequestType request_type_p, const S3AuthParams &auth_params_p, string date_now_p,
-	                string datetime_now_p, string payload_hash_p, string content_type_p, string content_md5_p,
-	                HTTPHeaders &headers_p)
-	    : encryption_util(encryption_util_p), url(std::move(url_p)), query(query_p.CanonicalQuery()),
+	S3HeaderBuilder(EncryptionUtil &encryption_util_p, string encoded_url_p, const S3RequestQuery &query_p,
+	                string host_p, string service_p, RequestType request_type_p, const S3AuthParams &auth_params_p,
+	                string date_now_p, string datetime_now_p, string payload_hash_p, string content_type_p,
+	                string content_md5_p, HTTPHeaders &headers_p)
+	    : encryption_util(encryption_util_p), encoded_url(std::move(encoded_url_p)), query(query_p.CanonicalQuery()),
 	      host(std::move(host_p)), service(std::move(service_p)), method(HTTPFSUtil::GetRequestMethod(request_type_p)),
 	      auth_params(auth_params_p), date_now(std::move(date_now_p)), datetime_now(std::move(datetime_now_p)),
 	      payload_hash(std::move(payload_hash_p)), content_type(std::move(content_type_p)),
@@ -250,7 +250,7 @@ private:
 	}
 
 	string BuildCanonicalRequest(const vector<CanonicalHeader> &canonical_headers, const string &signed_headers) const {
-		auto result = method + "\n" + S3Url::Encode(url, S3URLEncodeMode::PATH) + "\n" + query;
+		auto result = method + "\n" + encoded_url + "\n" + query;
 		for (const auto &header : canonical_headers) {
 			result += "\n" + header.name + ":" + header.value;
 		}
@@ -275,7 +275,7 @@ private:
 
 private:
 	EncryptionUtil &encryption_util;
-	const string url;
+	const string encoded_url;
 	const string query;
 	const string host;
 	const string service;
@@ -329,21 +329,24 @@ static HTTPHeaders CreateConfiguredS3Headers(const unordered_map<string, string>
 }
 
 HTTPHeaders S3RequestUtil::CreateHeaders(EncryptionUtil &encryption_util, const ParsedS3Url &parsed_url,
-                                         const S3RequestQuery &query, RequestType request_type,
+                                         S3RequestTarget target, const S3RequestQuery &query, RequestType request_type,
                                          const S3AuthParams &auth_params, string date_now, string datetime_now,
                                          string payload_hash, string content_type, string content_md5,
                                          const unordered_map<string, string> &extra_headers, const string &user_agent) {
+	const auto &host = parsed_url.GetHost();
+	const auto &encoded_path =
+	    target == S3RequestTarget::BUCKET ? parsed_url.GetEncodedBucketPath() : parsed_url.GetEncodedPath();
 	auto headers = CreateConfiguredS3Headers(extra_headers, user_agent, auth_params.provider_type);
 	if (auth_params.provider_type == S3ProviderType::GCS && !auth_params.user_project.empty()) {
 		headers["x-goog-user-project"] = auth_params.user_project;
 	}
 	switch (S3Provider::GetAuthType(auth_params)) {
 	case S3AuthType::ANONYMOUS: {
-		headers["Host"] = parsed_url.host;
+		headers["Host"] = host;
 		return headers;
 	}
 	case S3AuthType::SIGV4: {
-		S3HeaderBuilder(encryption_util, parsed_url.path, query, parsed_url.host, "s3", request_type, auth_params,
+		S3HeaderBuilder(encryption_util, encoded_path, query, host, "s3", request_type, auth_params,
 		                std::move(date_now), std::move(datetime_now), std::move(payload_hash), std::move(content_type),
 		                std::move(content_md5), headers)
 		    .Create();
@@ -351,7 +354,7 @@ HTTPHeaders S3RequestUtil::CreateHeaders(EncryptionUtil &encryption_util, const 
 	}
 	case S3AuthType::BEARER: {
 		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
-		headers["Host"] = parsed_url.host;
+		headers["Host"] = host;
 		if (!content_type.empty()) {
 			headers["Content-Type"] = content_type;
 		}
@@ -509,13 +512,10 @@ S3RequestData S3RequestExecutor::CreateRequestData(EncryptionUtil &encryption_ut
 	auto parsed_s3_url = S3Url::Parse(s3_url, result.auth_params);
 	result.display_url = S3Url::GetDisplayUrl(s3_url, result.auth_params);
 	auto query = create_query(parsed_s3_url);
-	if (target == S3RequestTarget::BUCKET) {
-		parsed_s3_url.path = parsed_s3_url.GetBucketPath();
-	}
-
-	result.http_url = parsed_s3_url.GetHTTPUrl(query.WireQuery());
+	result.http_url = target == S3RequestTarget::BUCKET ? parsed_s3_url.GetBucketHTTPUrl(query.WireQuery())
+	                                                    : parsed_s3_url.GetHTTPUrl(query.WireQuery());
 	auto &http_params = result.http_params->Cast<HTTPFSParams>();
-	result.headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_s3_url, query, request_type,
+	result.headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_s3_url, target, query, request_type,
 	                                              result.auth_params, "", "", payload_hash, content_type, content_md5,
 	                                              http_params.extra_headers, http_params.user_agent);
 	return result;

--- a/src/s3/s3_url.cpp
+++ b/src/s3/s3_url.cpp
@@ -59,13 +59,6 @@ void S3Url::ReadQueryParams(const string &url_query_param, S3AuthParams &params)
 	GetQueryParam("s3_access_key_id", params.access_key_id, query_params);
 	GetQueryParam("s3_secret_access_key", params.secret_access_key, query_params);
 	GetQueryParam("s3_session_token", params.session_token, query_params);
-	string endpoint;
-	if (GetQueryParam("s3_endpoint", endpoint, query_params)) {
-		params.SetEndpoint(std::move(endpoint));
-	}
-	if (GetQueryParam("s3_url_style", params.url_style, query_params)) {
-		S3Provider::ParseURLStyle(params.url_style);
-	}
 	auto found_param = query_params.find("s3_use_ssl");
 	if (found_param != query_params.end()) {
 		if (found_param->second == "true") {
@@ -76,6 +69,13 @@ void S3Url::ReadQueryParams(const string &url_query_param, S3AuthParams &params)
 			throw IOException("Incorrect setting found for s3_use_ssl, allowed values are: 'true' or 'false'");
 		}
 		query_params.erase(found_param);
+	}
+	string endpoint;
+	if (GetQueryParam("s3_endpoint", endpoint, query_params)) {
+		params.SetEndpoint(std::move(endpoint));
+	}
+	if (GetQueryParam("s3_url_style", params.url_style, query_params)) {
+		S3Provider::ParseURLStyle(params.url_style);
 	}
 	auto found_requester_pays_param = query_params.find("s3_requester_pays");
 	if (found_requester_pays_param != query_params.end()) {
@@ -103,9 +103,16 @@ void S3Url::ReadQueryParams(const string &url_query_param, S3AuthParams &params)
 }
 
 ParsedS3Url S3Url::Resolve(const string &url, S3AuthParams &params) {
-	auto parsed_url = Parse(url, params);
+	S3Provider::ParseURLStyle(params.url_style);
 	// The last source of an endpoint, so validation happens after it
-	ReadQueryParams(parsed_url.query_param, params);
+	string query_param;
+	if (!params.s3_url_compatibility_mode) {
+		auto question_pos = url.find_first_of('?');
+		if (question_pos != string::npos) {
+			query_param = url.substr(question_pos + 1);
+		}
+	}
+	ReadQueryParams(query_param, params);
 	S3Provider::FinalizeAuthParams(params);
 	return Parse(url, params);
 }
@@ -119,7 +126,7 @@ string S3Url::GetDisplayUrl(const string &url, const S3AuthParams &params) {
 }
 
 ParsedS3Url S3Url::Parse(const string &url, const S3AuthParams &params) {
-	string http_proto, prefix, host, bucket, key, path, query_param, trimmed_s3_url;
+	string prefix, host, bucket, key, encoded_path, encoded_bucket_path, query_string;
 
 	auto provider_match = S3Provider::TryMatchUrl(url);
 	if (provider_match) {
@@ -146,19 +153,15 @@ ParsedS3Url S3Url::Parse(const string &url, const S3AuthParams &params) {
 
 	if (params.s3_url_compatibility_mode) {
 		// In url compatibility mode, we will ignore any special chars, so query param strings are disabled
-		trimmed_s3_url = url;
 		key += url.substr(slash_pos);
 	} else {
 		// Parse query parameters
 		auto question_pos = url.find_first_of('?');
 		if (question_pos != string::npos) {
-			query_param = url.substr(question_pos + 1);
-			trimmed_s3_url = url.substr(0, question_pos);
-		} else {
-			trimmed_s3_url = url;
+			query_string = url.substr(question_pos + 1);
 		}
 
-		if (!query_param.empty()) {
+		if (!query_string.empty()) {
 			key += url.substr(slash_pos, question_pos - slash_pos);
 		} else {
 			key += url.substr(slash_pos);
@@ -169,52 +172,97 @@ ParsedS3Url S3Url::Parse(const string &url, const S3AuthParams &params) {
 		throw IOException("URL needs to contain key");
 	}
 
-	// Derived host and path based on the endpoint
-	auto sub_path_pos = params.endpoint.find_first_of('/');
-	if (sub_path_pos != string::npos) {
-		// Host header should conform to <host>:<port> so not include the path
-		host = params.endpoint.substr(0, sub_path_pos);
-		path = params.endpoint.substr(sub_path_pos);
-	} else {
-		host = params.endpoint;
-		path = "";
+	// Derived host and path based on the normalized endpoint
+	host = params.GetEndpoint().GetAuthority();
+	auto &base_path = params.GetEndpoint().GetBasePath();
+	for (idx_t i = 0; i < base_path.size(); i++) {
+		if (base_path[i] == '%' && i + 2 < base_path.size()) {
+			encoded_path += base_path.substr(i, 3);
+			i += 2;
+		} else {
+			encoded_path += Encode(base_path.substr(i, 1), S3URLEncodeMode::PATH);
+		}
 	}
 
 	// Update host and path according to the url style
 	// See https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
 	auto url_style = S3Provider::ParseURLStyle(params.url_style);
 	bool use_vhost = url_style == S3URLStyle::VIRTUAL_HOSTED;
+	if (use_vhost && params.GetEndpoint().IsIPv6()) {
+		throw InvalidInputException("IPv6 S3 endpoints require path-style URLs");
+	}
 	// A bucket name containing periods (.) is not addressable vhost-style over TLS. Fallback to path style url
-	bool use_path = url_style == S3URLStyle::PATH || (use_vhost && params.use_ssl && bucket.find('.') != string::npos);
+	bool use_path = url_style == S3URLStyle::PATH ||
+	                (use_vhost && params.GetEndpoint().UsesSSL() && bucket.find('.') != string::npos);
 	if (use_path) {
-		path += "/" + bucket;
+		encoded_path += "/" + Encode(bucket, S3URLEncodeMode::PATH);
 	} else if (use_vhost) {
 		host = bucket + "." + host;
 	}
+	encoded_bucket_path = encoded_path.empty() ? "/" : encoded_path + "/";
 
 	// Append key (including leading slash) to the path
-	path += key;
+	encoded_path += Encode(key, S3URLEncodeMode::PATH);
 
 	// Remove leading slash from key
 	key = key.substr(1);
 
-	http_proto = params.use_ssl ? "https://" : "http://";
+	ParsedS3Url result;
+	result.prefix = std::move(prefix);
+	result.bucket = std::move(bucket);
+	result.key = std::move(key);
+	result.query_string = std::move(query_string);
+	result.host = std::move(host);
+	result.encoded_path = std::move(encoded_path);
+	result.encoded_bucket_path = std::move(encoded_bucket_path);
+	result.use_ssl = params.GetEndpoint().UsesSSL();
+	return result;
+}
 
-	return {http_proto, prefix, host, bucket, key, path, query_param, trimmed_s3_url};
+const string &ParsedS3Url::GetPrefix() const {
+	return prefix;
+}
+
+const string &ParsedS3Url::GetBucket() const {
+	return bucket;
+}
+
+const string &ParsedS3Url::GetKey() const {
+	return key;
+}
+
+const string &ParsedS3Url::GetQueryString() const {
+	return query_string;
 }
 
 string ParsedS3Url::GetHTTPUrl(const string &http_query_string) const {
-	string full_url = http_proto + host + S3Url::Encode(path, S3URLEncodeMode::PATH);
+	return BuildHTTPUrl(encoded_path, http_query_string);
+}
+
+string ParsedS3Url::GetBucketHTTPUrl(const string &http_query_string) const {
+	return BuildHTTPUrl(encoded_bucket_path, http_query_string);
+}
+
+const string &ParsedS3Url::GetHost() const {
+	return host;
+}
+
+const string &ParsedS3Url::GetEncodedPath() const {
+	return encoded_path;
+}
+
+const string &ParsedS3Url::GetEncodedBucketPath() const {
+	return encoded_bucket_path;
+}
+
+string ParsedS3Url::BuildHTTPUrl(const string &request_path, const string &http_query_string) const {
+	string full_url = use_ssl ? "https://" : "http://";
+	full_url += host + request_path;
 
 	if (!http_query_string.empty()) {
 		full_url += "?" + http_query_string;
 	}
 	return full_url;
-}
-
-string ParsedS3Url::GetBucketPath() const {
-	auto bucket_path = path.substr(0, path.length() - key.length());
-	return bucket_path.empty() ? "/" : bucket_path;
 }
 
 } // namespace duckdb

--- a/test/unittest/s3/mock_s3_server.cpp
+++ b/test/unittest/s3/mock_s3_server.cpp
@@ -292,7 +292,8 @@ public:
 	}
 
 	string HTTPPath() const {
-		return StringUtil::Format("http://%s/%s/%s", Endpoint(), config.object.bucket, config.object.key);
+		return StringUtil::Format("http://%s%s/%s/%s", Endpoint(), config.endpoint_base_path, config.object.bucket,
+		                          config.object.key);
 	}
 
 	vector<MockS3RequestObservation> Observations() const DUCKDB_EXCLUDES(observation_lock) {
@@ -868,9 +869,12 @@ public:
 	}
 
 	void RegisterRoutes() {
-		const string path = StringUtil::Format("/%s/%s", config.object.bucket, config.object.key);
+		D_ASSERT(config.endpoint_base_path.empty() ||
+		         (config.endpoint_base_path[0] == '/' && config.endpoint_base_path.back() != '/'));
+		const string path =
+		    config.endpoint_base_path + StringUtil::Format("/%s/%s", config.object.bucket, config.object.key);
 		const string proxy_path = "https?://[^/]+" + path;
-		const string bucket_path = StringUtil::Format("/%s", config.object.bucket);
+		const string bucket_path = config.endpoint_base_path + StringUtil::Format("/%s", config.object.bucket);
 		const string bucket_path_with_slash = bucket_path + "/";
 		const string proxy_bucket_path = "https?://[^/]+" + bucket_path;
 		const string proxy_bucket_path_with_slash = proxy_bucket_path + "/";

--- a/test/unittest/s3/mock_s3_server.hpp
+++ b/test/unittest/s3/mock_s3_server.hpp
@@ -171,6 +171,8 @@ struct MockS3UploadConfig {
 };
 
 struct MockS3ServerConfig {
+	//! Path prefix configured as part of the endpoint, without a trailing slash
+	string endpoint_base_path;
 	MockS3ObjectConfig object;
 	MockS3AuthConfig auth;
 	MockS3MetadataConfig metadata;

--- a/test/unittest/s3/s3_refresh_test.cpp
+++ b/test/unittest/s3/s3_refresh_test.cpp
@@ -548,6 +548,7 @@ CREATE SECRET refresh_s3_endpoint_mode (
 	ClientContextFileOpener opener(*con.context);
 	FileOpenerInfo info = {S3TestHelper::S3_PATH};
 	auto auth_params = S3AuthParams::ReadFrom(opener, info);
+	S3Url::Resolve(S3TestHelper::S3_PATH, auth_params);
 	REQUIRE(auth_params.endpoint_mode == initial_mode);
 	auto session = S3RequestExecutor::CreateSession(opener, S3TestHelper::S3_PATH, auth_params);
 	if (!published_region.empty()) {
@@ -564,7 +565,7 @@ CREATE SECRET refresh_s3_endpoint_mode (
 	    [](const ParsedS3Url &) { return S3RequestQuery(); }, "", "", "",
 	    [&](S3RequestData &request_data) {
 		    observed_modes.push_back(request_data.auth_params.endpoint_mode);
-		    observed_endpoints.push_back(request_data.auth_params.endpoint);
+		    observed_endpoints.push_back(request_data.auth_params.GetEndpoint().GetHost());
 		    observed_regions.push_back(request_data.auth_params.region);
 		    if (observed_modes.size() == 1) {
 			    auto result = make_uniq<HTTPResponse>(HTTPStatusCode::Forbidden_403);
@@ -581,7 +582,7 @@ CREATE SECRET refresh_s3_endpoint_mode (
 	REQUIRE(observed_regions == vector<string> {expected_region, expected_region});
 	auto &snapshot = session->Capture().snapshot->Cast<S3RequestSnapshot>();
 	REQUIRE(snapshot.auth_params.endpoint_mode == refreshed_mode);
-	REQUIRE(snapshot.auth_params.endpoint == refreshed_resolved_endpoint);
+	REQUIRE(snapshot.auth_params.GetEndpoint().GetHost() == refreshed_resolved_endpoint);
 	S3TestHelper::RequireQueryOk(con, "COMMIT");
 	S3TestHelper::AssertSingleRefresh(test_id);
 }

--- a/test/unittest/s3/s3_request_test.cpp
+++ b/test/unittest/s3/s3_request_test.cpp
@@ -29,6 +29,14 @@ namespace duckdb {
 
 namespace {
 
+static ParsedS3Url ParseTestS3Url(const string &url, const string &endpoint, const string &url_style) {
+	S3AuthParams auth_params;
+	auth_params.SetEndpoint(endpoint);
+	auth_params.url_style = url_style;
+	S3Provider::FinalizeAuthParams(auth_params);
+	return S3Url::Parse(url, auth_params);
+}
+
 static void RunFullGetErrorBodyScenario(const string &client_implementation) {
 	MockS3ServerConfig config;
 	config.object.bucket = S3TestHelper::BUCKET;
@@ -157,6 +165,79 @@ CREATE SECRET s3_headers (
 		REQUIRE(found_amz_spelling);
 		REQUIRE(found_goog_spelling);
 	}
+}
+
+static void RunNormalizedEndpointWireScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.endpoint_base_path = "//gateway/base";
+	config.auth.stale_key_id = "NEVER_STALE";
+	config.list.paginate = true;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	S3TestHelper::LoadExtension(db);
+	S3TestHelper::RequireQueryOk(con,
+	                             StringUtil::Format("SET httpfs_client_implementation='%s'", client_implementation));
+	S3TestHelper::RequireQueryOk(con, "SET httpfs_connection_caching=false");
+	S3TestHelper::RequireQueryOk(con, "SET enable_global_s3_configuration=false");
+	S3TestHelper::RequireQueryOk(con, StringUtil::Format(R"(
+CREATE SECRET normalized_endpoint (
+	TYPE S3,
+	SCOPE 's3://refresh-bucket/',
+	KEY_ID 'FRESH_KEY',
+	SECRET 'FRESH_SECRET',
+	REGION 'us-east-1',
+	ENDPOINT 'HTTP://%s//gateway/base///',
+	USE_SSL true,
+	URL_STYLE 'path'
+))",
+	                                                     server.Endpoint()));
+
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+	{
+		auto handle = fs.OpenFile(S3TestHelper::S3_PATH, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+		char result;
+		handle->Read(QueryContext(*con.context), &result, 1, 0);
+		REQUIRE(result == server.ObjectData()[0]);
+	}
+	auto glob_result = fs.Glob("s3://refresh-bucket/*.bin", FileGlobOptions::ALLOW_EMPTY, nullptr);
+	REQUIRE(glob_result->GetAllFiles().size() == 2);
+	S3TestHelper::WriteSinglePutPayload(con);
+	auto legacy_endpoint = server.Endpoint() + "//gateway/base/";
+	auto uri_endpoint = "http://" + server.Endpoint() + "//gateway/base";
+	fs.RemoveFiles(
+	    {string(S3TestHelper::S3_PATH) + "?s3_endpoint=" +
+	         S3Url::Encode(legacy_endpoint, S3URLEncodeMode::QUERY_COMPONENT) + "&s3_use_ssl=false&s3_url_style=path",
+	     "s3://refresh-bucket/another.bin?s3_endpoint=" +
+	         S3Url::Encode(uri_endpoint, S3URLEncodeMode::QUERY_COMPONENT) + "&s3_use_ssl=true&s3_url_style=path"});
+	S3TestHelper::RequireQueryOk(con, "COMMIT");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	bool saw_read = false;
+	bool saw_list = false;
+	bool saw_put = false;
+	idx_t bulk_delete_count = 0;
+	for (const auto &observation : observations) {
+		REQUIRE(StringUtil::StartsWith(observation.path, "//gateway/base/"));
+		REQUIRE(MockS3HeaderValues(observation, "Host") == vector<string> {server.Endpoint()});
+		REQUIRE(StringUtil::Contains(observation.authorization, "SignedHeaders="));
+		REQUIRE(StringUtil::Contains(observation.authorization, "host"));
+		saw_read |= observation.method == "HEAD" || observation.method == "GET";
+		saw_list |= observation.method == "GET" && StringUtil::Contains(observation.target, "list-type=2");
+		saw_put |= observation.method == "PUT";
+		if (observation.method == "POST" && StringUtil::Contains(observation.target, "delete=")) {
+			bulk_delete_count++;
+			REQUIRE(observation.delete_key_count == 2);
+		}
+	}
+	REQUIRE(saw_read);
+	REQUIRE(saw_list);
+	REQUIRE(saw_put);
+	REQUIRE(bulk_delete_count == 1);
+	REQUIRE(server.UploadedObject() == "single-shot payload");
 }
 
 static void RunS3RejectedHeaderScenario(const string &client_implementation) {
@@ -742,7 +823,9 @@ static S3AuthParams ReadSecretAuthParams(Connection &con, KeyValueSecret &secret
                                          const string &path = "s3://bucket/key") {
 	ClientContextFileOpener opener(*con.context);
 	S3KeyValueReader secret_reader {KeyValueSecretReader(secret, opener)};
-	return S3AuthParams::ReadFrom(secret_reader, path);
+	auto result = S3AuthParams::ReadFrom(secret_reader, path);
+	S3Url::Resolve(path, result);
+	return result;
 }
 
 } // namespace
@@ -786,7 +869,8 @@ TEST_CASE("S3 provider selects multipart upload policy", "[httpfs][s3][provider]
 		S3AuthParams auth_params;
 		auth_params.provider_type = provider_type;
 		auth_params.scheme_is_alias = scheme_is_alias;
-		auth_params.endpoint = endpoint;
+		auth_params.SetEndpoint(endpoint);
+		S3Provider::FinalizeAuthParams(auth_params);
 		INFO(endpoint);
 		auto policy = S3Provider::GetMultipartUploadPolicy(auth_params);
 		REQUIRE(policy.part_size_strategy == expected.part_size_strategy);
@@ -800,6 +884,7 @@ TEST_CASE("S3 provider selects multipart upload policy", "[httpfs][s3][provider]
 	require_policy(S3ProviderType::S3, "account.r2.cloudflarestorage.com", fixed_policy);
 	require_policy(S3ProviderType::S3, "account.eu.r2.cloudflarestorage.com", fixed_policy);
 	require_policy(S3ProviderType::S3, "ACCOUNT.FEDRAMP.R2.CLOUDFLARESTORAGE.COM:443/path", fixed_policy);
+	require_policy(S3ProviderType::S3, "https://ACCOUNT.EU.R2.CLOUDFLARESTORAGE.COM:443/path", fixed_policy);
 	require_policy(S3ProviderType::S3, "account.us.r2.cloudflarestorage.com", fixed_policy, true);
 
 	require_policy(S3ProviderType::S3, "s3.amazonaws.com", adaptive_policy);
@@ -815,7 +900,8 @@ TEST_CASE("S3 provider selects bulk delete limits", "[httpfs][s3][provider][dele
 	auto require_limit = [](S3ProviderType provider_type, const string &endpoint, idx_t expected) {
 		S3AuthParams auth_params;
 		auth_params.provider_type = provider_type;
-		auth_params.endpoint = endpoint;
+		auth_params.SetEndpoint(endpoint);
+		S3Provider::FinalizeAuthParams(auth_params);
 		INFO(endpoint);
 		REQUIRE(S3Provider::GetBulkDeleteMaxBatchSize(auth_params) == expected);
 	};
@@ -824,6 +910,7 @@ TEST_CASE("S3 provider selects bulk delete limits", "[httpfs][s3][provider][dele
 	require_limit(S3ProviderType::S3, "account.r2.cloudflarestorage.com", 700);
 	require_limit(S3ProviderType::S3, "account.eu.r2.cloudflarestorage.com", 700);
 	require_limit(S3ProviderType::S3, "ACCOUNT.FEDRAMP.R2.CLOUDFLARESTORAGE.COM:443/path", 700);
+	require_limit(S3ProviderType::S3, "https://ACCOUNT.EU.R2.CLOUDFLARESTORAGE.COM:443/path", 700);
 
 	require_limit(S3ProviderType::S3, "s3.amazonaws.com", 1000);
 	require_limit(S3ProviderType::GCS, "account.r2.cloudflarestorage.com", 1000);
@@ -837,18 +924,18 @@ TEST_CASE("S3 endpoint provenance controls AWS endpoint derivation", "[httpfs][s
 	SECTION("automatic endpoints retain the existing region defaults") {
 		S3AuthParams anonymous;
 		anonymous.SetEndpoint("  ");
-		S3Provider::InitializeAuthParams(anonymous);
+		S3Provider::FinalizeAuthParams(anonymous);
 		REQUIRE(anonymous.endpoint_mode == S3EndpointMode::AUTOMATIC);
 		REQUIRE(anonymous.region.empty());
-		REQUIRE(anonymous.endpoint == "s3.amazonaws.com");
+		REQUIRE(anonymous.GetEndpoint().GetHost() == "s3.amazonaws.com");
 
 		S3AuthParams credentialed;
 		credentialed.SetEndpoint("s3.amazonaws.com");
 		credentialed.access_key_id = "key";
-		S3Provider::InitializeAuthParams(credentialed);
+		S3Provider::FinalizeAuthParams(credentialed);
 		REQUIRE(credentialed.endpoint_mode == S3EndpointMode::AUTOMATIC);
 		REQUIRE(credentialed.region == "us-east-1");
-		REQUIRE(credentialed.endpoint == "s3.us-east-1.amazonaws.com");
+		REQUIRE(credentialed.GetEndpoint().GetHost() == "s3.us-east-1.amazonaws.com");
 	}
 
 	SECTION("explicit endpoints keep their host") {
@@ -856,13 +943,13 @@ TEST_CASE("S3 endpoint provenance controls AWS endpoint derivation", "[httpfs][s
 		                             "s3.eu-west-1.amazonaws.com", "storage.example.com"}) {
 			S3AuthParams auth_params;
 			auth_params.SetEndpoint(endpoint);
-			S3Provider::InitializeAuthParams(auth_params);
+			S3Provider::FinalizeAuthParams(auth_params);
 			INFO(endpoint);
 			REQUIRE(auth_params.endpoint_mode == S3EndpointMode::EXPLICIT);
-			REQUIRE(auth_params.endpoint == endpoint);
+			REQUIRE(auth_params.GetEndpoint().GetHost() == endpoint);
 			REQUIRE(auth_params.region.empty());
 			auth_params.SetRegion("ap-southeast-2");
-			REQUIRE(auth_params.endpoint == endpoint);
+			REQUIRE(auth_params.GetEndpoint().GetHost() == endpoint);
 		}
 	}
 
@@ -870,28 +957,161 @@ TEST_CASE("S3 endpoint provenance controls AWS endpoint derivation", "[httpfs][s
 		S3AuthParams dualstack;
 		dualstack.SetEndpoint("s3.dualstack.us-east-1.amazonaws.com");
 		dualstack.access_key_id = "key";
-		S3Provider::InitializeAuthParams(dualstack);
+		S3Provider::FinalizeAuthParams(dualstack);
 		REQUIRE(dualstack.region == "us-east-1");
-		REQUIRE(dualstack.endpoint == "s3.dualstack.us-east-1.amazonaws.com");
+		REQUIRE(dualstack.GetEndpoint().GetHost() == "s3.dualstack.us-east-1.amazonaws.com");
 
 		S3AuthParams fips;
 		fips.SetEndpoint("s3-fips.us-east-1.amazonaws.com");
 		fips.access_key_id = "key";
-		S3Provider::InitializeAuthParams(fips);
+		S3Provider::FinalizeAuthParams(fips);
 		REQUIRE(fips.region.empty());
-		REQUIRE(fips.endpoint == "s3-fips.us-east-1.amazonaws.com");
+		REQUIRE(fips.GetEndpoint().GetHost() == "s3-fips.us-east-1.amazonaws.com");
 	}
 
 	SECTION("endpoint mode participates in authentication identity") {
 		S3AuthParams automatic;
 		automatic.region = "us-east-1";
-		S3Provider::InitializeAuthParams(automatic);
+		S3Provider::FinalizeAuthParams(automatic);
 		S3AuthParams explicit_endpoint;
 		explicit_endpoint.region = "us-east-1";
 		explicit_endpoint.SetEndpoint("s3.us-east-1.amazonaws.com");
-		S3Provider::InitializeAuthParams(explicit_endpoint);
-		REQUIRE(automatic.endpoint == explicit_endpoint.endpoint);
+		S3Provider::FinalizeAuthParams(explicit_endpoint);
+		REQUIRE(automatic.GetEndpoint().GetHost() == explicit_endpoint.GetEndpoint().GetHost());
 		REQUIRE_FALSE(automatic == explicit_endpoint);
+	}
+}
+
+TEST_CASE("S3 endpoints are normalized once for routing and signing", "[httpfs][s3][provider][endpoint]") {
+	SECTION("full URI schemes override the legacy SSL flag") {
+		S3AuthParams auth_params;
+		auth_params.use_ssl = false;
+		auth_params.url_style = "path";
+		auth_params.SetEndpoint("HTTPS://Storage.EXAMPLE.com:443/gateway/%2f//base///");
+		S3Provider::FinalizeAuthParams(auth_params);
+
+		REQUIRE(auth_params.GetEndpoint().UsesSSL());
+		REQUIRE(auth_params.GetEndpoint().GetHost() == "storage.example.com");
+		REQUIRE(auth_params.GetEndpoint().GetAuthority() == "storage.example.com");
+		REQUIRE(auth_params.GetEndpoint().GetBasePath() == "/gateway/%2f//base");
+
+		auto parsed_url = S3Url::Parse("s3://bucket/key with space", auth_params);
+		REQUIRE(parsed_url.GetEncodedBucketPath() == "/gateway/%2f//base/bucket/");
+		REQUIRE(parsed_url.GetEncodedPath() == "/gateway/%2f//base/bucket/key%20with%20space");
+		REQUIRE(parsed_url.GetHTTPUrl() == "https://storage.example.com/gateway/%2f//base/bucket/key%20with%20space");
+	}
+
+	SECTION("schemeless endpoints retain the SSL fallback and non-default ports") {
+		S3AuthParams auth_params;
+		auth_params.use_ssl = false;
+		auth_params.url_style = "path";
+		auth_params.SetEndpoint("Storage.EXAMPLE.com:8443/base/");
+		S3Provider::FinalizeAuthParams(auth_params);
+		auto parsed_url = S3Url::Parse("s3://bucket/key", auth_params);
+		REQUIRE(parsed_url.GetHost() == "storage.example.com:8443");
+		REQUIRE(parsed_url.GetHTTPUrl() == "http://storage.example.com:8443/base/bucket/key");
+	}
+
+	SECTION("legacy base paths remain opaque when they contain URI-like text") {
+		S3AuthParams auth_params;
+		auth_params.use_ssl = false;
+		auth_params.url_style = "path";
+		auth_params.SetEndpoint("storage.example.com/gateway/http://mirror");
+		S3Provider::FinalizeAuthParams(auth_params);
+		auto parsed_url = S3Url::Parse("s3://bucket/key", auth_params);
+		REQUIRE(auth_params.GetEndpoint().GetBasePath() == "/gateway/http://mirror");
+		REQUIRE(parsed_url.GetHTTPUrl() == "http://storage.example.com/gateway/http%3A//mirror/bucket/key");
+	}
+
+	SECTION("valid port boundaries are preserved") {
+		for (const auto &endpoint : {"storage.example.com:1", "storage.example.com:65535"}) {
+			S3AuthParams auth_params;
+			auth_params.SetEndpoint(endpoint);
+			S3Provider::FinalizeAuthParams(auth_params);
+			REQUIRE(auth_params.GetEndpoint().GetAuthority() == endpoint);
+		}
+	}
+
+	SECTION("virtual-hosted endpoints keep their base path separate from the bucket") {
+		S3AuthParams auth_params;
+		auth_params.use_ssl = true;
+		auth_params.url_style = "virtual";
+		auth_params.SetEndpoint("http://storage.example.com:80/gateway/base/");
+		S3Provider::FinalizeAuthParams(auth_params);
+		auto parsed_url = S3Url::Parse("s3://bucket/key", auth_params);
+		REQUIRE(parsed_url.GetHost() == "bucket.storage.example.com");
+		REQUIRE(parsed_url.GetEncodedPath() == "/gateway/base/key");
+		REQUIRE(parsed_url.GetEncodedBucketPath() == "/gateway/base/");
+		REQUIRE(parsed_url.GetHTTPUrl() == "http://bucket.storage.example.com/gateway/base/key");
+	}
+
+	SECTION("full default AWS endpoints retain automatic region derivation") {
+		S3AuthParams auth_params;
+		auth_params.use_ssl = false;
+		auth_params.access_key_id = "key";
+		auth_params.SetEndpoint("HTTPS://S3.AMAZONAWS.COM:443/");
+		S3Provider::FinalizeAuthParams(auth_params);
+		REQUIRE(auth_params.endpoint_mode == S3EndpointMode::AUTOMATIC);
+		REQUIRE(auth_params.region == "us-east-1");
+		REQUIRE(auth_params.GetEndpoint().GetHost() == "s3.us-east-1.amazonaws.com");
+		REQUIRE(auth_params.GetEndpoint().GetProtocol() == "https://");
+		REQUIRE(auth_params.GetEndpoint().GetAuthority() == "s3.us-east-1.amazonaws.com");
+	}
+
+	SECTION("canonical endpoint forms share authentication identity") {
+		S3AuthParams legacy;
+		legacy.url_style = "path";
+		legacy.SetEndpoint("STORAGE.EXAMPLE.COM:443/base/");
+		S3Provider::FinalizeAuthParams(legacy);
+
+		S3AuthParams uri;
+		uri.use_ssl = false;
+		uri.url_style = "path";
+		uri.SetEndpoint("https://storage.example.com/base");
+		S3Provider::FinalizeAuthParams(uri);
+		legacy.use_ssl = false;
+		REQUIRE(legacy == uri);
+	}
+
+	SECTION("a URL override replaces an invalid lower-precedence endpoint") {
+		S3AuthParams auth_params;
+		auth_params.SetEndpoint("ftp://invalid.example.com");
+		S3Provider::InitializeAuthParams(auth_params);
+		auto parsed_url =
+		    S3Url::Resolve("s3://bucket/key?s3_endpoint=http%3A%2F%2Fstorage.example.com%3A80%2Fbase&s3_use_ssl=true&"
+		                   "s3_url_style=path",
+		                   auth_params);
+		REQUIRE(parsed_url.GetHost() == "storage.example.com");
+		REQUIRE(parsed_url.GetEncodedPath() == "/base/bucket/key");
+		REQUIRE(parsed_url.GetHTTPUrl() == "http://storage.example.com/base/bucket/key");
+	}
+
+	SECTION("bracketed IPv6 is supported only with path-style addressing") {
+		S3AuthParams path_style;
+		path_style.url_style = "path";
+		path_style.SetEndpoint("http://[2001:DB8::1]:80/base");
+		S3Provider::FinalizeAuthParams(path_style);
+		auto parsed_url = S3Url::Parse("s3://bucket/key", path_style);
+		REQUIRE(parsed_url.GetHost() == "[2001:db8::1]");
+		REQUIRE(parsed_url.GetHTTPUrl() == "http://[2001:db8::1]/base/bucket/key");
+
+		S3AuthParams vhost_style;
+		vhost_style.SetEndpoint("http://[::1]");
+		REQUIRE_THROWS(S3Url::Resolve("s3://bucket/key", vhost_style));
+	}
+}
+
+TEST_CASE("Invalid S3 endpoints fail before request construction", "[httpfs][s3][provider][endpoint]") {
+	for (const auto &endpoint :
+	     {"ftp://storage.example.com", "http://", "http://user@storage.example.com",
+	      "http://storage.example.com?query=value", "http://storage.example.com#fragment", "storage.example.com:0",
+	      "storage.example.com:65536", "storage.example.com:", "storage.example.com:port", "storage.example.com\\base",
+	      "storage.example.com/base/%", "storage.example.com/base/./key", "storage.example.com/base/../key",
+	      "2001:db8::1", "http://[fe80::1%25lo0]", "http://[2001:db8::1"}) {
+		S3AuthParams auth_params;
+		auth_params.SetEndpoint(endpoint);
+		INFO(endpoint);
+		REQUIRE_THROWS(S3Provider::FinalizeAuthParams(auth_params));
 	}
 }
 
@@ -904,7 +1124,7 @@ TEST_CASE("S3 provider endpoint precedence is preserved", "[httpfs][s3][provider
 	SECTION("GCS ignores the endpoint setting") {
 		KeyValueSecret secret({"gcs://"}, Identifier("gcs"), Identifier("config"), Identifier("gcs_default"));
 		auto auth_params = ReadSecretAuthParams(con, secret, "gcs://bucket/key");
-		REQUIRE(auth_params.endpoint == "storage.googleapis.com");
+		REQUIRE(auth_params.GetEndpoint().GetHost() == "storage.googleapis.com");
 		REQUIRE(auth_params.endpoint_mode == S3EndpointMode::AUTOMATIC);
 	}
 
@@ -912,7 +1132,7 @@ TEST_CASE("S3 provider endpoint precedence is preserved", "[httpfs][s3][provider
 		KeyValueSecret secret({"gcs://"}, Identifier("gcs"), Identifier("config"), Identifier("gcs_explicit"));
 		secret.secret_map["endpoint"] = "gcs.example.com";
 		auto auth_params = ReadSecretAuthParams(con, secret, "gcs://bucket/key");
-		REQUIRE(auth_params.endpoint == "gcs.example.com");
+		REQUIRE(auth_params.GetEndpoint().GetHost() == "gcs.example.com");
 		REQUIRE(auth_params.endpoint_mode == S3EndpointMode::EXPLICIT);
 	}
 }
@@ -1023,17 +1243,17 @@ TEST_CASE("S3 URL styles share one validation policy", "[httpfs][s3][provider][u
 		auth_params.s3_url_compatibility_mode = true;
 		S3Provider::InitializeAuthParams(auth_params);
 		auto parsed = S3Url::Resolve("s3://bucket/key?s3_url_style=handwritten", auth_params);
-		REQUIRE(parsed.query_param.empty());
-		REQUIRE(parsed.key == "key?s3_url_style=handwritten");
+		REQUIRE(parsed.GetQueryString().empty());
+		REQUIRE(parsed.GetKey() == "key?s3_url_style=handwritten");
 	}
 
 	SECTION("dotted buckets use path style over TLS") {
 		S3AuthParams auth_params;
 		auth_params.url_style = "virtual";
-		S3Provider::InitializeAuthParams(auth_params);
+		S3Provider::FinalizeAuthParams(auth_params);
 		auto parsed = S3Url::Parse("s3://bucket.with.dots/key", auth_params);
-		REQUIRE(parsed.host == "s3.amazonaws.com");
-		REQUIRE(parsed.path == "/bucket.with.dots/key");
+		REQUIRE(parsed.GetHost() == "s3.amazonaws.com");
+		REQUIRE(parsed.GetEncodedPath() == "/bucket.with.dots/key");
 	}
 }
 
@@ -1125,8 +1345,8 @@ TEST_CASE("S3 URL query settings are resolved independently of the HTTP client",
 		REQUIRE(auth_params.access_key_id == "hello world");
 		REQUIRE(auth_params.secret_access_key == "secret+value");
 		REQUIRE(auth_params.region == "us-east-1");
-		REQUIRE(auth_params.endpoint == "s3.us-east-1.amazonaws.com");
-		REQUIRE(parsed_url.host == "bucket.s3.us-east-1.amazonaws.com");
+		REQUIRE(auth_params.GetEndpoint().GetHost() == "s3.us-east-1.amazonaws.com");
+		REQUIRE(parsed_url.GetHost() == "bucket.s3.us-east-1.amazonaws.com");
 	}
 
 	SECTION("routing overrides are reflected in the parsed URL") {
@@ -1137,11 +1357,11 @@ TEST_CASE("S3 URL query settings are resolved independently of the HTTP client",
 		                                 "s3_use_ssl=false&s3_url_style=path",
 		                                 auth_params);
 		REQUIRE(auth_params.region == "eu-west-1");
-		REQUIRE(auth_params.endpoint == "s3.eu-west-1.amazonaws.com");
+		REQUIRE(auth_params.GetEndpoint().GetHost() == "s3.eu-west-1.amazonaws.com");
 		REQUIRE(auth_params.endpoint_mode == S3EndpointMode::AUTOMATIC);
-		REQUIRE(parsed_url.http_proto == "http://");
-		REQUIRE(parsed_url.host == "s3.eu-west-1.amazonaws.com");
-		REQUIRE(parsed_url.path == "/bucket/key");
+		REQUIRE(parsed_url.GetHost() == "s3.eu-west-1.amazonaws.com");
+		REQUIRE(parsed_url.GetEncodedPath() == "/bucket/key");
+		REQUIRE(parsed_url.GetHTTPUrl() == "http://s3.eu-west-1.amazonaws.com/bucket/key");
 	}
 
 	SECTION("an endpoint override can switch from automatic to explicit") {
@@ -1152,8 +1372,8 @@ TEST_CASE("S3 URL query settings are resolved independently of the HTTP client",
 		auto parsed_url =
 		    S3Url::Resolve("s3://bucket/key?s3_endpoint=s3.dualstack.us-east-1.amazonaws.com", auth_params);
 		REQUIRE(auth_params.endpoint_mode == S3EndpointMode::EXPLICIT);
-		REQUIRE(auth_params.endpoint == "s3.dualstack.us-east-1.amazonaws.com");
-		REQUIRE(parsed_url.host == "bucket.s3.dualstack.us-east-1.amazonaws.com");
+		REQUIRE(auth_params.GetEndpoint().GetHost() == "s3.dualstack.us-east-1.amazonaws.com");
+		REQUIRE(parsed_url.GetHost() == "bucket.s3.dualstack.us-east-1.amazonaws.com");
 	}
 
 	SECTION("empty GCS routing overrides restore provider defaults") {
@@ -1162,10 +1382,10 @@ TEST_CASE("S3 URL query settings are resolved independently of the HTTP client",
 		auth_params.SetEndpoint("storage.googleapis.com");
 		auth_params.url_style = "path";
 		auto parsed_url = S3Url::Resolve("gcs://bucket/key?s3_endpoint=&s3_url_style=", auth_params);
-		REQUIRE(auth_params.endpoint == "storage.googleapis.com");
+		REQUIRE(auth_params.GetEndpoint().GetHost() == "storage.googleapis.com");
 		REQUIRE(auth_params.url_style == "path");
-		REQUIRE(parsed_url.host == "storage.googleapis.com");
-		REQUIRE(parsed_url.path == "/bucket/key");
+		REQUIRE(parsed_url.GetHost() == "storage.googleapis.com");
+		REQUIRE(parsed_url.GetEncodedPath() == "/bucket/key");
 	}
 
 	SECTION("empty R2 endpoints fail instead of routing to AWS") {
@@ -1247,9 +1467,9 @@ TEST_CASE("GCS HMAC signing region follows provider defaults", "[httpfs][s3][gcs
 		auth_params.provider_type = S3ProviderType::GCS;
 		auth_params.access_key_id = "key";
 		auth_params.secret_access_key = "secret";
-		S3Provider::InitializeAuthParams(auth_params);
+		S3Provider::FinalizeAuthParams(auth_params);
 		REQUIRE(auth_params.region == "auto");
-		REQUIRE(auth_params.endpoint == "storage.googleapis.com");
+		REQUIRE(auth_params.GetEndpoint().GetHost() == "storage.googleapis.com");
 		REQUIRE(auth_params.url_style == "path");
 	}
 
@@ -1338,15 +1558,13 @@ TEST_CASE("GCS HMAC signing region follows provider defaults", "[httpfs][s3][gcs
 
 TEST_CASE("S3 provider policy selects request authentication", "[httpfs][s3][provider][signing]") {
 	::AESStateSSLFactory encryption_util;
-	ParsedS3Url parsed_url;
-	parsed_url.path = "/bucket/key";
-	parsed_url.host = "storage.example.com";
+	auto parsed_url = ParseTestS3Url("s3://bucket/key", "storage.example.com", "path");
 
 	SECTION("anonymous") {
 		S3AuthParams auth_params;
-		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestQuery(),
-		                                            RequestType::GET_REQUEST, auth_params);
-		REQUIRE(headers.GetHeaderValue("Host") == parsed_url.host);
+		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
+		                                            S3RequestQuery(), RequestType::GET_REQUEST, auth_params);
+		REQUIRE(headers.GetHeaderValue("Host") == parsed_url.GetHost());
 		REQUIRE_FALSE(headers.HasHeader("Authorization"));
 	}
 
@@ -1357,8 +1575,8 @@ TEST_CASE("S3 provider policy selects request authentication", "[httpfs][s3][pro
 		auth_params.access_key_id = "key";
 		auth_params.secret_access_key = "secret";
 		auto headers =
-		    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestQuery(), RequestType::GET_REQUEST,
-		                                 auth_params, "20260806", "20260806T120000Z");
+		    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT, S3RequestQuery(),
+		                                 RequestType::GET_REQUEST, auth_params, "20260806", "20260806T120000Z");
 		REQUIRE(StringUtil::StartsWith(headers.GetHeaderValue("Authorization"), "AWS4-HMAC-SHA256"));
 	}
 
@@ -1368,9 +1586,9 @@ TEST_CASE("S3 provider policy selects request authentication", "[httpfs][s3][pro
 		auth_params.access_key_id = "key";
 		auth_params.secret_access_key = "secret";
 		auth_params.oauth2_bearer_token = "token";
-		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestQuery({{"delete", ""}}),
-		                                            RequestType::POST_REQUEST, auth_params, "", "", "payload",
-		                                            "application/xml", "content-md5");
+		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
+		                                            S3RequestQuery({{"delete", ""}}), RequestType::POST_REQUEST,
+		                                            auth_params, "", "", "payload", "application/xml", "content-md5");
 		REQUIRE(headers.GetHeaderValue("Authorization") == "Bearer token");
 		REQUIRE(headers.GetHeaderValue("Content-Type") == "application/xml");
 		REQUIRE(headers.GetHeaderValue("Content-MD5") == "content-md5");
@@ -1380,9 +1598,7 @@ TEST_CASE("S3 provider policy selects request authentication", "[httpfs][s3][pro
 
 TEST_CASE("S3 configured headers are validated before request authentication", "[httpfs][s3][headers]") {
 	::AESStateSSLFactory encryption_util;
-	ParsedS3Url parsed_url;
-	parsed_url.path = "/bucket/key";
-	parsed_url.host = "storage.example.com";
+	auto parsed_url = ParseTestS3Url("s3://bucket/key", "storage.example.com", "path");
 
 	vector<S3AuthParams> auth_params(3);
 	auth_params[1].region = "us-east-1";
@@ -1393,8 +1609,9 @@ TEST_CASE("S3 configured headers are validated before request authentication", "
 
 	auto create_headers = [&](const S3AuthParams &auth, const unordered_map<string, string> &extra_headers,
 	                          const string &user_agent = "httpfs-agent") {
-		return S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestQuery(), RequestType::GET_REQUEST,
-		                                    auth, "", "", "", "", "", extra_headers, user_agent);
+		return S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT, S3RequestQuery(),
+		                                    RequestType::GET_REQUEST, auth, "", "", "", "", "", extra_headers,
+		                                    user_agent);
 	};
 	auto capture_error = [&](const S3AuthParams &auth, const unordered_map<string, string> &extra_headers) {
 		try {
@@ -1596,12 +1813,10 @@ TEST_CASE("S3 request signing remains deterministic", "[httpfs][s3][signing]") {
 	auth_params.region = "us-east-1";
 	auth_params.access_key_id = "AKIAIOSFODNN7EXAMPLE";
 	auth_params.secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
-	ParsedS3Url parsed_url;
-	parsed_url.path = "/test.txt";
-	parsed_url.host = "examplebucket.s3.amazonaws.com";
+	auto parsed_url = ParseTestS3Url("s3://examplebucket/test.txt", "s3.amazonaws.com", "virtual");
 
-	auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestQuery(), RequestType::GET_REQUEST,
-	                                            auth_params, "20130524", "20130524T000000Z");
+	auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT, S3RequestQuery(),
+	                                            RequestType::GET_REQUEST, auth_params, "20130524", "20130524T000000Z");
 
 	REQUIRE(headers.GetHeaderValue("Host") == "examplebucket.s3.amazonaws.com");
 	REQUIRE(headers.GetHeaderValue("x-amz-content-sha256") ==
@@ -1621,13 +1836,11 @@ TEST_CASE("S3 request signing includes optional headers", "[httpfs][s3][signing]
 	auth_params.session_token = "token";
 	auth_params.kms_key_id = "kms-key";
 	auth_params.requester_pays = true;
-	ParsedS3Url parsed_url;
-	parsed_url.path = "/bucket/key";
-	parsed_url.host = "bucket.example.com";
+	auto parsed_url = ParseTestS3Url("s3://bucket/key", "bucket.example.com", "path");
 
-	auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestQuery(), RequestType::PUT_REQUEST,
-	                                            auth_params, "20260730", "20260730T120000Z", "",
-	                                            "application/octet-stream", "content-md5");
+	auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT, S3RequestQuery(),
+	                                            RequestType::PUT_REQUEST, auth_params, "20260730", "20260730T120000Z",
+	                                            "", "application/octet-stream", "content-md5");
 
 	REQUIRE(headers.GetHeaderValue("x-amz-security-token") == "token");
 	REQUIRE(headers.GetHeaderValue("x-amz-request-payer") == "requester");
@@ -1642,9 +1855,7 @@ TEST_CASE("S3 request signing includes optional headers", "[httpfs][s3][signing]
 
 TEST_CASE("GCS billing projects are applied across authentication modes", "[httpfs][s3][gcs][requester-pays]") {
 	::AESStateSSLFactory encryption_util;
-	ParsedS3Url parsed_url;
-	parsed_url.path = "/bucket/key";
-	parsed_url.host = "storage.googleapis.com";
+	auto parsed_url = ParseTestS3Url("s3://bucket/key", "storage.googleapis.com", "path");
 	const array<RequestType, 5> request_types {RequestType::GET_REQUEST, RequestType::HEAD_REQUEST,
 	                                           RequestType::PUT_REQUEST, RequestType::POST_REQUEST,
 	                                           RequestType::DELETE_REQUEST};
@@ -1658,8 +1869,9 @@ TEST_CASE("GCS billing projects are applied across authentication modes", "[http
 		auth_params.requester_pays = true;
 		auth_params.user_project = "billing-project";
 		for (const auto request_type : request_types) {
-			auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestQuery(), request_type,
-			                                            auth_params, "20260902", "20260902T120000Z");
+			auto headers =
+			    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT, S3RequestQuery(),
+			                                 request_type, auth_params, "20260902", "20260902T120000Z");
 			REQUIRE(headers.GetHeaderValue("x-goog-user-project") == "billing-project");
 			REQUIRE_FALSE(headers.HasHeader("x-amz-request-payer"));
 			REQUIRE(StringUtil::Contains(headers.GetHeaderValue("Authorization"), "x-goog-user-project"));
@@ -1672,8 +1884,8 @@ TEST_CASE("GCS billing projects are applied across authentication modes", "[http
 		bearer.oauth2_bearer_token = "gcs-token";
 		bearer.user_project = "billing-project";
 		for (const auto request_type : request_types) {
-			auto headers =
-			    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestQuery(), request_type, bearer);
+			auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
+			                                            S3RequestQuery(), request_type, bearer);
 			REQUIRE(headers.GetHeaderValue("x-goog-user-project") == "billing-project");
 			REQUIRE(headers.GetHeaderValue("Authorization") == "Bearer gcs-token");
 			REQUIRE_FALSE(headers.HasHeader("x-amz-request-payer"));
@@ -1682,8 +1894,8 @@ TEST_CASE("GCS billing projects are applied across authentication modes", "[http
 		S3AuthParams anonymous;
 		anonymous.provider_type = S3ProviderType::GCS;
 		anonymous.user_project = "billing-project";
-		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestQuery(),
-		                                            RequestType::GET_REQUEST, anonymous);
+		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
+		                                            S3RequestQuery(), RequestType::GET_REQUEST, anonymous);
 		REQUIRE(headers.GetHeaderValue("x-goog-user-project") == "billing-project");
 		REQUIRE_FALSE(headers.HasHeader("Authorization"));
 	}
@@ -1692,8 +1904,8 @@ TEST_CASE("GCS billing projects are applied across authentication modes", "[http
 		S3AuthParams auth_params;
 		auth_params.provider_type = S3ProviderType::GCS;
 		auth_params.oauth2_bearer_token = "gcs-token";
-		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestQuery(),
-		                                            RequestType::GET_REQUEST, auth_params);
+		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
+		                                            S3RequestQuery(), RequestType::GET_REQUEST, auth_params);
 		REQUIRE_FALSE(headers.HasHeader("x-goog-user-project"));
 	}
 
@@ -1701,12 +1913,14 @@ TEST_CASE("GCS billing projects are applied across authentication modes", "[http
 		unordered_map<string, string> extra_headers {{"X-GoOg-UsEr-PrOjEcT", "configured-project"}};
 		S3AuthParams gcs;
 		gcs.provider_type = S3ProviderType::GCS;
-		REQUIRE_THROWS(S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestQuery(),
-		                                            RequestType::GET_REQUEST, gcs, "", "", "", "", "", extra_headers));
+		REQUIRE_THROWS(S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
+		                                            S3RequestQuery(), RequestType::GET_REQUEST, gcs, "", "", "", "", "",
+		                                            extra_headers));
 
 		S3AuthParams s3;
-		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestQuery(),
-		                                            RequestType::GET_REQUEST, s3, "", "", "", "", "", extra_headers);
+		auto headers =
+		    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT, S3RequestQuery(),
+		                                 RequestType::GET_REQUEST, s3, "", "", "", "", "", extra_headers);
 		REQUIRE(headers.GetHeaderValue("X-GoOg-UsEr-PrOjEcT") == "configured-project");
 	}
 
@@ -1718,8 +1932,8 @@ TEST_CASE("GCS billing projects are applied across authentication modes", "[http
 		auth_params.secret_access_key = "secret";
 		auth_params.requester_pays = true;
 		auto headers =
-		    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestQuery(), RequestType::GET_REQUEST,
-		                                 auth_params, "20260902", "20260902T120000Z");
+		    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT, S3RequestQuery(),
+		                                 RequestType::GET_REQUEST, auth_params, "20260902", "20260902T120000Z");
 		REQUIRE(headers.GetHeaderValue("x-amz-request-payer") == "requester");
 		REQUIRE_FALSE(headers.HasHeader("x-goog-user-project"));
 	}
@@ -1731,19 +1945,17 @@ TEST_CASE("S3 request signing canonicalizes configured extension headers", "[htt
 	auth_params.region = "us-east-1";
 	auth_params.access_key_id = "key";
 	auth_params.secret_access_key = "secret";
-	ParsedS3Url parsed_url;
-	parsed_url.path = "/bucket/key";
-	parsed_url.host = "bucket.example.com";
+	auto parsed_url = ParseTestS3Url("s3://bucket/key", "bucket.example.com", "path");
 	unordered_map<string, string> raw_headers {
 	    {"X-AmZ-Meta-Color", "\t blue  green \t"}, {"x-GoOg-Meta-Mode", "  fast\tmode  "}, {"X-Ordinary", "value"}};
 	unordered_map<string, string> normalized_headers {
 	    {"x-amz-meta-color", "blue green"}, {"X-GOOG-META-MODE", "fast mode"}, {"X-Ordinary", "value"}};
 
-	auto raw = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestQuery(), RequestType::GET_REQUEST,
-	                                        auth_params, "20260831", "20260831T120000Z", "", "", "", raw_headers,
-	                                        "httpfs-agent");
-	auto normalized = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestQuery(),
-	                                               RequestType::GET_REQUEST, auth_params, "20260831",
+	auto raw = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT, S3RequestQuery(),
+	                                        RequestType::GET_REQUEST, auth_params, "20260831", "20260831T120000Z", "",
+	                                        "", "", raw_headers, "httpfs-agent");
+	auto normalized = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
+	                                               S3RequestQuery(), RequestType::GET_REQUEST, auth_params, "20260831",
 	                                               "20260831T120000Z", "", "", "", normalized_headers, "httpfs-agent");
 
 	const auto &authorization = raw.GetHeaderValue("Authorization");
@@ -1772,17 +1984,16 @@ TEST_CASE("S3 request signing preserves empty configured extension headers", "[h
 	auth_params.region = "us-east-1";
 	auth_params.access_key_id = "key";
 	auth_params.secret_access_key = "secret";
-	ParsedS3Url parsed_url;
-	parsed_url.path = "/bucket/key";
-	parsed_url.host = "bucket.example.com";
+	auto parsed_url = ParseTestS3Url("s3://bucket/key", "bucket.example.com", "path");
 	unordered_map<string, string> raw_headers {{"X-AmZ-Meta-Empty", ""}, {"x-GoOg-Meta-Whitespace", "\t  \t"}};
 	unordered_map<string, string> normalized_headers {{"x-amz-meta-empty", ""}, {"X-GOOG-META-WHITESPACE", ""}};
 
-	auto raw = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestQuery(), RequestType::GET_REQUEST,
-	                                        auth_params, "20260831", "20260831T120000Z", "", "", "", raw_headers);
-	auto normalized =
-	    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestQuery(), RequestType::GET_REQUEST,
-	                                 auth_params, "20260831", "20260831T120000Z", "", "", "", normalized_headers);
+	auto raw = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT, S3RequestQuery(),
+	                                        RequestType::GET_REQUEST, auth_params, "20260831", "20260831T120000Z", "",
+	                                        "", "", raw_headers);
+	auto normalized = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
+	                                               S3RequestQuery(), RequestType::GET_REQUEST, auth_params, "20260831",
+	                                               "20260831T120000Z", "", "", "", normalized_headers);
 
 	const auto &authorization = raw.GetHeaderValue("Authorization");
 	REQUIRE(authorization == normalized.GetHeaderValue("Authorization"));
@@ -1800,18 +2011,16 @@ TEST_CASE("S3 request signing changes configured headers after a region redirect
 	auth_params.region = "us-east-1";
 	auth_params.access_key_id = "key";
 	auth_params.secret_access_key = "secret";
-	ParsedS3Url parsed_url;
-	parsed_url.path = "/bucket/key";
-	parsed_url.host = "bucket.example.com";
+	auto parsed_url = ParseTestS3Url("s3://bucket/key", "bucket.example.com", "path");
 	unordered_map<string, string> extra_headers {{"X-AmZ-Meta-Region", "region-value"}};
 
-	auto us_east_1 =
-	    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestQuery(), RequestType::GET_REQUEST,
-	                                 auth_params, "20260831", "20260831T120000Z", "", "", "", extra_headers);
+	auto us_east_1 = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
+	                                              S3RequestQuery(), RequestType::GET_REQUEST, auth_params, "20260831",
+	                                              "20260831T120000Z", "", "", "", extra_headers);
 	auth_params.region = "eu-west-1";
-	auto eu_west_1 =
-	    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestQuery(), RequestType::GET_REQUEST,
-	                                 auth_params, "20260831", "20260831T120000Z", "", "", "", extra_headers);
+	auto eu_west_1 = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
+	                                              S3RequestQuery(), RequestType::GET_REQUEST, auth_params, "20260831",
+	                                              "20260831T120000Z", "", "", "", extra_headers);
 
 	const auto &us_authorization = us_east_1.GetHeaderValue("Authorization");
 	const auto &eu_authorization = eu_west_1.GetHeaderValue("Authorization");
@@ -1853,23 +2062,23 @@ TEST_CASE("S3 request queries share canonical and wire encoding", "[httpfs][s3][
 		auth_params.region = "us-east-1";
 		auth_params.access_key_id = "key";
 		auth_params.secret_access_key = "secret";
-		ParsedS3Url parsed_url;
-		parsed_url.path = "/bucket/key";
-		parsed_url.host = "bucket.example.com";
-		auto first = S3RequestUtil::CreateHeaders(
-		    encryption_util, parsed_url, S3RequestQuery({{"uploadId", "opaque&id"}, {"partNumber", "12"}}),
-		    RequestType::PUT_REQUEST, auth_params, "20260806", "20260806T120000Z");
-		auto second = S3RequestUtil::CreateHeaders(
-		    encryption_util, parsed_url, S3RequestQuery({{"partNumber", "12"}, {"uploadId", "opaque&id"}}),
-		    RequestType::PUT_REQUEST, auth_params, "20260806", "20260806T120000Z");
+		auto parsed_url = ParseTestS3Url("s3://bucket/key", "bucket.example.com", "path");
+		auto first =
+		    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
+		                                 S3RequestQuery({{"uploadId", "opaque&id"}, {"partNumber", "12"}}),
+		                                 RequestType::PUT_REQUEST, auth_params, "20260806", "20260806T120000Z");
+		auto second =
+		    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
+		                                 S3RequestQuery({{"partNumber", "12"}, {"uploadId", "opaque&id"}}),
+		                                 RequestType::PUT_REQUEST, auth_params, "20260806", "20260806T120000Z");
 		REQUIRE(first.GetHeaderValue("Authorization") == second.GetHeaderValue("Authorization"));
 		REQUIRE(first.GetHeaderValue("Authorization") ==
 		        "AWS4-HMAC-SHA256 Credential=key/20260806/us-east-1/s3/aws4_request, "
 		        "SignedHeaders=host;x-amz-content-sha256;x-amz-date, "
 		        "Signature=7d31006078e4c8754eb70f96358af8f4c84a60186bf8e8fe1605b9bb90fcffad");
 		auto empty_query =
-		    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestQuery(), RequestType::PUT_REQUEST,
-		                                 auth_params, "20260806", "20260806T120000Z");
+		    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT, S3RequestQuery(),
+		                                 RequestType::PUT_REQUEST, auth_params, "20260806", "20260806T120000Z");
 		REQUIRE(first.GetHeaderValue("Authorization") != empty_query.GetHeaderValue("Authorization"));
 	}
 }
@@ -2007,6 +2216,16 @@ TEST_CASE("S3 request sessions reject conflicting configured headers before HTTP
 	}
 	SECTION("curl") {
 		RunS3RejectedHeaderScenario("curl");
+	}
+}
+
+TEST_CASE("S3 full HTTP endpoints route every request through the normalized base path",
+          "[httpfs][s3][endpoint][request]") {
+	SECTION("httplib") {
+		RunNormalizedEndpointWireScenario("httplib");
+	}
+	SECTION("curl") {
+		RunNormalizedEndpointWireScenario("curl");
 	}
 }
 

--- a/test/unittest/s3/scheme_alias_isolation_test.cpp
+++ b/test/unittest/s3/scheme_alias_isolation_test.cpp
@@ -79,7 +79,7 @@ TEST_CASE("a required endpoint may arrive from any source, but must arrive", "[h
 			auto params = make_params(test_case);
 			// Reading secrets and settings leaves it unresolved rather than deriving an AWS endpoint
 			S3Provider::InitializeAuthParams(params);
-			REQUIRE(params.endpoint.empty());
+			REQUIRE(params.GetEndpoint().IsEmpty());
 			REQUIRE_THROWS(S3Url::Resolve(test_case.url, params));
 		}
 	}
@@ -89,9 +89,9 @@ TEST_CASE("a required endpoint may arrive from any source, but must arrive", "[h
 			auto params = make_params(test_case);
 			S3Provider::InitializeAuthParams(params);
 			auto parsed = S3Url::Resolve(string(test_case.url) + "?s3_endpoint=storage.example.com", params);
-			REQUIRE(params.endpoint == "storage.example.com");
+			REQUIRE(params.GetEndpoint().GetHost() == "storage.example.com");
 			REQUIRE(params.endpoint_mode == S3EndpointMode::EXPLICIT);
-			REQUIRE(parsed.host == "bucket.storage.example.com");
+			REQUIRE(parsed.GetHost() == "bucket.storage.example.com");
 		}
 	}
 
@@ -110,7 +110,7 @@ TEST_CASE("a required endpoint may arrive from any source, but must arrive", "[h
 		S3AuthParams params;
 		S3Provider::InitializeAuthParams(params);
 		S3Provider::FinalizeAuthParams(params);
-		REQUIRE(params.endpoint == "s3.amazonaws.com");
+		REQUIRE(params.GetEndpoint().GetHost() == "s3.amazonaws.com");
 	}
 }
 


### PR DESCRIPTION
This adds normalized S3 endpoint handling, including full HTTP(S) URLs, base paths, ports, and IPv6. URL construction and signing now share the same parsed endpoint state.