### PR TITLE
Refactoring/cleanup

### DIFF
--- a/src/create_secret_functions.cpp
+++ b/src/create_secret_functions.cpp
@@ -8,7 +8,7 @@
 namespace duckdb {
 
 void CreateS3SecretFunctions::Register(ExtensionLoader &loader) {
-	for (const auto secret_type : S3Provider::SecretTypes()) {
+	for (const auto secret_type : S3SecretConfig::SecretTypes()) {
 		RegisterCreateSecretFunction(loader, secret_type);
 	}
 }
@@ -31,15 +31,15 @@ static Value MapToStruct(const Value &map) {
 struct S3SecretBuilder {
 public:
 	explicit S3SecretBuilder(CreateSecretInput &input_p) : input(input_p) {
-		auto scope =
-		    input.scope.empty() ? S3Provider::DefaultSecretScope(static_cast<const string &>(input.type)) : input.scope;
+		auto scope = input.scope.empty() ? S3SecretConfig::DefaultSecretScope(static_cast<const string &>(input.type))
+		                                 : input.scope;
 		secret = make_uniq<KeyValueSecret>(std::move(scope), input.type, input.provider, input.name);
 		secret->redact_keys = {"secret", "session_token"};
 	}
 
 public:
 	unique_ptr<BaseSecret> Create() {
-		S3Provider::ApplySecretDefaults(input, *secret);
+		S3SecretConfig::ApplySecretDefaults(input, *secret);
 		for (const auto &option : input.options) {
 			ApplyOption(StringUtil::Lower(option.first), option.second);
 		}
@@ -55,7 +55,7 @@ private:
 			secret->secret_map[Identifier(name)] = value.ToString();
 		} else if (name == "url_style") {
 			auto url_style = StringUtil::Lower(value.ToString());
-			S3Provider::ParseURLStyle(url_style);
+			S3AuthURLParams::ParseStyle(url_style);
 			secret->secret_map[Identifier(name)] = std::move(url_style);
 		} else if (name == "use_ssl" || name == "verify_ssl" || name == "url_compatibility_mode" ||
 		           name == "requester_pays") {
@@ -64,7 +64,7 @@ private:
 			SetRefresh(value);
 		} else if (name == "refresh_info") {
 			SetRefreshInfo(value);
-		} else if (S3Provider::TryApplySecretOption(input, name, value, *secret)) {
+		} else if (S3SecretConfig::TryApplySecretOption(input, name, value, *secret)) {
 			return;
 		} else {
 			throw InvalidInputException("Unknown named parameter passed to CreateSecretFunctionInternal: " + name);
@@ -140,7 +140,7 @@ CreateSecretInput CreateS3SecretFunctions::GenerateRefreshSecretInfo(const Secre
 }
 
 static bool SecretCredentialMaterialChanged(const KeyValueSecret &old_secret, const KeyValueSecret &new_secret) {
-	for (const auto key : S3Provider::CredentialMaterialKeys()) {
+	for (const auto key : S3SecretConfig::CredentialMaterialKeys()) {
 		Value old_value;
 		Value new_value;
 		auto old_has_value = old_secret.TryGetValue(key, old_value);
@@ -222,7 +222,7 @@ void CreateS3SecretFunctions::SetBaseNamedParams(CreateSecretFunction &function,
 	// Debugging/testing option: it allows specifying how the secret will be refreshed using a manually specfied MAP
 	function.named_parameters["refresh_info"] = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR);
 
-	S3Provider::SetSecretNamedParameters(type, function);
+	S3SecretConfig::SetSecretNamedParameters(type, function);
 }
 
 void CreateS3SecretFunctions::RegisterCreateSecretFunction(ExtensionLoader &loader, string type) {

--- a/src/hffs.cpp
+++ b/src/hffs.cpp
@@ -1,23 +1,21 @@
 #include "hffs.hpp"
 
-#include "duckdb/common/atomic.hpp"
 #include "duckdb/common/exception/http_exception.hpp"
 #include "duckdb/common/file_opener.hpp"
-#include "http/http_state.hpp"
-#include "duckdb/common/types/hash.hpp"
-#include "duckdb/main/database.hpp"
+#include "duckdb/common/path.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/function/scalar/string_common.hpp"
 
-#include <chrono>
+#include <sstream>
 #include <string>
-
-#include <map>
 
 namespace duckdb {
 
-HuggingFaceFileSystem::~HuggingFaceFileSystem() {
+static string JoinHFPath(const string &base, const string &path) {
+	return Path::FromString(base).Join(path).ToString();
 }
+
+HuggingFaceFileSystem::~HuggingFaceFileSystem() = default;
 
 static string ParseNextUrlFromLinkHeader(const string &link_header_content) {
 	auto split_outer = StringUtil::Split(link_header_content, ',');
@@ -42,11 +40,9 @@ static string ParseNextUrlFromLinkHeader(const string &link_header_content) {
 	throw IOException("Failed to parse Link header for paginated response, pagination support");
 }
 
-HFFileHandle::~HFFileHandle() {
-}
+HFFileHandle::~HFFileHandle() = default;
 
-string HuggingFaceFileSystem::ListHFRequest(ParsedHFUrl &url, HTTPFSParams &http_params, string &next_page_url,
-                                            optional_ptr<HTTPState> state) {
+string HuggingFaceFileSystem::ListHFRequest(const ParsedHFUrl &url, HTTPFSParams &http_params, string &next_page_url) {
 	HTTPHeaders header_map;
 	string link_header_result;
 
@@ -255,8 +251,6 @@ vector<OpenFileInfo> HuggingFaceFileSystem::Glob(const string &path, FileOpener 
 	auto params = http_util.InitializeParameters(opener, info);
 	auto &http_params = params->Cast<HTTPFSParams>();
 	SetParams(http_params, path, opener);
-	auto http_state = HTTPState::TryGetState(opener);
-
 	ParsedHFUrl curr_hf_path = parsed_glob_url;
 	curr_hf_path.path = shared_path;
 
@@ -276,7 +270,7 @@ vector<OpenFileInfo> HuggingFaceFileSystem::Glob(const string &path, FileOpener 
 			break;
 		}
 
-		auto response_str = ListHFRequest(curr_hf_path, http_params, next_page_url, http_state);
+		auto response_str = ListHFRequest(curr_hf_path, http_params, next_page_url);
 		ParseListResult(response_str, files, dirs);
 	}
 
@@ -421,11 +415,11 @@ string HuggingFaceFileSystem::GetTreeUrl(const ParsedHFUrl &url, idx_t limit) {
 	//! Url format {endpoint}/api/{repo_type}/{repository}/tree/{revision}{encoded_path_in_repo}
 	string http_url = url.endpoint;
 
-	http_url = JoinPath(http_url, "api");
-	http_url = JoinPath(http_url, url.repo_type);
-	http_url = JoinPath(http_url, url.repository);
-	http_url = JoinPath(http_url, "tree");
-	http_url = JoinPath(http_url, url.revision);
+	http_url = JoinHFPath(http_url, "api");
+	http_url = JoinHFPath(http_url, url.repo_type);
+	http_url = JoinHFPath(http_url, url.repository);
+	http_url = JoinHFPath(http_url, "tree");
+	http_url = JoinHFPath(http_url, url.revision);
 	http_url += url.path;
 
 	if (limit > 0) {
@@ -438,10 +432,10 @@ string HuggingFaceFileSystem::GetTreeUrl(const ParsedHFUrl &url, idx_t limit) {
 string HuggingFaceFileSystem::GetFileUrl(const ParsedHFUrl &url) {
 	//! Url format {endpoint}/{repo_type}[/{repository}/{revision}{encoded_path_in_repo}
 	string http_url = url.endpoint;
-	http_url = JoinPath(http_url, url.repo_type);
-	http_url = JoinPath(http_url, url.repository);
-	http_url = JoinPath(http_url, "resolve");
-	http_url = JoinPath(http_url, url.revision);
+	http_url = JoinHFPath(http_url, url.repo_type);
+	http_url = JoinHFPath(http_url, url.repository);
+	http_url = JoinHFPath(http_url, "resolve");
+	http_url = JoinHFPath(http_url, url.revision);
 	http_url += url.path;
 
 	return http_url;

--- a/src/http/http_request.cpp
+++ b/src/http/http_request.cpp
@@ -291,20 +291,18 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh,
 unique_ptr<HTTPResponse> HTTPFileSystem::HeadRequest(FileHandle &handle, const string &url, HTTPHeaders header_map) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
 	auto captured = hfh.request_session->Capture();
-	captured.snapshot->AddConfiguredHeaders(header_map);
-	auto request_params = captured.snapshot->CreateRequestParams();
-	return RunHeadRequest(url, header_map, *request_params, [&](BaseRequest &request) {
-		return SendSessionRequest(*hfh.request_session, captured, *request_params, request);
+	auto session_request = captured.snapshot->CreateRequest(std::move(header_map));
+	return RunHeadRequest(url, session_request.headers, *session_request.params, [&](BaseRequest &request) {
+		return SendSessionRequest(*hfh.request_session, captured, *session_request.params, request);
 	});
 }
 
 unique_ptr<HTTPResponse> HTTPFileSystem::DeleteRequest(FileHandle &handle, const string &url, HTTPHeaders header_map) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
 	auto captured = hfh.request_session->Capture();
-	captured.snapshot->AddConfiguredHeaders(header_map);
-	auto request_params = captured.snapshot->CreateRequestParams();
-	return RunDeleteRequest(url, header_map, *request_params, [&](BaseRequest &request) {
-		return SendSessionRequest(*hfh.request_session, captured, *request_params, request);
+	auto session_request = captured.snapshot->CreateRequest(std::move(header_map));
+	return RunDeleteRequest(url, session_request.headers, *session_request.params, [&](BaseRequest &request) {
+		return SendSessionRequest(*hfh.request_session, captured, *session_request.params, request);
 	});
 }
 
@@ -377,13 +375,12 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRequest(FileHandle &handle, string u
                                                     const HTTPReadConfig &read_config, CachedFileDownload &download) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
 	auto captured = hfh.request_session->Capture();
-	captured.snapshot->AddConfiguredHeaders(header_map);
-	auto request_params = captured.snapshot->CreateRequestParams();
+	auto session_request = captured.snapshot->CreateRequest(std::move(header_map));
 	return RunGetRequest(
-	    hfh, url, header_map, *request_params, read_config, download,
+	    hfh, url, session_request.headers, *session_request.params, read_config, download,
 	    [&](const HTTPResponse &response) { return GetHTTPError(handle, response, RequestType::GET_REQUEST, url); },
 	    [&](BaseRequest &request) {
-		    return SendSessionRequest(*hfh.request_session, captured, *request_params, request);
+		    return SendSessionRequest(*hfh.request_session, captured, *session_request.params, request);
 	    });
 }
 
@@ -392,13 +389,13 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
                                                          data_ptr_t buffer_out, idx_t buffer_out_len) {
 	auto &hfh = handle.Cast<HTTPFileHandle>();
 	auto captured = hfh.request_session->Capture();
-	captured.snapshot->AddConfiguredHeaders(header_map);
-	auto request_params = captured.snapshot->CreateRequestParams();
+	auto session_request = captured.snapshot->CreateRequest(std::move(header_map));
 	return RunGetRangeRequest(
-	    hfh, url, header_map, *request_params, read_config, file_offset, buffer_out, buffer_out_len,
+	    hfh, url, session_request.headers, *session_request.params, read_config, file_offset, buffer_out,
+	    buffer_out_len,
 	    [&](const HTTPResponse &response) { return GetHTTPError(handle, response, RequestType::GET_REQUEST, url); },
 	    [&](BaseRequest &request) {
-		    return SendSessionRequest(*hfh.request_session, captured, *request_params, request);
+		    return SendSessionRequest(*hfh.request_session, captured, *session_request.params, request);
 	    });
 }
 

--- a/src/http/http_request_session.cpp
+++ b/src/http/http_request_session.cpp
@@ -15,19 +15,19 @@ bool HTTPRequestSnapshot::CanReuseClientsWith(const HTTPRequestSnapshot &other) 
 	       params.client_reuse_mode == other.params.client_reuse_mode;
 }
 
-unique_ptr<HTTPFSParams> HTTPRequestSnapshot::CreateRequestParams() const {
-	auto result = make_uniq<HTTPFSParams>(params);
-	result->pre_merged_headers = true;
-	return result;
-}
-
-void HTTPRequestSnapshot::AddConfiguredHeaders(HTTPHeaders &headers) const {
-	if (!params.user_agent.empty()) {
-		headers.Insert("User-Agent", params.user_agent);
+HTTPSessionRequest HTTPRequestSnapshot::CreateRequest(HTTPHeaders headers) const {
+	auto request_params = make_uniq<HTTPFSParams>(params);
+	HTTPConfiguredHeaders configured_headers {std::move(request_params->user_agent),
+	                                          std::move(request_params->extra_headers)};
+	request_params->user_agent.clear();
+	request_params->extra_headers.clear();
+	if (!configured_headers.user_agent.empty()) {
+		headers.Insert("User-Agent", configured_headers.user_agent);
 	}
-	for (const auto &header : params.extra_headers) {
+	for (const auto &header : configured_headers.extra_headers) {
 		headers[header.first] = header.second;
 	}
+	return {std::move(headers), std::move(request_params), std::move(configured_headers)};
 }
 
 HTTPClientLease::HTTPClientLease(shared_ptr<HTTPRequestSession> session_p, reference<HTTPUtil> http_util_p,

--- a/src/http/http_settings.cpp
+++ b/src/http/http_settings.cpp
@@ -68,7 +68,7 @@ static void SetHTTPConnectionCaching(ClientContext &context, SetScope, Value &pa
 	auto &http_util = DBConfig::GetConfig(context).GetHTTPUtil();
 	if (http_util.GetName() == "HTTPFS-Curl") {
 		auto &curl_util = http_util.Cast<HTTPFSCurlUtil>();
-		curl_util.connection_caching_enabled = BooleanValue::Get(parameter);
+		curl_util.SetConnectionCachingEnabled(BooleanValue::Get(parameter));
 	}
 #endif
 }

--- a/src/http/http_state.cpp
+++ b/src/http/http_state.cpp
@@ -1,7 +1,13 @@
 #include "http/http_state.hpp"
+#include "duckdb/common/http_util.hpp"
 #include "duckdb/main/query_profiler.hpp"
 
 namespace duckdb {
+
+bool HTTPStateCounters::IsEmpty() const {
+	return head_count == 0 && get_count == 0 && put_count == 0 && post_count == 0 && delete_count == 0 &&
+	       options_count == 0 && total_bytes_received == 0 && total_bytes_sent == 0;
+}
 
 unique_ptr<CachedFileHandle> CachedFile::TryGetHandle() {
 	annotated_lock_guard<annotated_mutex> guard(lock);
@@ -123,12 +129,63 @@ void HTTPState::Reset() {
 	put_count = 0;
 	post_count = 0;
 	delete_count = 0;
+	options_count = 0;
 	total_bytes_received = 0;
 	total_bytes_sent = 0;
 
 	// Reset per-path state
 	annotated_lock_guard<annotated_mutex> lock(file_states_mutex);
 	file_states.clear();
+}
+
+void HTTPState::RecordRequest(RequestType request_type) {
+	switch (request_type) {
+	case RequestType::HEAD_REQUEST:
+		head_count++;
+		break;
+	case RequestType::GET_REQUEST:
+		get_count++;
+		break;
+	case RequestType::PUT_REQUEST:
+		put_count++;
+		break;
+	case RequestType::POST_REQUEST:
+		post_count++;
+		break;
+	case RequestType::DELETE_REQUEST:
+		delete_count++;
+		break;
+	case RequestType::OPTIONS_REQUEST:
+		options_count++;
+		break;
+	default:
+		throw InternalException("Unsupported HTTP request type");
+	}
+}
+
+void HTTPState::RecordBytesReceived(idx_t byte_count) {
+	total_bytes_received += byte_count;
+}
+
+void HTTPState::RecordBytesSent(idx_t byte_count) {
+	total_bytes_sent += byte_count;
+}
+
+HTTPStateCounters HTTPState::GetCounters() const {
+	HTTPStateCounters result;
+	result.head_count = head_count.load();
+	result.get_count = get_count.load();
+	result.put_count = put_count.load();
+	result.post_count = post_count.load();
+	result.delete_count = delete_count.load();
+	result.options_count = options_count.load();
+	result.total_bytes_received = total_bytes_received.load();
+	result.total_bytes_sent = total_bytes_sent.load();
+	return result;
+}
+
+bool HTTPState::IsEmpty() const {
+	return GetCounters().IsEmpty();
 }
 
 shared_ptr<HTTPState> HTTPState::TryGetState(ClientContext &context) {
@@ -144,13 +201,15 @@ shared_ptr<HTTPState> HTTPState::TryGetState(optional_ptr<FileOpener> opener) {
 }
 
 void HTTPState::WriteProfilingInformation(std::ostream &ss) {
-	string read = "in: " + StringUtil::BytesToHumanReadableString(total_bytes_received);
-	string written = "out: " + StringUtil::BytesToHumanReadableString(total_bytes_sent);
-	string head = "#HEAD: " + to_string(head_count);
-	string get = "#GET: " + to_string(get_count);
-	string put = "#PUT: " + to_string(put_count);
-	string post = "#POST: " + to_string(post_count);
-	string del = "#DELETE: " + to_string(delete_count);
+	auto counters = GetCounters();
+	string read = "in: " + StringUtil::BytesToHumanReadableString(counters.total_bytes_received);
+	string written = "out: " + StringUtil::BytesToHumanReadableString(counters.total_bytes_sent);
+	string head = "#HEAD: " + to_string(counters.head_count);
+	string get = "#GET: " + to_string(counters.get_count);
+	string put = "#PUT: " + to_string(counters.put_count);
+	string post = "#POST: " + to_string(counters.post_count);
+	string del = "#DELETE: " + to_string(counters.delete_count);
+	string options = "#OPTIONS: " + to_string(counters.options_count);
 
 	constexpr idx_t TOTAL_BOX_WIDTH = 39;
 	ss << "┌─────────────────────────────────────┐\n";
@@ -164,6 +223,7 @@ void HTTPState::WriteProfilingInformation(std::ostream &ss) {
 	ss << "││" + QueryProfiler::DrawPadded(put, TOTAL_BOX_WIDTH - 4) + "││\n";
 	ss << "││" + QueryProfiler::DrawPadded(post, TOTAL_BOX_WIDTH - 4) + "││\n";
 	ss << "││" + QueryProfiler::DrawPadded(del, TOTAL_BOX_WIDTH - 4) + "││\n";
+	ss << "││" + QueryProfiler::DrawPadded(options, TOTAL_BOX_WIDTH - 4) + "││\n";
 	ss << "│└───────────────────────────────────┘│\n";
 	ss << "└─────────────────────────────────────┘\n";
 }

--- a/src/http/httpfs.cpp
+++ b/src/http/httpfs.cpp
@@ -129,13 +129,13 @@ private:
 			return false;
 		}
 		auto db = FileOpener::TryGetDatabase(opener);
-		auto aliases = db ? S3Provider::GetSchemeAliasPrefixes(db->config) : vector<string>();
-		return S3Provider::TryMatchUrl(info->file_path, aliases).has_value();
+		auto aliases = db ? S3UrlScheme::GetAliasPrefixes(db->config) : vector<string>();
+		return S3UrlScheme::TryMatch(info->file_path, aliases).has_value();
 	}
 
 	unique_ptr<KeyValueSecretReader> CreateSettingsReader() {
 		if (IsS3Path()) {
-			auto provider_secret_types = S3Provider::SecretTypes();
+			auto provider_secret_types = S3SecretConfig::SecretTypes();
 			vector<const char *> s3_secret_types(provider_secret_types.begin(), provider_secret_types.end());
 			s3_secret_types.push_back("http");
 			idx_t secret_type_count = s3_secret_types.size();

--- a/src/http/httpfs.cpp
+++ b/src/http/httpfs.cpp
@@ -822,12 +822,12 @@ void HTTPFileHandle::InitializeRequestState(optional_ptr<FileOpener> opener) {
 		buffer_allocator = database ? BufferAllocator::Get(*database) : Allocator::DefaultAllocator();
 	}
 	auto captured = request_session->Capture();
-	auto request_params = captured.snapshot->CreateRequestParams();
-	request_params->state = HTTPState::TryGetState(opener);
-	if (!request_params->state) {
-		request_params->state = make_shared_ptr<HTTPState>();
+	auto snapshot_params = captured.snapshot->Params();
+	snapshot_params.state = HTTPState::TryGetState(opener);
+	if (!snapshot_params.state) {
+		snapshot_params.state = make_shared_ptr<HTTPState>();
 	}
-	request_session->TryPublish(captured.snapshot, CreateRequestSnapshot(*request_params));
+	request_session->TryPublish(captured.snapshot, CreateRequestSnapshot(snapshot_params));
 	auto request_snapshot = request_session->Capture().snapshot;
 	file_state = request_snapshot->Params().state->GetFileState(path);
 

--- a/src/http/httpfs_connection_caching.cpp
+++ b/src/http/httpfs_connection_caching.cpp
@@ -90,8 +90,8 @@ void HTTPClientConnectionCache::Clear() {
 // HTTPFSCurlUtil — connection caching
 //===--------------------------------------------------------------------===//
 
-bool HTTPFSCurlUtil::EnableCaching(BaseRequest &request) {
-	if (!connection_caching_enabled) {
+bool HTTPFSCurlUtil::EnableCaching(const BaseRequest &request) const {
+	if (!ConnectionCachingEnabled()) {
 		return false;
 	}
 	if (!request.params.http_proxy.empty()) {
@@ -100,21 +100,54 @@ bool HTTPFSCurlUtil::EnableCaching(BaseRequest &request) {
 	return true;
 }
 
+bool HTTPFSCurlUtil::ConnectionCachingEnabled() const {
+	return connection_caching_enabled.load();
+}
+
+unique_ptr<HTTPClient> HTTPFSCurlUtil::FindCachedClient(const string &base_url) {
+	if (!ConnectionCachingEnabled()) {
+		return nullptr;
+	}
+	auto client = connection_cache.Find(base_url);
+	if (!ConnectionCachingEnabled()) {
+		client.reset();
+	}
+	return client;
+}
+
+void HTTPFSCurlUtil::StoreCachedClient(unique_ptr<HTTPClient> &&client) {
+	if (!ConnectionCachingEnabled()) {
+		client.reset();
+		return;
+	}
+	connection_cache.Store(std::move(client));
+	if (!ConnectionCachingEnabled()) {
+		connection_cache.Clear();
+	}
+}
+
 void HTTPFSCurlUtil::ClearCachedConnections() {
 	connection_cache.Clear();
 }
 
 HTTPClientReuseMode HTTPFSCurlUtil::GetClientReuseMode() const {
-	return connection_caching_enabled ? HTTPClientReuseMode::SHARED : HTTPClientReuseMode::SESSION_LOCAL;
+	return ConnectionCachingEnabled() ? HTTPClientReuseMode::SHARED : HTTPClientReuseMode::SESSION_LOCAL;
+}
+
+void HTTPFSCurlUtil::SetConnectionCachingEnabled(bool enabled) {
+	connection_caching_enabled.store(enabled);
+	if (!enabled) {
+		ClearCachedConnections();
+	}
 }
 
 void HTTPFSCurlUtil::CloseClient(unique_ptr<HTTPClient> &&client) {
-	if (!client || !connection_caching_enabled) {
+	if (!client) {
 		return;
 	}
 	client->Cleanup();
 	// TODO: would be nice to log connection_cache_store here, but no logger is available at this call site
-	connection_cache.Store(std::move(client));
+	StoreCachedClient(std::move(client));
 }
 
 unique_ptr<HTTPResponse> HTTPFSCurlUtil::BaseSendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client) {
@@ -125,7 +158,7 @@ unique_ptr<HTTPResponse> HTTPFSCurlUtil::CachingSendRequest(BaseRequest &request
 	bool caller_owns_client = client != nullptr;
 
 	if (!client) {
-		auto cached_client = connection_cache.Find(request.proto_host_port);
+		auto cached_client = FindCachedClient(request.proto_host_port);
 		if (cached_client) {
 			if (request.params.logger &&
 			    request.params.logger->ShouldLog(HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL)) {
@@ -150,7 +183,7 @@ unique_ptr<HTTPResponse> HTTPFSCurlUtil::CachingSendRequest(BaseRequest &request
 	// Only cache if the caller didn't provide the client — otherwise the caller manages its lifecycle
 	if (!caller_owns_client) {
 		if (r && !r->HasRequestError()) {
-			connection_cache.Store(std::move(client));
+			StoreCachedClient(std::move(client));
 		} else {
 			client.reset();
 		}

--- a/src/http/httpfs_curl_client.cpp
+++ b/src/http/httpfs_curl_client.cpp
@@ -335,7 +335,7 @@ private:
 			}
 
 			if (client.state) {
-				client.state->total_bytes_received += bytes_received;
+				client.state->RecordBytesReceived(bytes_received);
 			}
 		}
 
@@ -379,7 +379,7 @@ public:
 		AddUserAgentIfAvailable(info.params.Cast<HTTPFSParams>(), info.headers);
 		ResetRequestInfo();
 		if (state) {
-			state->get_count++;
+			state->RecordRequest(RequestType::GET_REQUEST);
 		}
 
 		auto curl_headers = TransformHeadersCurl(info.headers, info.params);
@@ -405,8 +405,8 @@ public:
 		AddUserAgentIfAvailable(info.params.Cast<HTTPFSParams>(), info.headers);
 		ResetRequestInfo();
 		if (state) {
-			state->put_count++;
-			state->total_bytes_sent += info.buffer_in_len;
+			state->RecordRequest(RequestType::PUT_REQUEST);
+			state->RecordBytesSent(info.buffer_in_len);
 		}
 
 		auto curl_headers = TransformHeadersCurl(info.headers, info.params);
@@ -440,14 +440,14 @@ public:
 
 		curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, &request_info->response_code);
 
-		return TransformResponseCurl(res);
+		return TransformBufferedResponseCurl(res);
 	}
 
 	unique_ptr<HTTPResponse> Head(HeadRequestInfo &info) override {
 		AddUserAgentIfAvailable(info.params.Cast<HTTPFSParams>(), info.headers);
 		ResetRequestInfo();
 		if (state) {
-			state->head_count++;
+			state->RecordRequest(RequestType::HEAD_REQUEST);
 		}
 
 		auto curl_headers = TransformHeadersCurl(info.headers, info.params);
@@ -476,14 +476,14 @@ public:
 		}
 
 		curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, &request_info->response_code);
-		return TransformResponseCurl(res);
+		return TransformBufferedResponseCurl(res);
 	}
 
 	unique_ptr<HTTPResponse> Delete(DeleteRequestInfo &info) override {
 		AddUserAgentIfAvailable(info.params.Cast<HTTPFSParams>(), info.headers);
 		ResetRequestInfo();
 		if (state) {
-			state->delete_count++;
+			state->RecordRequest(RequestType::DELETE_REQUEST);
 		}
 		auto curl_headers = TransformHeadersCurl(info.headers, info.params);
 		// transform parameters
@@ -510,11 +510,14 @@ public:
 
 		// Get HTTP response status code
 		curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, &request_info->response_code);
-		return TransformResponseCurl(res);
+		return TransformBufferedResponseCurl(res);
 	}
 
 	unique_ptr<HTTPResponse> Options(OptionsRequestInfo &info) override {
 		ResetRequestInfo();
+		if (state) {
+			state->RecordRequest(RequestType::OPTIONS_REQUEST);
+		}
 		auto curl_headers = TransformHeadersCurl(info.headers, info.params);
 		request_info->url = info.url;
 
@@ -535,15 +538,15 @@ public:
 		}
 
 		curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, &request_info->response_code);
-		return TransformResponseCurl(res);
+		return TransformBufferedResponseCurl(res);
 	}
 
 	unique_ptr<HTTPResponse> Post(PostRequestInfo &info) override {
 		AddUserAgentIfAvailable(info.params.Cast<HTTPFSParams>(), info.headers);
 		ResetRequestInfo();
 		if (state) {
-			state->post_count++;
-			state->total_bytes_sent += info.buffer_in_len;
+			state->RecordRequest(RequestType::POST_REQUEST);
+			state->RecordBytesSent(info.buffer_in_len);
 		}
 
 		auto curl_headers = TransformHeadersCurl(info.headers, info.params);
@@ -584,13 +587,7 @@ public:
 		curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, &request_info->response_code);
 		info.buffer_out = request_info->body;
 
-		const idx_t bytes_received = request_info->body.size();
-		if (state) {
-			state->total_bytes_received += bytes_received;
-		}
-
-		// Construct HTTPResponse
-		return TransformResponseCurl(res);
+		return TransformBufferedResponseCurl(res);
 	}
 
 	void Cleanup() override {
@@ -656,6 +653,14 @@ private:
 		return response;
 	}
 
+	unique_ptr<HTTPResponse> TransformBufferedResponseCurl(CURLcode res) {
+		auto response = TransformResponseCurl(res);
+		if (state) {
+			state->RecordBytesReceived(request_info->body.size());
+		}
+		return response;
+	}
+
 	static void InitCurlGlobal() {
 		auto &state = GetCURLGlobalState();
 		annotated_lock_guard<annotated_mutex> lock(state.lock);
@@ -687,8 +692,8 @@ private:
 };
 
 unique_ptr<HTTPClient> HTTPFSCurlUtil::InitializeClient(HTTPParams &http_params, const string &proto_host_port) {
-	if (connection_caching_enabled) {
-		auto client = connection_cache.Find(proto_host_port);
+	if (ConnectionCachingEnabled()) {
+		auto client = FindCachedClient(proto_host_port);
 		if (client) {
 			if (http_params.logger &&
 			    http_params.logger->ShouldLog(HTTPFSInfoLogType::NAME, HTTPFSInfoLogType::LEVEL)) {

--- a/src/http/httpfs_curl_client.cpp
+++ b/src/http/httpfs_curl_client.cpp
@@ -619,16 +619,12 @@ private:
 	}
 
 	static CURLRequestHeaders TransformHeadersCurl(const HTTPHeaders &header_map, const HTTPParams &params) {
-		auto &httpfs_params = params.Cast<HTTPFSParams>();
-
 		CURLRequestHeaders curl_headers;
 		for (auto &entry : header_map) {
 			curl_headers.Add(entry.first, entry.second);
 		}
-		if (!httpfs_params.pre_merged_headers) {
-			for (auto &entry : params.extra_headers) {
-				curl_headers.Add(entry.first, entry.second);
-			}
+		for (auto &entry : params.extra_headers) {
+			curl_headers.Add(entry.first, entry.second);
 		}
 		return curl_headers;
 	}

--- a/src/http/httpfs_curl_client.cpp
+++ b/src/http/httpfs_curl_client.cpp
@@ -50,7 +50,7 @@ static size_t RequestWriteCallback(void *contents, size_t size, size_t nmemb, vo
 static size_t RequestHeaderCallback(void *contents, size_t size, size_t nmemb, void *userp) {
 	auto total_size = size * nmemb;
 	string header(char_ptr_cast(contents), total_size);
-	auto &header_collection = *static_cast<HeaderCollector *>(userp);
+	auto &header_collection = *static_cast<vector<HTTPHeaders> *>(userp);
 
 	// Trim trailing \r\n
 	if (!header.empty() && header.back() == '\n') {
@@ -63,21 +63,22 @@ static size_t RequestHeaderCallback(void *contents, size_t size, size_t nmemb, v
 	// If header starts with HTTP/... curl has followed a redirect and we have a new Header,
 	// so we push back a new header_collection and store headers from the redirect there.
 	if (header.rfind("HTTP/", 0) == 0) {
-		header_collection.header_collection.emplace_back();
-		header_collection.header_collection.back().Insert("__RESPONSE_STATUS__", header);
+		header_collection.emplace_back();
+		header_collection.back().Insert("__RESPONSE_STATUS__", header);
 	}
 
 	idx_t colon_pos = header.find(':');
 
 	if (colon_pos != string::npos) {
-		// Split the string into two parts
-		string part1 = header.substr(0, colon_pos);
-		string part2 = header.substr(colon_pos + 1);
-		if (part2.at(0) == ' ') {
-			part2.erase(0, 1);
+		if (header_collection.empty()) {
+			header_collection.emplace_back();
 		}
-
-		header_collection.header_collection.back().Insert(part1, part2);
+		auto name = header.substr(0, colon_pos);
+		auto value = header.substr(colon_pos + 1);
+		if (!value.empty() && value.front() == ' ') {
+			value.erase(0, 1);
+		}
+		header_collection.back().Append(std::move(name), std::move(value));
 	}
 	// TODO: log headers that don't follow the header format
 
@@ -180,6 +181,7 @@ private:
 			curl_easy_setopt(*client.curl, CURLOPT_LOW_SPEED_TIME, params.timeout);
 			curl_easy_setopt(*client.curl, CURLOPT_ACCEPT_ENCODING, nullptr);
 			curl_easy_setopt(*client.curl, CURLOPT_FOLLOWLOCATION, params.follow_location ? 1L : 0L);
+			curl_easy_setopt(*client.curl, CURLOPT_SUPPRESS_CONNECT_HEADERS, 1L);
 			curl_easy_setopt(*client.curl, CURLOPT_HEADERFUNCTION, RequestHeaderCallback);
 			curl_easy_setopt(*client.curl, CURLOPT_HEADERDATA, &client.request_info->header_collection);
 			curl_easy_setopt(*client.curl, CURLOPT_WRITEFUNCTION, RequestWriteCallback);
@@ -255,7 +257,7 @@ private:
 			auto &state = *static_cast<GetTransferState *>(userp);
 			const auto total_size = RequestHeaderCallback(
 			    contents, size, nmemb, static_cast<void *>(&state.client.request_info->header_collection));
-			if (total_size == 0 || !state.IsEndOfHeaders(contents, total_size) || state.IsProxyConnectResponse()) {
+			if (total_size == 0 || !state.IsEndOfHeaders(contents, total_size)) {
 				return total_size;
 			}
 			try {
@@ -283,18 +285,6 @@ private:
 		static bool IsEndOfHeaders(void *contents, idx_t size) {
 			auto header = const_char_ptr_cast(contents);
 			return (size == 2 && header[0] == '\r' && header[1] == '\n') || (size == 1 && header[0] == '\n');
-		}
-
-		bool IsProxyConnectResponse() const {
-			if (client.request_info->header_collection.empty()) {
-				return false;
-			}
-			auto &headers = client.request_info->header_collection.back();
-			if (!headers.HasHeader("__RESPONSE_STATUS__")) {
-				return false;
-			}
-			auto status = StringUtil::Lower(headers.GetHeaderValue("__RESPONSE_STATUS__"));
-			return status.find("connection established") != string::npos;
 		}
 
 		size_t Write(void *contents, idx_t size) {
@@ -404,7 +394,7 @@ public:
 
 			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
 			curl_easy_setopt(*curl, CURLOPT_CURLU, url.Get());
-			curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers ? curl_headers.headers : nullptr);
+			curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers.Get());
 			GetTransferState transfer(*this, info);
 			res = curl->Execute();
 			return transfer.Finish(res);
@@ -440,7 +430,7 @@ public:
 			curl_easy_setopt(*curl, CURLOPT_POSTFIELDSIZE_LARGE, NumericCast<curl_off_t>(info.buffer_in_len));
 
 			// Apply headers
-			curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers ? curl_headers.headers : nullptr);
+			curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers.Get());
 
 			res = curl->Execute();
 			curl_easy_setopt(*curl, CURLOPT_CUSTOMREQUEST, nullptr);
@@ -477,7 +467,7 @@ public:
 			curl_easy_setopt(*curl, CURLOPT_CURLU, url.Get());
 
 			// Add headers if any
-			curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers ? curl_headers.headers : nullptr);
+			curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers.Get());
 
 			// Execute HEAD request
 			res = curl->Execute();
@@ -511,7 +501,7 @@ public:
 			curl_easy_setopt(*curl, CURLOPT_CUSTOMREQUEST, "DELETE");
 
 			// Add headers if any
-			curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers ? curl_headers.headers : nullptr);
+			curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers.Get());
 
 			// Execute DELETE request
 			res = curl->Execute();
@@ -538,7 +528,7 @@ public:
 
 			curl_easy_setopt(*curl, CURLOPT_CUSTOMREQUEST, "OPTIONS");
 
-			curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers ? curl_headers.headers : nullptr);
+			curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers.Get());
 
 			res = curl->Execute();
 			curl_easy_setopt(*curl, CURLOPT_CUSTOMREQUEST, nullptr);
@@ -581,7 +571,7 @@ public:
 			curl_easy_setopt(*curl, CURLOPT_POSTFIELDSIZE, info.buffer_in_len);
 
 			// Add headers if any
-			curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers ? curl_headers.headers : nullptr);
+			curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers.Get());
 
 			// Execute POST request
 			res = curl->Execute();
@@ -651,12 +641,15 @@ private:
 		response->url = request_info->url;
 		response->reason = HTTPUtil::GetStatusMessage(HTTPUtil::ToStatusCode(request_info->response_code));
 		if (!request_info->header_collection.empty()) {
-			for (auto &header : request_info->header_collection.back()) {
+			auto &response_headers = request_info->header_collection.back();
+			for (auto &header : response_headers) {
 				// We should not return __RESPONSE_STATUS__ to the user. It's only there for debugging.
 				if (header.first == "__RESPONSE_STATUS__") {
 					continue;
 				}
-				response->headers.Insert(header.first, header.second);
+				for (auto &value : response_headers.GetHeaderValues(header.first)) {
+					response->headers.Append(header.first, std::move(value));
+				}
 			}
 		}
 		// ResetRequestInfo();

--- a/src/http/httpfs_httplib_client.cpp
+++ b/src/http/httpfs_httplib_client.cpp
@@ -227,16 +227,12 @@ public:
 
 private:
 	static duckdb_httplib_openssl::Headers TransformHeaders(const HTTPHeaders &header_map, const HTTPParams &params) {
-		auto &httpfs_params = params.Cast<HTTPFSParams>();
-
 		duckdb_httplib_openssl::Headers headers;
 		for (auto &entry : header_map) {
 			headers.emplace(entry.first, HTTPFSHeaderValue::IsEmpty(entry.second) ? string() : entry.second);
 		}
-		if (!httpfs_params.pre_merged_headers) {
-			for (auto &entry : params.extra_headers) {
-				headers.emplace(entry.first, HTTPFSHeaderValue::IsEmpty(entry.second) ? string() : entry.second);
-			}
+		for (auto &entry : params.extra_headers) {
+			headers.emplace(entry.first, HTTPFSHeaderValue::IsEmpty(entry.second) ? string() : entry.second);
 		}
 		return headers;
 	}

--- a/src/http/httpfs_httplib_client.cpp
+++ b/src/http/httpfs_httplib_client.cpp
@@ -32,7 +32,7 @@ private:
 			auto chunk_size = NumericCast<idx_t>(data_length);
 			total_bytes += chunk_size;
 			if (client.state) {
-				client.state->total_bytes_received += chunk_size;
+				client.state->RecordBytesReceived(chunk_size);
 			}
 			if (deferred_response) {
 				deferred_response->body.append(data, data_length);
@@ -132,15 +132,11 @@ public:
 	unique_ptr<HTTPResponse> Get(GetRequestInfo &info) override {
 		AddUserAgentIfAvailable(info.params.Cast<HTTPFSParams>(), info.headers);
 		if (state) {
-			state->get_count++;
+			state->RecordRequest(RequestType::GET_REQUEST);
 		}
 		auto headers = TransformHeaders(info.headers, info.params);
 		if (!info.response_handler && !info.content_handler) {
-			auto result = TransformResult(client->Get(info.path, headers));
-			if (state) {
-				state->total_bytes_received += result->body.size();
-			}
-			return result;
+			return TransformBufferedResult(client->Get(info.path, headers));
 		}
 		GetTransferState transfer(*this, info);
 		auto result = client->Get(
@@ -152,8 +148,8 @@ public:
 	unique_ptr<HTTPResponse> Put(PutRequestInfo &info) override {
 		AddUserAgentIfAvailable(info.params.Cast<HTTPFSParams>(), info.headers);
 		if (state) {
-			state->put_count++;
-			state->total_bytes_sent += info.buffer_in_len;
+			state->RecordRequest(RequestType::PUT_REQUEST);
+			state->RecordBytesSent(info.buffer_in_len);
 		}
 		auto headers = TransformHeaders(info.headers, info.params);
 		auto body_size = NumericCast<size_t>(info.buffer_in_len);
@@ -165,38 +161,41 @@ public:
 			}
 			return sink.write(const_char_ptr_cast(body + NumericCast<idx_t>(offset)), length);
 		};
-		return TransformResult(
+		return TransformBufferedResult(
 		    client->Put(info.path, headers, body_size, std::move(content_provider), info.content_type));
 	}
 
 	unique_ptr<HTTPResponse> Head(HeadRequestInfo &info) override {
 		AddUserAgentIfAvailable(info.params.Cast<HTTPFSParams>(), info.headers);
 		if (state) {
-			state->head_count++;
+			state->RecordRequest(RequestType::HEAD_REQUEST);
 		}
 		auto headers = TransformHeaders(info.headers, info.params);
-		return TransformResult(client->Head(info.path, headers));
+		return TransformBufferedResult(client->Head(info.path, headers));
 	}
 
 	unique_ptr<HTTPResponse> Delete(DeleteRequestInfo &info) override {
 		AddUserAgentIfAvailable(info.params.Cast<HTTPFSParams>(), info.headers);
 		if (state) {
-			state->delete_count++;
+			state->RecordRequest(RequestType::DELETE_REQUEST);
 		}
 		auto headers = TransformHeaders(info.headers, info.params);
-		return TransformResult(client->Delete(info.path, headers));
+		return TransformBufferedResult(client->Delete(info.path, headers));
 	}
 
 	unique_ptr<HTTPResponse> Options(OptionsRequestInfo &info) override {
+		if (state) {
+			state->RecordRequest(RequestType::OPTIONS_REQUEST);
+		}
 		auto headers = TransformHeaders(info.headers, info.params);
-		return TransformResult(client->Options(info.path, headers));
+		return TransformBufferedResult(client->Options(info.path, headers));
 	}
 
 	unique_ptr<HTTPResponse> Post(PostRequestInfo &info) override {
 		AddUserAgentIfAvailable(info.params.Cast<HTTPFSParams>(), info.headers);
 		if (state) {
-			state->post_count++;
-			state->total_bytes_sent += info.buffer_in_len;
+			state->RecordRequest(RequestType::POST_REQUEST);
+			state->RecordBytesSent(info.buffer_in_len);
 		}
 		// We use a custom Request method here, because there is no Post call with a contentreceiver in httplib
 		duckdb_httplib_openssl::Request req;
@@ -212,9 +211,6 @@ public:
 		}
 		req.content_receiver = [&](const char *data, size_t data_length, uint64_t /*offset*/,
 		                           uint64_t /*total_length*/) {
-			if (state) {
-				state->total_bytes_received += data_length;
-			}
 			info.buffer_out += string(data, data_length);
 			return true;
 		};
@@ -222,6 +218,9 @@ public:
 		req.body.assign(const_char_ptr_cast(info.buffer_in), info.buffer_in_len);
 		auto transformed_req = TransformResult(client->send(req));
 		transformed_req->body = info.buffer_out;
+		if (state) {
+			state->RecordBytesReceived(info.buffer_out.size());
+		}
 		return transformed_req;
 	}
 
@@ -257,6 +256,14 @@ private:
 			result->request_error = to_string(res.error());
 			return result;
 		}
+	}
+
+	unique_ptr<HTTPResponse> TransformBufferedResult(const duckdb_httplib_openssl::Result &res) {
+		auto response = TransformResult(res);
+		if (state) {
+			state->RecordBytesReceived(response->body.size());
+		}
+		return response;
 	}
 
 private:

--- a/src/include/create_secret_functions.hpp
+++ b/src/include/create_secret_functions.hpp
@@ -4,7 +4,7 @@
 
 namespace duckdb {
 struct CreateSecretInput;
-struct S3AuthParams;
+class S3AuthParams;
 class CreateSecretFunction;
 class BaseSecret;
 struct SecretEntry;

--- a/src/include/hffs.hpp
+++ b/src/include/hffs.hpp
@@ -5,17 +5,14 @@
 namespace duckdb {
 
 struct ParsedHFUrl {
-	//! Path within the
-	string path;
-	//! Name of the repo (i presume)
-	string repository;
-
-	//! Endpoint, defaults to HF
-	string endpoint = "https://huggingface.co";
-	//! Which revision/branch/tag to use
-	string revision = "main";
-	//! For DuckDB this may be a sensible default?
+	//! Repository coordinates
 	string repo_type = "datasets";
+	string repository;
+	string revision = "main";
+
+	//! Request routing
+	string endpoint = "https://huggingface.co";
+	string path;
 };
 
 class HuggingFaceFileSystem : public HTTPFileSystem {
@@ -23,8 +20,16 @@ public:
 	~HuggingFaceFileSystem() override;
 
 public:
+	//! FileSystem overrides
 	vector<OpenFileInfo> Glob(const string &path, FileOpener *opener = nullptr) override;
+	bool CanHandleFile(const string &fpath) override {
+		return fpath.rfind("hf://", 0) == 0;
+	}
+	string GetName() const override {
+		return "HuggingFaceFileSystem";
+	}
 
+	//! HTTP request overrides
 	unique_ptr<HTTPResponse> HeadRequest(FileHandle &handle, const string &hf_url, HTTPHeaders header_map) override;
 	unique_ptr<HTTPResponse> GetRequest(FileHandle &handle, string hf_url, HTTPHeaders header_map,
 	                                    const HTTPReadConfig &read_config, CachedFileDownload &download) override;
@@ -32,27 +37,21 @@ public:
 	                                         const HTTPReadConfig &read_config, idx_t file_offset,
 	                                         data_ptr_t buffer_out, idx_t buffer_out_len) override;
 
-	bool CanHandleFile(const string &fpath) override {
-		return fpath.rfind("hf://", 0) == 0;
-	};
-
-	string GetName() const override {
-		return "HuggingFaceFileSystem";
-	}
-	static ParsedHFUrl HFUrlParse(const string &url);
+	//! List response parsing
 	static void ParseListResult(const string &input, vector<string> &files, vector<string> &directories);
-	static string GetHFUrl(const ParsedHFUrl &url);
-	string GetTreeUrl(const ParsedHFUrl &url, idx_t limit);
-	string GetFileUrl(const ParsedHFUrl &url);
-
-	static void SetParams(HTTPFSParams &params, const string &path, optional_ptr<FileOpener> opener);
 
 protected:
 	unique_ptr<HTTPFileHandle> CreateHandle(const OpenFileInfo &file, FileOpenFlags flags,
 	                                        optional_ptr<FileOpener> opener) override;
 
-	static string ListHFRequest(ParsedHFUrl &url, HTTPFSParams &http_params, string &next_page_url,
-	                            optional_ptr<HTTPState> state);
+	static string ListHFRequest(const ParsedHFUrl &url, HTTPFSParams &http_params, string &next_page_url);
+
+private:
+	static ParsedHFUrl HFUrlParse(const string &url);
+	static string GetHFUrl(const ParsedHFUrl &url);
+	static string GetTreeUrl(const ParsedHFUrl &url, idx_t limit);
+	static string GetFileUrl(const ParsedHFUrl &url);
+	static void SetParams(HTTPFSParams &params, const string &path, optional_ptr<FileOpener> opener);
 };
 
 class HFFileHandle : public HTTPFileHandle {
@@ -65,7 +64,7 @@ public:
 	}
 	~HFFileHandle() override;
 
-protected:
+private:
 	ParsedHFUrl parsed_url;
 };
 

--- a/src/include/http/http_metadata_cache.hpp
+++ b/src/include/http/http_metadata_cache.hpp
@@ -42,7 +42,7 @@ public:
 		map.erase(path);
 	}
 
-	bool Find(const string &path, HTTPMetadataCacheEntry &ret_val) DUCKDB_EXCLUDES(lock) {
+	bool Find(const string &path, HTTPMetadataCacheEntry &ret_val) const DUCKDB_EXCLUDES(lock) {
 		annotated_lock_guard<annotated_mutex> guard(lock);
 		auto lookup = map.find(path);
 		if (lookup == map.end()) {
@@ -64,10 +64,13 @@ public:
 		}
 	}
 
-protected:
-	annotated_mutex lock;
+private:
+	//! Cache policy
+	const HTTPMetadataCacheMode mode;
+
+	//! Cached metadata
+	mutable annotated_mutex lock;
 	unordered_map<string, HTTPMetadataCacheEntry> map DUCKDB_GUARDED_BY(lock);
-	HTTPMetadataCacheMode mode;
 };
 
 } // namespace duckdb

--- a/src/include/http/http_request_session.hpp
+++ b/src/include/http/http_request_session.hpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/http_util.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/unordered_map.hpp"
 #include "http/httpfs_client.hpp"
 
 namespace duckdb {
@@ -14,6 +15,17 @@ class Logger;
 
 enum class HTTPRequestSnapshotType : uint8_t { HTTP, S3 };
 
+struct HTTPConfiguredHeaders {
+	string user_agent;
+	unordered_map<string, string> extra_headers;
+};
+
+struct HTTPSessionRequest {
+	HTTPHeaders headers;
+	unique_ptr<HTTPFSParams> params;
+	HTTPConfiguredHeaders configured_headers;
+};
+
 struct HTTPRequestSnapshot {
 	explicit HTTPRequestSnapshot(const HTTPFSParams &params,
 	                             HTTPRequestSnapshotType type_p = HTTPRequestSnapshotType::HTTP);
@@ -21,8 +33,7 @@ struct HTTPRequestSnapshot {
 
 public:
 	bool CanReuseClientsWith(const HTTPRequestSnapshot &other) const;
-	unique_ptr<HTTPFSParams> CreateRequestParams() const;
-	void AddConfiguredHeaders(HTTPHeaders &headers) const;
+	HTTPSessionRequest CreateRequest(HTTPHeaders headers = {}) const;
 	const HTTPFSParams &Params() const {
 		return params;
 	}

--- a/src/include/http/http_state.hpp
+++ b/src/include/http/http_state.hpp
@@ -16,6 +16,7 @@ namespace duckdb {
 
 class CachedFileHandle;
 class CachedFileDownload;
+enum class RequestType : uint8_t;
 
 enum class RangeRequestSupport : uint8_t { UNKNOWN, SUPPORTED, NOT_SUPPORTED };
 
@@ -216,22 +217,40 @@ private:
 	RangeRequestState range_request_state;
 };
 
+struct HTTPStateCounters {
+	//! Request counts
+	idx_t head_count = 0;
+	idx_t get_count = 0;
+	idx_t put_count = 0;
+	idx_t post_count = 0;
+	idx_t delete_count = 0;
+	idx_t options_count = 0;
+
+	//! Transferred bytes
+	idx_t total_bytes_received = 0;
+	idx_t total_bytes_sent = 0;
+
+	bool IsEmpty() const;
+};
+
 class HTTPState : public ClientContextState {
 public:
 	//! Reset all counters and per-path state
 	void Reset();
-	//! Get per-path state, creating it if needed
+	//! Record request and transfer statistics
+	void RecordRequest(RequestType request_type);
+	void RecordBytesReceived(idx_t byte_count);
+	void RecordBytesSent(idx_t byte_count);
+	HTTPStateCounters GetCounters() const;
+	bool IsEmpty() const;
+
+	//! Per-path state shared by HTTP file handles
 	shared_ptr<HTTPFileState> GetFileState(const string &path);
-	//! Erase all state for a path
 	void EraseFileState(const string &path);
+
 	//! Helper functions to get the HTTP state
 	static shared_ptr<HTTPState> TryGetState(ClientContext &context);
 	static shared_ptr<HTTPState> TryGetState(optional_ptr<FileOpener> opener);
-
-	bool IsEmpty() {
-		return head_count == 0 && get_count == 0 && put_count == 0 && post_count == 0 && delete_count == 0 &&
-		       total_bytes_received == 0 && total_bytes_sent == 0;
-	}
 
 	//! Called by the ClientContext when the current query ends
 	void QueryEnd(ClientContext &context) override {
@@ -240,12 +259,14 @@ public:
 	void WriteProfilingInformation(std::ostream &ss) override;
 	bool RunCredentialRefresh(const std::function<bool()> &callback) DUCKDB_EXCLUDES(credential_refresh_mutex);
 
-public:
+private:
+	//! Request and transfer statistics
 	atomic<idx_t> head_count {0};
 	atomic<idx_t> get_count {0};
 	atomic<idx_t> put_count {0};
 	atomic<idx_t> post_count {0};
 	atomic<idx_t> delete_count {0};
+	atomic<idx_t> options_count {0};
 	atomic<idx_t> total_bytes_received {0};
 	atomic<idx_t> total_bytes_sent {0};
 

--- a/src/include/http/httpfs.hpp
+++ b/src/include/http/httpfs.hpp
@@ -150,7 +150,6 @@ public:
 	bool IsPipe(const string &filename, optional_ptr<FileOpener> opener) override;
 	string GetName() const override;
 	string PathSeparator(const string &path) override;
-	static void Verify();
 
 	optional_ptr<HTTPMetadataCache> GetGlobalCache();
 	virtual HTTPException GetHTTPError(FileHandle &, const HTTPResponse &response, RequestType request_type,

--- a/src/include/http/httpfs_client.hpp
+++ b/src/include/http/httpfs_client.hpp
@@ -72,7 +72,6 @@ public:
 	bool s3_version_id_pinning {false};
 	shared_ptr<HTTPState> state;
 	string user_agent = {""};
-	bool pre_merged_headers = false;
 	idx_t force_download_threshold = 0;
 	HTTPClientReuseMode client_reuse_mode = HTTPClientReuseMode::SESSION_LOCAL;
 	optional_ptr<HTTPFSUtil> httpfs_util;

--- a/src/include/http/httpfs_client.hpp
+++ b/src/include/http/httpfs_client.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb/common/http_util.hpp"
+#include "duckdb/common/atomic.hpp"
 #include "duckdb/common/array.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/vector.hpp"
@@ -127,6 +128,7 @@ public:
 	void CloseClient(unique_ptr<HTTPClient> &&client) override;
 	void ClearCachedConnections() override;
 	HTTPClientReuseMode GetClientReuseMode() const override;
+	void SetConnectionCachingEnabled(bool enabled);
 	unique_ptr<HTTPResponse> SendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client) override;
 
 	string GetName() const override;
@@ -137,13 +139,14 @@ private:
 	//! Send request without caching (delegates to HTTPUtil::SendRequest)
 	unique_ptr<HTTPResponse> BaseSendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client);
 
-	bool EnableCaching(BaseRequest &request);
-
-public:
-	//! Whether connection caching is enabled
-	bool connection_caching_enabled = true;
+	bool EnableCaching(const BaseRequest &request) const;
+	bool ConnectionCachingEnabled() const;
+	unique_ptr<HTTPClient> FindCachedClient(const string &base_url);
+	void StoreCachedClient(unique_ptr<HTTPClient> &&client);
 
 private:
+	//! Shared connection-cache state
+	atomic<bool> connection_caching_enabled {true};
 	HTTPClientConnectionCache connection_cache;
 };
 

--- a/src/include/http/httpfs_client.hpp
+++ b/src/include/http/httpfs_client.hpp
@@ -149,8 +149,4 @@ private:
 
 #endif
 
-struct HeaderCollector {
-	vector<HTTPHeaders> header_collection;
-};
-
 } // namespace duckdb

--- a/src/include/http/httpfs_curl_client.hpp
+++ b/src/include/http/httpfs_curl_client.hpp
@@ -10,6 +10,7 @@ class HTTPLogger;
 class FileOpener;
 struct FileOpenerInfo;
 class HTTPState;
+class HTTPFSCurlClient;
 
 class CURLURLHandle {
 private:
@@ -49,11 +50,11 @@ private:
 };
 
 class CURLRequestHeaders {
+	friend class HTTPFSCurlClient;
+
 public:
-	CURLRequestHeaders() {
-	}
-	CURLRequestHeaders(CURLRequestHeaders &&other) noexcept {
-		headers = other.headers;
+	CURLRequestHeaders() = default;
+	CURLRequestHeaders(CURLRequestHeaders &&other) noexcept : headers(other.headers) {
 		other.headers = nullptr;
 	}
 	CURLRequestHeaders &operator=(CURLRequestHeaders &&other) noexcept {
@@ -69,11 +70,12 @@ public:
 		headers = nullptr;
 	}
 
-public:
-	explicit operator bool() const {
-		return headers != nullptr;
+private:
+	curl_slist *Get() const {
+		return headers;
 	}
 
+public:
 	void Add(const string &header) {
 		headers = curl_slist_append(headers, header.c_str());
 	}
@@ -85,7 +87,7 @@ public:
 		}
 	}
 
-public:
+private:
 	curl_slist *headers = nullptr;
 };
 

--- a/src/include/s3/s3_auth.hpp
+++ b/src/include/s3/s3_auth.hpp
@@ -11,6 +11,61 @@ namespace duckdb {
 
 enum class S3EndpointMode : uint8_t { AUTOMATIC, EXPLICIT };
 
+struct S3AuthCredentials {
+	string region;
+	string access_key_id;
+	string secret_access_key;
+	string session_token;
+	string oauth2_bearer_token;
+
+	bool operator==(const S3AuthCredentials &other) const;
+};
+
+struct S3AuthURLParams {
+	static S3URLStyle ParseStyle(const string &url_style);
+
+	NormalizedS3Endpoint endpoint;
+	S3EndpointMode endpoint_mode = S3EndpointMode::AUTOMATIC;
+	S3URLStyle style = S3URLStyle::VIRTUAL_HOSTED;
+	bool compatibility_mode = false;
+
+	bool operator==(const S3AuthURLParams &other) const;
+};
+
+struct S3AuthRequestOptions {
+	string kms_key_id;
+	bool requester_pays = false;
+	string user_project;
+
+	bool operator==(const S3AuthRequestOptions &other) const;
+};
+
+struct S3AuthRefreshIdentity {
+	bool use_ssl = true;
+
+	bool operator==(const S3AuthRefreshIdentity &other) const {
+		return use_ssl == other.use_ssl;
+	}
+};
+
+struct S3AuthConfig {
+	//! Provider and URL routing
+	S3ProviderMatch route {S3ProviderType::S3, "s3://"};
+
+	//! Authentication
+	S3AuthCredentials credentials;
+
+	//! Endpoint and URL behavior
+	string endpoint;
+	S3EndpointMode endpoint_mode = S3EndpointMode::AUTOMATIC;
+	string url_style;
+	bool use_ssl = true;
+	bool compatibility_mode = false;
+
+	//! Request headers
+	S3AuthRequestOptions request_options;
+};
+
 class S3KeyValueReader {
 public:
 	S3KeyValueReader(FileOpener &opener_p, optional_ptr<FileOpenerInfo> info, const char **secret_types,
@@ -58,49 +113,44 @@ private:
 	KeyValueSecretReader reader;
 };
 
-struct S3AuthParams {
+class S3AuthParams {
 public:
-	//! Construction and secret lookup
-	static S3AuthParams ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info);
-	static S3AuthParams ReadFrom(S3KeyValueReader &secret_reader, const string &file_path);
-
-	//! Endpoint resolution
-	void SetEndpoint(string endpoint_p);
-	const NormalizedS3Endpoint &GetEndpoint() const;
-
-	//! Refresh and session identity
-	void SetRegion(string region_p);
+	const S3Provider &GetProvider() const {
+		return provider;
+	}
+	const S3AuthCredentials &GetCredentials() const {
+		return credentials;
+	}
+	const S3AuthURLParams &GetURLParams() const {
+		return url;
+	}
+	const S3AuthRequestOptions &GetRequestOptions() const {
+		return request_options;
+	}
+	const S3AuthRefreshIdentity &GetRefreshIdentity() const {
+		return refresh_identity;
+	}
+	S3AuthParams WithRegion(string region) const;
 	bool operator==(const S3AuthParams &other) const;
 
-public:
-	//! Provider and URL routing
-	S3ProviderType provider_type = S3ProviderType::S3;
-	bool scheme_is_alias = false;
+private:
+	friend struct S3AuthResolver;
+	S3AuthParams();
 
-	//! Authentication
-	string region;
-	string access_key_id;
-	string secret_access_key;
-	string session_token;
-	string oauth2_bearer_token;
+	S3Provider provider;
+	S3AuthCredentials credentials;
+	S3AuthURLParams url;
+	S3AuthRequestOptions request_options;
+	S3AuthRefreshIdentity refresh_identity;
+};
 
-	//! Endpoint and URL behavior
-	S3EndpointMode endpoint_mode = S3EndpointMode::AUTOMATIC;
-	string url_style;
-	bool use_ssl = true;
-	bool s3_url_compatibility_mode = false;
-
-	//! Request headers
-	string kms_key_id;
-	bool requester_pays = false;
-	string user_project;
+struct S3AuthResolver {
+	static S3AuthParams Resolve(optional_ptr<FileOpener> opener, FileOpenerInfo &info);
+	static S3AuthParams Resolve(S3KeyValueReader &secret_reader, const string &file_path);
+	static S3AuthParams Resolve(S3AuthConfig config, const string &file_path);
 
 private:
-	friend struct S3Provider;
-
-	//! Selected endpoint text before finalization and its normalized value afterwards
-	string endpoint_source;
-	NormalizedS3Endpoint endpoint;
+	static S3AuthConfig ReadConfig(S3KeyValueReader &secret_reader, const string &file_path);
 };
 
 struct AWSEnvironmentCredentialsProvider {

--- a/src/include/s3/s3_endpoint.hpp
+++ b/src/include/s3/s3_endpoint.hpp
@@ -5,10 +5,12 @@
 
 namespace duckdb {
 
-struct S3Provider;
+class S3AuthParams;
+struct S3AuthResolver;
 
 class NormalizedS3Endpoint {
-	friend struct S3Provider;
+	friend class S3AuthParams;
+	friend struct S3AuthResolver;
 
 public:
 	NormalizedS3Endpoint() = default;

--- a/src/include/s3/s3_provider.hpp
+++ b/src/include/s3/s3_provider.hpp
@@ -10,12 +10,17 @@ namespace duckdb {
 class CreateSecretFunction;
 struct DBConfig;
 class KeyValueSecret;
+class NormalizedS3Endpoint;
 class Value;
 struct CreateSecretInput;
-struct S3AuthParams;
+class S3AuthParams;
 class S3KeyValueReader;
 
 enum class S3ProviderType : uint8_t { S3, GCS, R2 };
+
+enum class S3CompatibilityProfile : uint8_t { S3, GCS, R2 };
+
+enum class S3UrlSchemeOrigin : uint8_t { BUILTIN, ALIAS };
 
 enum class S3AuthType : uint8_t { ANONYMOUS, SIGV4, BEARER };
 
@@ -36,9 +41,26 @@ struct S3MultipartUploadPolicy {
 struct S3ProviderMatch {
 	S3ProviderType type;
 	string prefix;
+	S3UrlSchemeOrigin origin = S3UrlSchemeOrigin::BUILTIN;
+
+	bool IsAlias() const {
+		return origin == S3UrlSchemeOrigin::ALIAS;
+	}
 };
 
-struct S3Provider {
+struct S3UrlScheme {
+	static optional<S3ProviderMatch> TryMatch(const string &url);
+	static optional<S3ProviderMatch> TryMatch(const string &url, const vector<string> &scheme_alias_prefixes);
+	static S3ProviderMatch Match(const string &url);
+	static S3ProviderMatch MatchRoutedUrl(const string &url);
+
+	//! Validate and normalize bare URL scheme aliases
+	static Value NormalizeAliases(const Value &aliases);
+	//! The configured aliases as '<scheme>://' prefixes
+	static vector<string> GetAliasPrefixes(const DBConfig &config);
+};
+
+struct S3SecretConfig {
 	static constexpr const char *S3_SECRET_TYPE = "s3";
 	static constexpr const char *R2_SECRET_TYPE = "r2";
 	static constexpr const char *GCS_SECRET_TYPE = "gcs";
@@ -47,32 +69,43 @@ struct S3Provider {
 	static const array<const char *, 4> &SecretTypes();
 	static const array<const char *, 13> &CredentialMaterialKeys();
 
-	static optional<S3ProviderMatch> TryMatchUrl(const string &url);
-	static optional<S3ProviderMatch> TryMatchUrl(const string &url, const vector<string> &scheme_alias_prefixes);
-	static S3ProviderMatch MatchUrl(const string &url);
-
-	//! Validate and normalize the 's3_url_scheme_aliases' value (bare scheme names, lowercased, deduplicated)
-	static Value NormalizeSchemeAliases(const Value &aliases);
-	//! The database's configured scheme aliases as '<scheme>://' prefixes
-	static vector<string> GetSchemeAliasPrefixes(const DBConfig &config);
-
 	static vector<string> DefaultSecretScope(const string &secret_type);
 	static void SetSecretNamedParameters(const string &secret_type, CreateSecretFunction &function);
 	static void ApplySecretDefaults(const CreateSecretInput &input, KeyValueSecret &secret);
 	static bool TryApplySecretOption(const CreateSecretInput &input, const string &name, const Value &value,
 	                                 KeyValueSecret &secret);
+};
 
-	static void ReadAuthParams(S3KeyValueReader &secret_reader, const string &file_path, S3AuthParams &result);
-	//! Apply provider defaults; a required endpoint no secret or setting supplied stays unresolved
-	static void InitializeAuthParams(S3AuthParams &auth_params);
-	//! Validate that endpoint once every source has been read, then derive the remaining defaults
-	static void FinalizeAuthParams(S3AuthParams &auth_params);
-	static S3URLStyle ParseURLStyle(const string &url_style);
-	static S3AuthType GetAuthType(const S3AuthParams &auth_params);
-	static S3MultipartUploadPolicy GetMultipartUploadPolicy(const S3AuthParams &auth_params);
-	static idx_t GetBulkDeleteMaxBatchSize(const S3AuthParams &auth_params);
-	static string GetBadRequestError(const S3AuthParams &auth_params, const string &correct_region = "");
-	static string GetAuthError(const S3AuthParams &auth_params);
+class S3Provider {
+public:
+	static S3Provider Resolve(S3ProviderMatch route, const NormalizedS3Endpoint &endpoint);
+
+	const S3ProviderMatch &GetRoute() const {
+		return route;
+	}
+	S3ProviderType GetType() const {
+		return route.type;
+	}
+	S3CompatibilityProfile GetCompatibilityProfile() const {
+		return profile;
+	}
+
+	S3AuthType GetAuthType(const S3AuthParams &auth_params) const;
+	S3MultipartUploadPolicy GetMultipartUploadPolicy() const;
+	idx_t GetBulkDeleteMaxBatchSize() const;
+	string GetBadRequestError(const S3AuthParams &auth_params, const string &correct_region = "") const;
+	string GetAuthError(const S3AuthParams &auth_params) const;
+
+	bool operator==(const S3Provider &other) const;
+
+private:
+	friend class S3AuthParams;
+	S3Provider();
+	S3Provider(S3ProviderMatch route_p, S3CompatibilityProfile profile_p);
+
+	//! Finalized route and compatibility policy
+	S3ProviderMatch route;
+	S3CompatibilityProfile profile;
 };
 
 } // namespace duckdb

--- a/src/include/s3/s3_request.hpp
+++ b/src/include/s3/s3_request.hpp
@@ -35,8 +35,28 @@ public:
 };
 
 enum class S3RequestTarget : uint8_t { OBJECT, BUCKET };
-enum class S3PostRequestMode : uint8_t { DEFAULT, RETRY_RECEIVED_RESPONSES };
+enum class S3RequestOperation : uint8_t {
+	HEAD_OBJECT,
+	GET_OBJECT,
+	PUT_OBJECT,
+	DELETE_OBJECT,
+	LIST_OBJECTS,
+	DELETE_OBJECTS,
+	CREATE_MULTIPART_UPLOAD,
+	UPLOAD_PART,
+	COMPLETE_MULTIPART_UPLOAD,
+	ABORT_MULTIPART_UPLOAD
+};
 enum class S3ReceivedResponseAction : uint8_t { ACCEPT, RETRY_FRESH_CONNECTION };
+
+struct S3RequestOperationInfo {
+	RequestType request_type;
+	S3RequestTarget target;
+	const char *description;
+	bool retry_timeout;
+	bool retry_received_response;
+	bool uses_kms_headers;
+};
 
 struct S3RequestQuery {
 	S3RequestQuery() = default;
@@ -73,13 +93,34 @@ public:
 };
 
 struct S3RequestContext {
-	RequestType request_type = RequestType::GET_REQUEST;
-	S3AuthParams auth_params;
+	S3RequestOperation operation;
+	CapturedHTTPRequestSnapshot captured;
 	string display_url;
+
+	const S3AuthParams &GetAuthParams() const {
+		D_ASSERT(captured.snapshot);
+		return captured.snapshot->Cast<S3RequestSnapshot>().auth_params;
+	}
+};
+
+struct S3RequestResult {
+	unique_ptr<HTTPResponse> response;
+	S3RequestContext context;
+};
+
+struct S3RequestSpec {
+	using CreateQueryCallback = std::function<S3RequestQuery(const ParsedS3Url &)>;
+
+	string url;
+	S3RequestOperation operation;
+	CreateQueryCallback create_query;
+	string payload_hash;
+	string content_type;
+	string content_md5;
 };
 
 struct S3RequestData {
-	RequestType request_type = RequestType::GET_REQUEST;
+	S3RequestOperation operation;
 	S3AuthParams auth_params;
 	unique_ptr<HTTPParams> http_params;
 	CapturedHTTPRequestSnapshot captured;
@@ -89,8 +130,9 @@ struct S3RequestData {
 };
 
 struct S3RequestUtil {
+	static const S3RequestOperationInfo &GetOperationInfo(S3RequestOperation operation);
 	static HTTPHeaders CreateHeaders(EncryptionUtil &encryption_util, const ParsedS3Url &parsed_url,
-	                                 S3RequestTarget target, const S3RequestQuery &query, RequestType request_type,
+	                                 S3RequestOperation operation, const S3RequestQuery &query,
 	                                 const S3AuthParams &auth_params, string date_now = "", string datetime_now = "",
 	                                 string payload_hash = "", string content_type = "", string content_md5 = "",
 	                                 const unordered_map<string, string> &extra_headers = {},
@@ -102,28 +144,22 @@ struct S3RequestUtil {
 	static string ParseError(const string &error);
 	static HTTPException GetError(const S3AuthParams &auth_params, const HTTPResponse &response,
 	                              RequestType request_type, const string &operation, const string &display_url);
+	static HTTPException GetRequestError(const S3RequestContext &request_context, const HTTPResponse &response);
 	static HTTPException GetRequestError(const S3RequestData &request_data, const HTTPResponse &response);
 };
 
 struct S3RequestExecutor {
 	using RequestCallback = std::function<unique_ptr<HTTPResponse>(S3RequestData &)>;
-	using CreateQueryCallback = std::function<S3RequestQuery(const ParsedS3Url &)>;
 	using RegionRedirectCallback = std::function<void(const S3RequestData &, const string &, const string &)>;
 	using ReceivedResponseCallback =
 	    std::function<S3ReceivedResponseAction(const S3RequestData &, const HTTPResponse &)>;
 
-	static unique_ptr<HTTPResponse> RunSession(EncryptionUtil &encryption_util, HTTPRequestSession &session,
-	                                           const string &s3_url, RequestType request_type, S3RequestTarget target,
-	                                           const CreateQueryCallback &create_query, const string &payload_hash,
-	                                           const string &content_type, const string &content_md5,
-	                                           const RequestCallback &request,
-	                                           const RegionRedirectCallback &region_redirect = {},
-	                                           optional_ptr<S3RequestContext> request_context = nullptr,
-	                                           S3PostRequestMode post_request_mode = S3PostRequestMode::DEFAULT,
-	                                           const ReceivedResponseCallback &response_callback = {});
-	static unique_ptr<HTTPResponse> RunHandle(EncryptionUtil &encryption_util, S3FileHandle &handle,
-	                                          const string &s3_url, RequestType request_type, const string &version_id,
-	                                          const RequestCallback &request);
+	static S3RequestResult RunSession(EncryptionUtil &encryption_util, HTTPRequestSession &session,
+	                                  const S3RequestSpec &spec, const RequestCallback &request,
+	                                  const RegionRedirectCallback &region_redirect = {},
+	                                  const ReceivedResponseCallback &response_callback = {});
+	static S3RequestResult RunHandle(EncryptionUtil &encryption_util, S3FileHandle &handle, const S3RequestSpec &spec,
+	                                 const RequestCallback &request);
 
 	static bool SetSessionRegion(HTTPRequestSession &session, const string &correct_region, string &previous_region);
 	static bool CredentialRefreshEnabled(optional_ptr<FileOpener> opener);
@@ -140,26 +176,20 @@ struct S3RequestExecutor {
 
 private:
 	using CreateDataCallback = std::function<S3RequestData()>;
-	using FinalRequestCallback = std::function<void(const S3RequestData &)>;
 	using FreshConnectionCallback = std::function<void(const S3RequestData &)>;
 	using RefreshCallback = std::function<bool(const S3RequestData &)>;
 	using SetRegionCallback = std::function<void(const S3RequestData &, const string &)>;
 
-	static unique_ptr<HTTPResponse> Run(const string &s3_url, const CreateDataCallback &create_data,
-	                                    const RequestCallback &request, const RefreshCallback &refresh_auth_params,
-	                                    const SetRegionCallback &set_region, const FinalRequestCallback &final_request,
-	                                    const FreshConnectionCallback &fresh_connection,
-	                                    S3PostRequestMode post_request_mode = S3PostRequestMode::DEFAULT,
-	                                    const ReceivedResponseCallback &response_callback = {});
+	static S3RequestResult Run(const CreateDataCallback &create_data, const RequestCallback &request,
+	                           const RefreshCallback &refresh_auth_params, const SetRegionCallback &set_region,
+	                           const FreshConnectionCallback &fresh_connection,
+	                           const ReceivedResponseCallback &response_callback = {});
 	static bool TryRefreshSession(HTTPRequestSession &session, const S3RequestData &request_data);
 	static void InvalidateSessionConnections(HTTPRequestSession &session, HTTPFSParams &params);
 	static S3RequestData CreateRequestData(EncryptionUtil &encryption_util, const CapturedHTTPRequestSnapshot &captured,
-	                                       const string &s3_url, RequestType request_type, S3RequestTarget target,
-	                                       const CreateQueryCallback &create_query, const string &payload_hash = "",
-	                                       const string &content_type = "", const string &content_md5 = "");
+	                                       const S3RequestSpec &spec);
 	static S3RequestData CreateHandleRequestData(EncryptionUtil &encryption_util, S3FileHandle &handle,
-	                                             const string &s3_url, RequestType request_type,
-	                                             const string &version_id);
+	                                             const S3RequestSpec &spec);
 };
 
 } // namespace duckdb

--- a/src/include/s3/s3_request.hpp
+++ b/src/include/s3/s3_request.hpp
@@ -135,8 +135,7 @@ struct S3RequestUtil {
 	                                 S3RequestOperation operation, const S3RequestQuery &query,
 	                                 const S3AuthParams &auth_params, string date_now = "", string datetime_now = "",
 	                                 string payload_hash = "", string content_type = "", string content_md5 = "",
-	                                 const unordered_map<string, string> &extra_headers = {},
-	                                 const string &user_agent = "");
+	                                 const HTTPConfiguredHeaders &configured_headers = {});
 	static string GetPayloadHash(EncryptionUtil &encryption_util, const_data_ptr_t buffer, idx_t buffer_len);
 	static bool IsRequestTimeout(const HTTPResponse &response);
 	static bool IsRetryableReceivedResponse(const HTTPResponse &response);

--- a/src/include/s3/s3_upload_session.hpp
+++ b/src/include/s3/s3_upload_session.hpp
@@ -18,6 +18,8 @@ class S3FileSystem;
 struct HTTPResponse;
 struct S3RequestContext;
 struct S3RequestQuery;
+struct S3RequestResult;
+enum class S3RequestOperation : uint8_t;
 enum class RequestType : uint8_t;
 
 class S3UploadSession {
@@ -144,16 +146,15 @@ private:
 	void CompleteMultipartUpload();
 
 	//! S3 upload and cleanup requests.
-	unique_ptr<HTTPResponse> RunUploadRequest(const_data_ptr_t data, idx_t size, const S3RequestQuery &query,
-	                                          S3RequestContext &request_context);
+	S3RequestResult RunUploadRequest(S3RequestOperation operation, const_data_ptr_t data, idx_t size,
+	                                 const S3RequestQuery &query);
 	void UploadObject(const_data_ptr_t data, idx_t size);
 	void UploadPart(PreparedPart &part);
 	shared_ptr<const ErrorData> AbortMultipartUpload(const string &upload_id);
 
 	//! Request diagnostics.
 	string GetDisplayPath() const;
-	static HTTPException GetStatusError(const HTTPResponse &response, const S3RequestContext &request_context,
-	                                    const string &operation);
+	static HTTPException GetStatusError(const HTTPResponse &response, const S3RequestContext &request_context);
 
 private:
 	//! Immutable upload context.

--- a/src/include/s3/s3_url.hpp
+++ b/src/include/s3/s3_url.hpp
@@ -46,13 +46,13 @@ enum class S3URLEncodeMode : uint8_t { PATH, QUERY_COMPONENT };
 struct S3Url {
 	static string Decode(const string &input);
 	static string Encode(const string &input, S3URLEncodeMode mode);
+	static void ApplyAuthQueryParameters(const string &url, S3AuthConfig &config);
 	static ParsedS3Url Parse(const string &url, const S3AuthParams &params);
-	static ParsedS3Url Resolve(const string &url, S3AuthParams &params);
 	static string GetDisplayUrl(const string &url, const S3AuthParams &params);
 
 private:
 	static unordered_map<string, string> ParseQueryParameters(const string &url_query_param);
-	static void ReadQueryParams(const string &url_query_param, S3AuthParams &params);
+	static void ReadQueryParams(const string &url_query_param, S3AuthConfig &config);
 };
 
 } // namespace duckdb

--- a/src/include/s3/s3fs.hpp
+++ b/src/include/s3/s3fs.hpp
@@ -115,17 +115,14 @@ public:
 	unique_ptr<HTTPResponse> GetRangeRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
 	                                         const HTTPReadConfig &read_config, idx_t file_offset,
 	                                         data_ptr_t buffer_out, idx_t buffer_out_len) override;
-	unique_ptr<HTTPResponse> PostRequest(HTTPRequestSession &session, const string &s3_url, string &buffer_out,
-	                                     const_data_ptr_t buffer_in, idx_t buffer_in_len,
-	                                     const S3RequestQuery &query = S3RequestQuery(),
-	                                     S3PostRequestMode mode = S3PostRequestMode::DEFAULT,
-	                                     optional_ptr<S3RequestContext> request_context = nullptr);
-	unique_ptr<HTTPResponse> PutRequest(HTTPRequestSession &session, const string &s3_url, const_data_ptr_t buffer_in,
-	                                    idx_t buffer_in_len, const S3RequestQuery &query = S3RequestQuery(),
-	                                    optional_ptr<S3RequestContext> request_context = nullptr);
-	unique_ptr<HTTPResponse> DeleteRequest(HTTPRequestSession &session, const string &s3_url,
-	                                       const S3RequestQuery &query,
-	                                       optional_ptr<S3RequestContext> request_context = nullptr);
+	S3RequestResult PostRequest(HTTPRequestSession &session, S3RequestOperation operation, const string &s3_url,
+	                            string &buffer_out, const_data_ptr_t buffer_in, idx_t buffer_in_len,
+	                            const S3RequestQuery &query = S3RequestQuery());
+	S3RequestResult PutRequest(HTTPRequestSession &session, S3RequestOperation operation, const string &s3_url,
+	                           const_data_ptr_t buffer_in, idx_t buffer_in_len,
+	                           const S3RequestQuery &query = S3RequestQuery());
+	S3RequestResult DeleteRequest(HTTPRequestSession &session, S3RequestOperation operation, const string &s3_url,
+	                              const S3RequestQuery &query);
 	unique_ptr<HTTPResponse> DeleteRequest(FileHandle &handle, const string &s3_url, HTTPHeaders header_map) override;
 	HTTPException GetHTTPError(FileHandle &, const HTTPResponse &response, RequestType request_type,
 	                           const string &url) override;
@@ -144,9 +141,8 @@ protected:
 	                                        optional_ptr<FileOpener> opener) override;
 
 private:
-	unique_ptr<HTTPResponse> RunS3BulkDeleteRequest(HTTPRequestSession &session, const string &secret_lookup_url,
-	                                                const string &body, idx_t key_count, string &result,
-	                                                optional_ptr<S3RequestContext> request_context = nullptr);
+	S3RequestResult RunS3BulkDeleteRequest(HTTPRequestSession &session, const string &secret_lookup_url,
+	                                       const string &body, idx_t key_count, string &result);
 
 public:
 	BufferManager &buffer_manager;

--- a/src/include/s3/s3fs.hpp
+++ b/src/include/s3/s3fs.hpp
@@ -127,7 +127,9 @@ public:
 	HTTPException GetHTTPError(FileHandle &, const HTTPResponse &response, RequestType request_type,
 	                           const string &url) override;
 
+	//! Database services used by S3 requests and uploads.
 	EncryptionUtil &GetEncryptionUtil();
+	BufferManager &GetBufferManager();
 
 protected:
 	//! FileSystem extension points for S3 open/list/glob.
@@ -144,7 +146,7 @@ private:
 	S3RequestResult RunS3BulkDeleteRequest(HTTPRequestSession &session, const string &secret_lookup_url,
 	                                       const string &body, idx_t key_count, string &result);
 
-public:
+	//! Database-owned buffer manager.
 	BufferManager &buffer_manager;
 };
 } // namespace duckdb

--- a/src/s3/s3_auth.cpp
+++ b/src/s3/s3_auth.cpp
@@ -1,5 +1,7 @@
 #include "s3/s3_auth.hpp"
 
+#include "s3/s3_url.hpp"
+
 #include "duckdb/common/string_util.hpp"
 
 #include <cstdlib>
@@ -31,53 +33,183 @@ void AWSEnvironmentCredentialsProvider::SetAll() {
 	this->SetExtensionOptionValue("s3_requester_pays", DUCKDB_REQUESTER_PAYS_ENV_VAR);
 }
 
-S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info) {
-	// Without a FileOpener we can not access settings nor secrets: return empty auth params
-	if (!opener) {
-		auto result = S3AuthParams();
-		// Matches ReadAuthParams: a scheme that is not built in was routed here by an alias
-		auto provider_match = S3Provider::TryMatchUrl(info.file_path);
-		result.provider_type = provider_match ? provider_match->type : S3ProviderType::S3;
-		result.scheme_is_alias = !provider_match;
-		return result;
-	}
+S3AuthParams::S3AuthParams() = default;
 
-	auto secret_types = S3Provider::SecretTypes();
-	S3KeyValueReader secret_reader(*opener, info, secret_types.data(), secret_types.size());
-
-	return ReadFrom(secret_reader, info.file_path);
+bool S3AuthCredentials::operator==(const S3AuthCredentials &other) const {
+	return region == other.region && access_key_id == other.access_key_id &&
+	       secret_access_key == other.secret_access_key && session_token == other.session_token &&
+	       oauth2_bearer_token == other.oauth2_bearer_token;
 }
 
-S3AuthParams S3AuthParams::ReadFrom(S3KeyValueReader &secret_reader, const string &file_path) {
-	auto result = S3AuthParams();
-	S3Provider::ReadAuthParams(secret_reader, file_path, result);
+bool S3AuthURLParams::operator==(const S3AuthURLParams &other) const {
+	return endpoint == other.endpoint && endpoint_mode == other.endpoint_mode && style == other.style &&
+	       compatibility_mode == other.compatibility_mode;
+}
+
+bool S3AuthRequestOptions::operator==(const S3AuthRequestOptions &other) const {
+	return kms_key_id == other.kms_key_id && requester_pays == other.requester_pays &&
+	       user_project == other.user_project;
+}
+
+S3AuthParams S3AuthResolver::Resolve(optional_ptr<FileOpener> opener, FileOpenerInfo &info) {
+	// Without a FileOpener we cannot access settings or secrets.
+	if (!opener) {
+		S3AuthConfig config;
+		config.route = S3UrlScheme::MatchRoutedUrl(info.file_path);
+		return Resolve(std::move(config), info.file_path);
+	}
+
+	auto secret_types = S3SecretConfig::SecretTypes();
+	S3KeyValueReader secret_reader(*opener, info, secret_types.data(), secret_types.size());
+	return Resolve(secret_reader, info.file_path);
+}
+
+S3AuthParams S3AuthResolver::Resolve(S3KeyValueReader &secret_reader, const string &file_path) {
+	return Resolve(ReadConfig(secret_reader, file_path), file_path);
+}
+
+static void SetEndpoint(S3AuthConfig &config, string endpoint) {
+	config.endpoint = std::move(endpoint);
+	auto trimmed_endpoint = config.endpoint;
+	StringUtil::Trim(trimmed_endpoint);
+	config.endpoint_mode = trimmed_endpoint.empty() ? S3EndpointMode::AUTOMATIC : S3EndpointMode::EXPLICIT;
+}
+
+S3AuthConfig S3AuthResolver::ReadConfig(S3KeyValueReader &secret_reader, const string &file_path) {
+	S3AuthConfig config;
+	config.route = S3UrlScheme::MatchRoutedUrl(file_path);
+	auto &credentials = config.credentials;
+	auto &request_options = config.request_options;
+	secret_reader.TryGetSecretKeyOrSetting("region", "s3_region", credentials.region);
+	secret_reader.TryGetSecretKeyOrSetting("key_id", "s3_access_key_id", credentials.access_key_id);
+	secret_reader.TryGetSecretKeyOrSetting("secret", "s3_secret_access_key", credentials.secret_access_key);
+	secret_reader.TryGetSecretKeyOrSetting("session_token", "s3_session_token", credentials.session_token);
+	secret_reader.TryGetSecretKeyOrSetting("use_ssl", "s3_use_ssl", config.use_ssl);
+	secret_reader.TryGetSecretKeyOrSetting("kms_key_id", "s3_kms_key_id", request_options.kms_key_id);
+	secret_reader.TryGetSecretKeysOrSetting("url_compatibility_mode", "s3_url_compatibility_mode",
+	                                        "s3_url_compatibility_mode", config.compatibility_mode);
+	secret_reader.TryGetSecretKeyOrSetting("requester_pays", "s3_requester_pays", request_options.requester_pays);
+
+	string endpoint;
+	auto endpoint_result = secret_reader.TryGetSecretKeyOrSetting("endpoint", "s3_endpoint", endpoint);
+	auto url_style_result = secret_reader.TryGetSecretKeyOrSetting("url_style", "s3_url_style", config.url_style);
+	if (config.route.type == S3ProviderType::GCS) {
+		if (endpoint_result && endpoint_result.GetScope() == SettingScope::SECRET) {
+			SetEndpoint(config, std::move(endpoint));
+		}
+		if (config.url_style.empty() || !url_style_result || url_style_result.GetScope() != SettingScope::SECRET) {
+			config.url_style = "path";
+		}
+		secret_reader.TryGetSecretKeyOrSetting("user_project", "gcs_user_project", request_options.user_project);
+		secret_reader.TryGetSecretKey("bearer_token", credentials.oauth2_bearer_token);
+	} else {
+		SetEndpoint(config, std::move(endpoint));
+	}
+	return config;
+}
+
+static bool EndpointIsAWS(const NormalizedS3Endpoint &endpoint) {
+	if (endpoint.IsEmpty()) {
+		return true;
+	}
+	return StringUtil::StartsWith(endpoint.GetHost(), "s3.") &&
+	       StringUtil::EndsWith(endpoint.GetHost(), ".amazonaws.com");
+}
+
+static bool EndpointIsUnresolved(const string &endpoint) {
+	auto trimmed_endpoint = endpoint;
+	StringUtil::Trim(trimmed_endpoint);
+	return trimmed_endpoint.empty();
+}
+
+S3URLStyle S3AuthURLParams::ParseStyle(const string &url_style) {
+	if (url_style.empty() || url_style == "vhost" || url_style == "virtual") {
+		return S3URLStyle::VIRTUAL_HOSTED;
+	}
+	if (url_style == "path") {
+		return S3URLStyle::PATH;
+	}
+	throw InvalidInputException("Invalid S3 URL style '%s': expected 'vhost', 'virtual', 'path', or an empty string",
+	                            url_style);
+}
+
+S3AuthParams S3AuthResolver::Resolve(S3AuthConfig config, const string &file_path) {
+	S3Url::ApplyAuthQueryParameters(file_path, config);
+	auto &credentials = config.credentials;
+	auto &request_options = config.request_options;
+
+	if (config.route.type == S3ProviderType::GCS) {
+		if (EndpointIsUnresolved(config.endpoint)) {
+			config.endpoint = "storage.googleapis.com";
+			config.endpoint_mode = S3EndpointMode::AUTOMATIC;
+		}
+		if (config.url_style.empty()) {
+			config.url_style = "path";
+		}
+		if (credentials.region.empty() && credentials.oauth2_bearer_token.empty() &&
+		    (!credentials.secret_access_key.empty() || !credentials.access_key_id.empty())) {
+			credentials.region = "auto";
+		}
+	}
+
+	auto style = S3AuthURLParams::ParseStyle(config.url_style);
+	if (config.route.type == S3ProviderType::GCS && request_options.requester_pays &&
+	    request_options.user_project.empty()) {
+		throw InvalidInputException(
+		    "GCS Requester Pays requires a billing project; set USER_PROJECT in the GCS secret, "
+		    "set gcs_user_project, or pass gcs_user_project in the URL.");
+	}
+	if ((config.route.IsAlias() || config.route.type == S3ProviderType::R2) && EndpointIsUnresolved(config.endpoint)) {
+		if (config.route.type == S3ProviderType::R2) {
+			throw IOException("R2 requires an endpoint; provide account_id in the secret or s3_endpoint in the URL");
+		}
+		throw IOException("An aliased URL scheme requires an endpoint; provide ENDPOINT in the secret, set "
+		                  "s3_endpoint, or pass s3_endpoint in the URL");
+	}
+
+	auto endpoint = NormalizedS3Endpoint::Parse(config.endpoint, config.use_ssl);
+	if (config.route.type == S3ProviderType::S3 && !config.route.IsAlias() &&
+	    endpoint.GetHost() == "s3.amazonaws.com" && endpoint.GetBasePath().empty() && endpoint.IsDefaultPort()) {
+		config.endpoint_mode = S3EndpointMode::AUTOMATIC;
+	}
+	if (config.route.type == S3ProviderType::S3 &&
+	    (config.endpoint_mode == S3EndpointMode::AUTOMATIC || EndpointIsAWS(endpoint))) {
+		if (credentials.region.empty()) {
+			if (credentials.access_key_id.empty()) {
+				if (config.endpoint_mode == S3EndpointMode::AUTOMATIC) {
+					endpoint.SetHost("s3.amazonaws.com");
+				}
+			} else {
+				credentials.region = "us-east-1";
+			}
+		}
+		if (config.endpoint_mode == S3EndpointMode::AUTOMATIC && !credentials.region.empty()) {
+			endpoint.SetHost(StringUtil::Format("s3.%s.amazonaws.com", credentials.region));
+		}
+	}
+
+	S3AuthParams result;
+	result.provider = S3Provider::Resolve(std::move(config.route), endpoint);
+	result.credentials = std::move(credentials);
+	result.url = {std::move(endpoint), config.endpoint_mode, style, config.compatibility_mode};
+	result.request_options = std::move(request_options);
+	result.refresh_identity = {config.use_ssl};
 	return result;
 }
 
-void S3AuthParams::SetEndpoint(string new_endpoint) {
-	endpoint_source = std::move(new_endpoint);
-	endpoint = NormalizedS3Endpoint();
-	auto trimmed_endpoint = endpoint_source;
-	StringUtil::Trim(trimmed_endpoint);
-	endpoint_mode = trimmed_endpoint.empty() ? S3EndpointMode::AUTOMATIC : S3EndpointMode::EXPLICIT;
-}
-
-const NormalizedS3Endpoint &S3AuthParams::GetEndpoint() const {
-	return endpoint;
-}
-
-void S3AuthParams::SetRegion(string new_region) {
-	region = std::move(new_region);
-	S3Provider::FinalizeAuthParams(*this);
+S3AuthParams S3AuthParams::WithRegion(string region) const {
+	auto result = *this;
+	result.credentials.region = std::move(region);
+	if (result.provider.GetType() == S3ProviderType::S3 && result.url.endpoint_mode == S3EndpointMode::AUTOMATIC) {
+		result.url.endpoint.SetHost(StringUtil::Format("s3.%s.amazonaws.com", result.credentials.region));
+	}
+	result.provider = S3Provider::Resolve(result.provider.GetRoute(), result.url.endpoint);
+	return result;
 }
 
 bool S3AuthParams::operator==(const S3AuthParams &other) const {
-	return provider_type == other.provider_type && scheme_is_alias == other.scheme_is_alias && region == other.region &&
-	       access_key_id == other.access_key_id && secret_access_key == other.secret_access_key &&
-	       session_token == other.session_token && endpoint == other.endpoint && endpoint_mode == other.endpoint_mode &&
-	       kms_key_id == other.kms_key_id && url_style == other.url_style &&
-	       s3_url_compatibility_mode == other.s3_url_compatibility_mode && requester_pays == other.requester_pays &&
-	       user_project == other.user_project && oauth2_bearer_token == other.oauth2_bearer_token;
+	return provider == other.provider && credentials == other.credentials && url == other.url &&
+	       request_options == other.request_options;
 }
 
 S3KeyValueReader::S3KeyValueReader(FileOpener &opener_p, optional_ptr<FileOpenerInfo> info, const char **secret_types,

--- a/src/s3/s3_delete.cpp
+++ b/src/s3/s3_delete.cpp
@@ -7,18 +7,81 @@
 #include "duckdb/common/crypto/md5.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/blob.hpp"
+#include "duckdb/common/unordered_map.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 
-#include <algorithm>
+#include <functional>
 
 namespace duckdb {
+
+static void CombineDeleteHash(hash_t &result, hash_t value) {
+	result ^= value + 0x9e3779b97f4a7c15ULL + (result << 6) + (result >> 2);
+}
+
+static void AddDeleteHash(hash_t &result, const string &value) {
+	CombineDeleteHash(result, std::hash<string> {}(value));
+}
+
+static void AddDeleteHash(hash_t &result, idx_t value) {
+	CombineDeleteHash(result, std::hash<idx_t> {}(value));
+}
+
+template <class ENUM_TYPE>
+static void AddDeleteEnumHash(hash_t &result, ENUM_TYPE value) {
+	AddDeleteHash(result, static_cast<idx_t>(value));
+}
+
+static void AddDeleteAuthHash(hash_t &result, const S3AuthParams &auth_params) {
+	auto &provider = auth_params.GetProvider();
+	auto &route = provider.GetRoute();
+	AddDeleteEnumHash(result, route.type);
+	AddDeleteHash(result, route.prefix);
+	AddDeleteEnumHash(result, route.origin);
+	AddDeleteEnumHash(result, provider.GetCompatibilityProfile());
+
+	auto &credentials = auth_params.GetCredentials();
+	AddDeleteHash(result, credentials.region);
+	AddDeleteHash(result, credentials.access_key_id);
+	AddDeleteHash(result, credentials.secret_access_key);
+	AddDeleteHash(result, credentials.session_token);
+	AddDeleteHash(result, credentials.oauth2_bearer_token);
+
+	auto &url = auth_params.GetURLParams();
+	AddDeleteHash(result, url.endpoint.GetCanonicalValue());
+	AddDeleteEnumHash(result, url.endpoint_mode);
+	AddDeleteEnumHash(result, url.style);
+	AddDeleteHash(result, static_cast<idx_t>(url.compatibility_mode));
+
+	auto &request_options = auth_params.GetRequestOptions();
+	AddDeleteHash(result, request_options.kms_key_id);
+	AddDeleteHash(result, static_cast<idx_t>(request_options.requester_pays));
+	AddDeleteHash(result, request_options.user_project);
+}
+
+static void AddDeleteHTTPHash(hash_t &result, const S3RefreshableHTTPParams &http_params) {
+	AddDeleteHash(result, http_params.http_proxy);
+	AddDeleteHash(result, http_params.http_proxy_port);
+	AddDeleteHash(result, http_params.http_proxy_username);
+	AddDeleteHash(result, http_params.http_proxy_password);
+	AddDeleteHash(result, static_cast<idx_t>(http_params.override_verify_ssl));
+	AddDeleteHash(result, static_cast<idx_t>(http_params.verify_ssl));
+	AddDeleteHash(result, http_params.bearer_token);
+
+	hash_t headers_hash = 0;
+	for (const auto &header : http_params.extra_headers) {
+		hash_t header_hash = 0;
+		AddDeleteHash(header_hash, header.first);
+		AddDeleteHash(header_hash, header.second);
+		headers_hash ^= header_hash;
+	}
+	CombineDeleteHash(result, headers_hash);
+}
 
 void S3FileSystem::RemoveFile(const string &path, optional_ptr<FileOpener> opener) {
 	auto handle = OpenFile(path, FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS, opener);
 	if (!handle) {
 		FileOpenerInfo info = {path};
-		auto auth_params = S3AuthParams::ReadFrom(opener, info);
-		S3Url::Resolve(path, auth_params);
+		auto auth_params = S3AuthResolver::Resolve(opener, info);
 		throw IOException({{"errno", "404"}}, "Could not remove file \"%s\": %s",
 		                  S3Url::GetDisplayUrl(path, auth_params), string("No such file or directory"));
 	}
@@ -42,107 +105,118 @@ struct S3DeleteBatchUrlInfo {
 	S3AuthParams auth_params;
 };
 
-struct S3DeleteBatch {
+struct S3DeleteSecretIdentity {
+	string lookup_type;
+	string secret_type;
+	string provider;
+	string name;
+	string storage_mode;
+	idx_t persist_type = 0;
+	vector<string> scope;
+	optional_idx score;
+
+	bool operator==(const S3DeleteSecretIdentity &other) const {
+		return lookup_type == other.lookup_type && secret_type == other.secret_type && provider == other.provider &&
+		       name == other.name && storage_mode == other.storage_mode && persist_type == other.persist_type &&
+		       scope == other.scope && score == other.score;
+	}
+
+	void AddHash(hash_t &result) const {
+		AddDeleteHash(result, lookup_type);
+		AddDeleteHash(result, secret_type);
+		AddDeleteHash(result, provider);
+		AddDeleteHash(result, name);
+		AddDeleteHash(result, storage_mode);
+		AddDeleteHash(result, persist_type);
+		for (const auto &entry : scope) {
+			AddDeleteHash(result, entry);
+		}
+		AddDeleteHash(result, static_cast<idx_t>(score.IsValid()));
+		if (score.IsValid()) {
+			AddDeleteHash(result, score.GetIndex());
+		}
+	}
+};
+
+struct S3DeleteBatchIdentity {
 	S3DeleteBatchUrlInfo url_info;
-	vector<string> keys;
-	vector<string> secret_lookup_paths;
+	S3RefreshableHTTPParams http_params;
+	vector<S3DeleteSecretIdentity> selected_secrets;
+	bool credential_refresh_enabled = false;
+	bool has_refreshable_secret = false;
+	string refresh_lookup_directory;
+	optional<S3AuthRefreshIdentity> refresh_identity;
+
+	bool operator==(const S3DeleteBatchIdentity &other) const {
+		return url_info.prefix == other.url_info.prefix && url_info.bucket_http_url == other.url_info.bucket_http_url &&
+		       url_info.auth_params == other.url_info.auth_params && http_params == other.http_params &&
+		       selected_secrets == other.selected_secrets &&
+		       credential_refresh_enabled == other.credential_refresh_enabled &&
+		       has_refreshable_secret == other.has_refreshable_secret &&
+		       refresh_lookup_directory == other.refresh_lookup_directory && refresh_identity == other.refresh_identity;
+	}
+
+	hash_t Hash() const {
+		hash_t result = 0;
+		AddDeleteHash(result, url_info.prefix);
+		AddDeleteHash(result, url_info.bucket_http_url);
+		AddDeleteAuthHash(result, url_info.auth_params);
+		AddDeleteHTTPHash(result, http_params);
+		for (const auto &secret : selected_secrets) {
+			secret.AddHash(result);
+		}
+		AddDeleteHash(result, static_cast<idx_t>(credential_refresh_enabled));
+		AddDeleteHash(result, static_cast<idx_t>(has_refreshable_secret));
+		AddDeleteHash(result, refresh_lookup_directory);
+		AddDeleteHash(result, static_cast<idx_t>(refresh_identity.has_value()));
+		if (refresh_identity) {
+			AddDeleteHash(result, static_cast<idx_t>(refresh_identity->use_ssl));
+		}
+		return result;
+	}
 };
 
-struct S3DeleteBatchKeyBuilder {
-	void AddString(const string &value) {
-		parts.push_back(StringUtil::Format("%s:%s;", to_string(value.size()), value));
+struct S3DeleteBatchIdentityHash {
+	std::size_t operator()(const S3DeleteBatchIdentity &identity) const {
+		return identity.Hash();
 	}
-
-	void AddBool(bool value) {
-		AddString(value ? string("1") : string("0"));
-	}
-
-	void AddIndex(idx_t value) {
-		AddString(to_string(value));
-	}
-
-	string Build() const {
-		return StringUtil::Join(parts, "");
-	}
-
-private:
-	vector<string> parts;
 };
 
-static void AddDeleteBatchUrlKeyParts(S3DeleteBatchKeyBuilder &key_builder, const S3DeleteBatchUrlInfo &url_info) {
-	key_builder.AddString(url_info.prefix);
-	key_builder.AddString(url_info.bucket_http_url);
-}
+struct S3DeleteBatchEntry {
+	string key;
+	string secret_lookup_path;
+};
 
-static void AddDeleteBatchAuthKeyParts(S3DeleteBatchKeyBuilder &key_builder, const S3AuthParams &auth_params) {
-	key_builder.AddIndex(static_cast<idx_t>(auth_params.provider_type));
-	key_builder.AddString(auth_params.region);
-	key_builder.AddString(auth_params.access_key_id);
-	key_builder.AddString(auth_params.secret_access_key);
-	key_builder.AddString(auth_params.session_token);
-	key_builder.AddString(auth_params.GetEndpoint().GetCanonicalValue());
-	key_builder.AddIndex(static_cast<idx_t>(auth_params.endpoint_mode));
-	key_builder.AddString(auth_params.kms_key_id);
-	key_builder.AddString(auth_params.url_style);
-	key_builder.AddBool(auth_params.s3_url_compatibility_mode);
-	key_builder.AddBool(auth_params.requester_pays);
-	key_builder.AddString(auth_params.user_project);
-	key_builder.AddString(auth_params.oauth2_bearer_token);
-}
-
-static void AddDeleteBatchHTTPKeyParts(S3DeleteBatchKeyBuilder &key_builder,
-                                       const S3RefreshableHTTPParams &refreshable_http_params) {
-	key_builder.AddString(refreshable_http_params.http_proxy);
-	key_builder.AddIndex(refreshable_http_params.http_proxy_port);
-	key_builder.AddString(refreshable_http_params.http_proxy_username);
-	key_builder.AddString(refreshable_http_params.http_proxy_password);
-	key_builder.AddBool(refreshable_http_params.override_verify_ssl);
-	key_builder.AddBool(refreshable_http_params.verify_ssl);
-	key_builder.AddString(refreshable_http_params.bearer_token);
-
-	vector<pair<string, string>> extra_headers;
-	for (auto &entry : refreshable_http_params.extra_headers) {
-		extra_headers.emplace_back(entry.first, entry.second);
-	}
-	std::sort(extra_headers.begin(), extra_headers.end());
-	for (auto &entry : extra_headers) {
-		key_builder.AddString(entry.first);
-		key_builder.AddString(entry.second);
-	}
-}
-
-static void AddDeleteBatchSecretKeyParts(S3DeleteBatchKeyBuilder &key_builder, const SecretEntry &secret_entry) {
+static S3DeleteSecretIdentity GetDeleteSecretIdentity(const string &lookup_type, const SecretEntry &secret_entry,
+                                                      idx_t score) {
 	auto &secret = *secret_entry.secret;
-	key_builder.AddString(static_cast<const string &>(secret.GetType()));
-	key_builder.AddString(static_cast<const string &>(secret.GetProvider()));
-	key_builder.AddString(static_cast<const string &>(secret.GetName()));
-	key_builder.AddString(secret_entry.storage_mode);
-	key_builder.AddIndex(static_cast<idx_t>(secret_entry.persist_type));
-	key_builder.AddIndex(secret.GetScope().size());
-	for (auto &scope : secret.GetScope()) {
-		key_builder.AddString(scope);
-	}
+	return {lookup_type,
+	        static_cast<const string &>(secret.GetType()),
+	        static_cast<const string &>(secret.GetProvider()),
+	        static_cast<const string &>(secret.GetName()),
+	        secret_entry.storage_mode,
+	        static_cast<idx_t>(secret_entry.persist_type),
+	        secret.GetScope(),
+	        score};
 }
 
-static void AddDeleteBatchSelectedSecretKeyParts(S3DeleteBatchKeyBuilder &key_builder, optional_ptr<FileOpener> opener,
-                                                 const string &path) {
+static vector<S3DeleteSecretIdentity> GetSelectedSecretIdentities(optional_ptr<FileOpener> opener, const string &path) {
+	vector<S3DeleteSecretIdentity> result;
 	auto secret_manager = FileOpener::TryGetSecretManager(opener);
 	auto transaction = FileOpener::TryGetCatalogTransaction(opener);
 	if (!secret_manager || !transaction) {
-		key_builder.AddString("");
-		return;
+		return result;
 	}
 
-	for (const auto type : S3Provider::SecretTypes()) {
-		key_builder.AddString(type);
+	for (const auto type : S3SecretConfig::SecretTypes()) {
 		auto match = secret_manager->LookupSecret(*transaction, path, type);
 		if (!match.HasMatch()) {
-			key_builder.AddString("");
+			result.push_back({type, {}});
 			continue;
 		}
-		key_builder.AddIndex(NumericCast<idx_t>(match.score));
-		AddDeleteBatchSecretKeyParts(key_builder, *match.secret_entry);
+		result.push_back(GetDeleteSecretIdentity(type, *match.secret_entry, NumericCast<idx_t>(match.score)));
 	}
+	return result;
 }
 
 static string GetDeleteBatchLookupDirectory(const string &path) {
@@ -157,34 +231,28 @@ static bool HasRefreshableS3Secret(optional_ptr<FileOpener> opener, const string
 	if (!opener) {
 		return false;
 	}
-	auto secret_types = S3Provider::SecretTypes();
+	auto secret_types = S3SecretConfig::SecretTypes();
 	FileOpenerInfo info = {path};
 	KeyValueSecretReader secret_reader(*opener, info, secret_types.data(), secret_types.size());
 	Value refresh_info;
 	return secret_reader.TryGetSecretKey("refresh_info", refresh_info);
 }
 
-static void AddDeleteBatchRefreshKeyParts(S3DeleteBatchKeyBuilder &key_builder, optional_ptr<FileOpener> opener,
-                                          const string &path, const S3AuthParams &auth_params) {
-	auto refreshable = S3RequestExecutor::CredentialRefreshEnabled(opener) && HasRefreshableS3Secret(opener, path);
-	if (refreshable) {
-		key_builder.AddString(GetDeleteBatchLookupDirectory(path));
-	} else {
-		key_builder.AddString("");
+static S3DeleteBatchIdentity CreateDeleteBatchIdentity(S3DeleteBatchUrlInfo url_info,
+                                                       S3RefreshableHTTPParams http_params,
+                                                       optional_ptr<FileOpener> opener, const string &path) {
+	auto selected_secrets = GetSelectedSecretIdentities(opener, path);
+	auto credential_refresh_enabled = S3RequestExecutor::CredentialRefreshEnabled(opener);
+	auto has_refreshable_secret = HasRefreshableS3Secret(opener, path);
+	string refresh_lookup_directory;
+	optional<S3AuthRefreshIdentity> refresh_identity;
+	if (credential_refresh_enabled && has_refreshable_secret) {
+		refresh_lookup_directory = GetDeleteBatchLookupDirectory(path);
+		refresh_identity = url_info.auth_params.GetRefreshIdentity();
 	}
-	key_builder.AddBool(refreshable && auth_params.use_ssl);
-}
-
-static string CreateDeleteBatchKey(const S3DeleteBatchUrlInfo &url_info,
-                                   const S3RefreshableHTTPParams &refreshable_http_params,
-                                   optional_ptr<FileOpener> opener, const string &path) {
-	S3DeleteBatchKeyBuilder key_builder;
-	AddDeleteBatchUrlKeyParts(key_builder, url_info);
-	AddDeleteBatchAuthKeyParts(key_builder, url_info.auth_params);
-	AddDeleteBatchHTTPKeyParts(key_builder, refreshable_http_params);
-	AddDeleteBatchSelectedSecretKeyParts(key_builder, opener, path);
-	AddDeleteBatchRefreshKeyParts(key_builder, opener, path, url_info.auth_params);
-	return key_builder.Build();
+	return {std::move(url_info),        std::move(http_params), std::move(selected_secrets),
+	        credential_refresh_enabled, has_refreshable_secret, std::move(refresh_lookup_directory),
+	        std::move(refresh_identity)};
 }
 
 static string GetS3DeleteContentMD5(const string &body) {
@@ -196,21 +264,20 @@ static string GetS3DeleteContentMD5(const string &body) {
 	return Blob::ToBase64(md5_blob);
 }
 
-unique_ptr<HTTPResponse> S3FileSystem::RunS3BulkDeleteRequest(HTTPRequestSession &session,
-                                                              const string &secret_lookup_url, const string &body,
-                                                              idx_t key_count, string &result,
-                                                              optional_ptr<S3RequestContext> request_context) {
+S3RequestResult S3FileSystem::RunS3BulkDeleteRequest(HTTPRequestSession &session, const string &secret_lookup_url,
+                                                     const string &body, idx_t key_count, string &result) {
 	auto payload_hash =
 	    S3RequestUtil::GetPayloadHash(GetEncryptionUtil(), const_data_ptr_cast(body.data()), body.length());
 	auto content_md5 = GetS3DeleteContentMD5(body);
 	return S3RequestExecutor::RunSession(
-	    GetEncryptionUtil(), session, secret_lookup_url, RequestType::POST_REQUEST, S3RequestTarget::BUCKET,
-	    [&](const ParsedS3Url &) {
-		    return S3RequestQuery({{"delete", ""}});
-	    },
-	    payload_hash, "application/xml", content_md5,
+	    GetEncryptionUtil(), session,
+	    S3RequestSpec {secret_lookup_url, S3RequestOperation::DELETE_OBJECTS,
+	                   [&](const ParsedS3Url &) {
+		                   return S3RequestQuery({{"delete", ""}});
+	                   },
+	                   payload_hash, "application/xml", content_md5},
 	    [&](S3RequestData &request_data) {
-		    auto maximum_key_count = S3Provider::GetBulkDeleteMaxBatchSize(request_data.auth_params);
+		    auto maximum_key_count = request_data.auth_params.GetProvider().GetBulkDeleteMaxBatchSize();
 		    if (key_count > maximum_key_count) {
 			    throw IOException(
 			        "Cannot send S3 bulk delete with %llu keys because the current provider policy allows "
@@ -224,8 +291,7 @@ unique_ptr<HTTPResponse> S3FileSystem::RunS3BulkDeleteRequest(HTTPRequestSession
 			                          return S3RequestExecutor::SendSessionRequest(session, request_data.captured,
 			                                                                       params, request);
 		                          });
-	    },
-	    {}, request_context);
+	    });
 }
 
 void S3FileSystem::RemoveFiles(const vector<string> &paths, optional_ptr<FileOpener> opener) {
@@ -233,52 +299,51 @@ void S3FileSystem::RemoveFiles(const vector<string> &paths, optional_ptr<FileOpe
 		return;
 	}
 
-	unordered_map<string, S3DeleteBatch> delete_batches;
+	unordered_map<S3DeleteBatchIdentity, vector<S3DeleteBatchEntry>, S3DeleteBatchIdentityHash> delete_batches;
 
 	for (auto &path : paths) {
 		FileOpenerInfo info = {path};
-		S3AuthParams auth_params = S3AuthParams::ReadFrom(opener, info);
-		auto parsed_url = S3Url::Resolve(path, auth_params);
+		auto auth_params = S3AuthResolver::Resolve(opener, info);
+		auto parsed_url = S3Url::Parse(path, auth_params);
 
 		S3DeleteBatchUrlInfo url_info = {parsed_url.GetPrefix(), parsed_url.GetBucketHTTPUrl(), auth_params};
 		auto refreshable_http_params = S3RequestExecutor::ReadRefreshableHTTPParams(opener, path);
-		auto batch_key = CreateDeleteBatchKey(url_info, refreshable_http_params, opener, path);
-		auto entry = delete_batches.find(batch_key);
+		auto identity =
+		    CreateDeleteBatchIdentity(std::move(url_info), std::move(refreshable_http_params), opener, path);
+		auto entry = delete_batches.find(identity);
 		if (entry == delete_batches.end()) {
-			S3DeleteBatch batch;
-			batch.url_info = std::move(url_info);
-			entry = delete_batches.emplace(std::move(batch_key), std::move(batch)).first;
+			entry = delete_batches.emplace(std::move(identity), vector<S3DeleteBatchEntry>()).first;
 		}
-		auto &batch = entry->second;
-
-		batch.keys.push_back(parsed_url.GetKey());
-		batch.secret_lookup_paths.push_back(path);
+		entry->second.push_back({parsed_url.GetKey(), path});
 	}
 
-	for (auto &batch_entry : delete_batches) {
-		auto &batch = batch_entry.second;
-		const vector<string> &keys = batch.keys;
-		const vector<string> &secret_lookup_paths = batch.secret_lookup_paths;
-		auto &url_info = batch.url_info;
-		auto maximum_key_count = S3Provider::GetBulkDeleteMaxBatchSize(url_info.auth_params);
+	for (auto &batch : delete_batches) {
+		auto &url_info = batch.first.url_info;
+		auto &entries = batch.second;
+		auto maximum_key_count = url_info.auth_params.GetProvider().GetBulkDeleteMaxBatchSize();
 		auto delete_session =
-		    S3RequestExecutor::CreateSession(opener, secret_lookup_paths.front(), url_info.auth_params);
+		    S3RequestExecutor::CreateSession(opener, entries.front().secret_lookup_path, url_info.auth_params);
+		vector<string> keys;
+		keys.reserve(entries.size());
+		for (auto &entry : entries) {
+			keys.push_back(entry.key);
+		}
 
 		for (idx_t batch_start = 0; batch_start < keys.size(); batch_start += maximum_key_count) {
 			auto batch_end = MinValue<idx_t>(batch_start + maximum_key_count, keys.size());
 			auto body = S3XMLWriter::WriteDeleteObjectsRequest(keys, batch_start, batch_end);
 			string result;
-			S3RequestContext request_context;
-			auto res = RunS3BulkDeleteRequest(*delete_session, secret_lookup_paths[batch_start], body,
-			                                  batch_end - batch_start, result, request_context);
+			auto request_result = RunS3BulkDeleteRequest(*delete_session, entries[batch_start].secret_lookup_path, body,
+			                                             batch_end - batch_start, result);
+			auto &res = request_result.response;
+			auto &request_context = request_result.context;
 
 			if (res->HasRequestError()) {
 				throw IOException("S3 bulk delete request for \"%s\" could not be completed: %s",
 				                  request_context.display_url, res->GetRequestError());
 			}
 			if (res->status != HTTPStatusCode::OK_200) {
-				throw S3RequestUtil::GetError(request_context.auth_params, *res, request_context.request_type,
-				                              "bulk-deleting from", request_context.display_url);
+				throw S3RequestUtil::GetRequestError(request_context, *res);
 			}
 
 			S3DeleteObjectsResult delete_result;

--- a/src/s3/s3_list.cpp
+++ b/src/s3/s3_list.cpp
@@ -92,16 +92,16 @@ S3GlobResult::S3GlobResult(S3FileSystem &fs_p, const string &glob_pattern_p, opt
 	FileOpenerInfo info = {glob_pattern};
 
 	// Trim any query parameters from the string
-	auto s3_auth_params = S3AuthParams::ReadFrom(opener, info);
+	auto s3_auth_params = S3AuthResolver::Resolve(opener, info);
 
 	// In url compatibility mode, we ignore globs allowing users to query files with the glob chars
-	if (s3_auth_params.s3_url_compatibility_mode) {
+	if (s3_auth_params.GetURLParams().compatibility_mode) {
 		expanded_files.emplace_back(glob_pattern);
 		finished = true;
 		return;
 	}
 
-	parsed_s3_url = S3Url::Resolve(glob_pattern, s3_auth_params);
+	parsed_s3_url = S3Url::Parse(glob_pattern, s3_auth_params);
 	auto parsed_glob_url = S3Url::GetDisplayUrl(glob_pattern, s3_auth_params);
 
 	// AWS matches on prefix, not glob pattern, so we take a substring until the first wildcard char for the aws calls
@@ -233,8 +233,8 @@ void S3GlobResult::AppendMatchingFiles(vector<OpenFileInfo> &s3_keys) const {
 			auto captured = request_session->Capture();
 			auto &snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
 			if (snapshot.region_redirected) {
-				D_ASSERT(!snapshot.auth_params.region.empty());
-				s3_key.extended_info->options["s3_region"] = snapshot.auth_params.region;
+				D_ASSERT(!snapshot.auth_params.GetCredentials().region.empty());
+				s3_key.extended_info->options["s3_region"] = snapshot.auth_params.GetCredentials().region;
 			}
 			expanded_files.push_back(std::move(s3_key));
 		}
@@ -280,8 +280,7 @@ struct S3ListRequest {
 			if (response->HasRequestError()) {
 				throw IOException("%s error for HTTP GET to '%s'", response->GetRequestError(), display_url);
 			}
-			throw S3RequestUtil::GetError(request_context.auth_params, *response, request_context.request_type,
-			                              "listing", display_url);
+			throw S3RequestUtil::GetRequestError(request_context, *response);
 		}
 		if (!result) {
 			throw IOException("Malformed S3 list response for \"%s\"", request_context.display_url);
@@ -311,14 +310,14 @@ struct S3ListRequest {
 S3ListObjectsV2Result AWSListObjectV2::Request(EncryptionUtil &encryption_util, HTTPRequestSession &session,
                                                const string &path, const string &continuation_token, S3ListMode mode,
                                                optional_idx max_keys) {
-	S3RequestContext request_context;
 	optional<S3ListObjectsV2Result> parsed_result;
-	auto response = S3RequestExecutor::RunSession(
-	    encryption_util, session, path, RequestType::GET_REQUEST, S3RequestTarget::BUCKET,
-	    [&](const ParsedS3Url &parsed_url) {
-		    return S3ListRequest::BuildQuery(parsed_url, continuation_token, mode, max_keys);
-	    },
-	    "", "", "",
+	auto request_result = S3RequestExecutor::RunSession(
+	    encryption_util, session,
+	    S3RequestSpec {path, S3RequestOperation::LIST_OBJECTS,
+	                   [&](const ParsedS3Url &parsed_url) {
+		                   return S3ListRequest::BuildQuery(parsed_url, continuation_token, mode, max_keys);
+	                   },
+	                   "", "", ""},
 	    [&](S3RequestData &request_data) {
 		    auto &params = request_data.http_params->Cast<HTTPFSParams>();
 		    GetRequestInfo get_request(request_data.http_url, request_data.headers, params, nullptr, nullptr);
@@ -332,7 +331,6 @@ S3ListObjectsV2Result AWSListObjectV2::Request(EncryptionUtil &encryption_util, 
 		        "Consider setting the S3 region to this explicitly to avoid extra round-trips.",
 		        request_data.display_url, previous_region, correct_region);
 	    },
-	    request_context, S3PostRequestMode::DEFAULT,
 	    [&](const S3RequestData &, const HTTPResponse &response) {
 		    parsed_result.reset();
 		    if (response.HasRequestError() || response.status != HTTPStatusCode::OK_200) {
@@ -345,7 +343,7 @@ S3ListObjectsV2Result AWSListObjectV2::Request(EncryptionUtil &encryption_util, 
 		    parsed_result = std::move(attempt_result);
 		    return S3ReceivedResponseAction::ACCEPT;
 	    });
-	return S3ListRequest::Finish(request_context, std::move(response), std::move(parsed_result));
+	return S3ListRequest::Finish(request_result.context, std::move(request_result.response), std::move(parsed_result));
 }
 
 void AWSListObjectV2::AppendFileList(const S3ListObjectsV2Result &response, vector<OpenFileInfo> &result) {

--- a/src/s3/s3_provider.cpp
+++ b/src/s3/s3_provider.cpp
@@ -57,7 +57,7 @@ static bool SchemeSyntaxIsValid(const string &scheme) {
 	return true;
 }
 
-Value S3Provider::NormalizeSchemeAliases(const Value &aliases) {
+Value S3UrlScheme::NormalizeAliases(const Value &aliases) {
 	vector<Value> normalized;
 	vector<string> seen;
 	if (aliases.IsNull()) {
@@ -88,7 +88,7 @@ Value S3Provider::NormalizeSchemeAliases(const Value &aliases) {
 	return Value::LIST(LogicalType::VARCHAR, std::move(normalized));
 }
 
-vector<string> S3Provider::GetSchemeAliasPrefixes(const DBConfig &config) {
+vector<string> S3UrlScheme::GetAliasPrefixes(const DBConfig &config) {
 	Value value;
 	if (!config.TryGetCurrentSetting("s3_url_scheme_aliases", value) || value.IsNull() ||
 	    value.type().id() != LogicalTypeId::LIST) {
@@ -110,13 +110,13 @@ vector<string> S3Provider::GetSchemeAliasPrefixes(const DBConfig &config) {
 	return result;
 }
 
-const array<const char *, 4> &S3Provider::SecretTypes() {
+const array<const char *, 4> &S3SecretConfig::SecretTypes() {
 	static constexpr array<const char *, 4> SECRET_TYPES = {S3_SECRET_TYPE, R2_SECRET_TYPE, GCS_SECRET_TYPE,
 	                                                        AWS_SECRET_TYPE};
 	return SECRET_TYPES;
 }
 
-const array<const char *, 13> &S3Provider::CredentialMaterialKeys() {
+const array<const char *, 13> &S3SecretConfig::CredentialMaterialKeys() {
 	static constexpr array<const char *, 13> CREDENTIAL_MATERIAL_KEYS = {
 	    "key_id",    "secret",  "session_token",          "region",         "endpoint",     "kms_key_id",
 	    "url_style", "use_ssl", "url_compatibility_mode", "requester_pays", "bearer_token", "user_project",
@@ -124,7 +124,7 @@ const array<const char *, 13> &S3Provider::CredentialMaterialKeys() {
 	return CREDENTIAL_MATERIAL_KEYS;
 }
 
-optional<S3ProviderMatch> S3Provider::TryMatchUrl(const string &url) {
+optional<S3ProviderMatch> S3UrlScheme::TryMatch(const string &url) {
 	auto lower_url = StringUtil::Lower(url);
 	for (const auto &provider_match : ProviderMatches()) {
 		if (StringUtil::StartsWith(lower_url, provider_match.prefix)) {
@@ -134,8 +134,8 @@ optional<S3ProviderMatch> S3Provider::TryMatchUrl(const string &url) {
 	return {};
 }
 
-optional<S3ProviderMatch> S3Provider::TryMatchUrl(const string &url, const vector<string> &scheme_alias_prefixes) {
-	auto provider_match = TryMatchUrl(url);
+optional<S3ProviderMatch> S3UrlScheme::TryMatch(const string &url, const vector<string> &scheme_alias_prefixes) {
+	auto provider_match = TryMatch(url);
 	if (provider_match) {
 		return provider_match;
 	}
@@ -143,14 +143,14 @@ optional<S3ProviderMatch> S3Provider::TryMatchUrl(const string &url, const vecto
 	auto lower_url = StringUtil::Lower(url);
 	for (auto &prefix : scheme_alias_prefixes) {
 		if (StringUtil::StartsWith(lower_url, prefix)) {
-			return S3ProviderMatch {S3ProviderType::S3, prefix};
+			return S3ProviderMatch {S3ProviderType::S3, prefix, S3UrlSchemeOrigin::ALIAS};
 		}
 	}
 	return {};
 }
 
-S3ProviderMatch S3Provider::MatchUrl(const string &url) {
-	auto provider_match = TryMatchUrl(url);
+S3ProviderMatch S3UrlScheme::Match(const string &url) {
+	auto provider_match = TryMatch(url);
 	if (!provider_match) {
 		vector<string> prefixes;
 		for (const auto &entry : ProviderMatches()) {
@@ -162,7 +162,19 @@ S3ProviderMatch S3Provider::MatchUrl(const string &url) {
 	return *provider_match;
 }
 
-vector<string> S3Provider::DefaultSecretScope(const string &secret_type) {
+S3ProviderMatch S3UrlScheme::MatchRoutedUrl(const string &url) {
+	auto provider_match = TryMatch(url);
+	if (provider_match) {
+		return *provider_match;
+	}
+	auto scheme_end = url.find("://");
+	if (scheme_end == string::npos) {
+		return Match(url);
+	}
+	return {S3ProviderType::S3, StringUtil::Lower(url.substr(0, scheme_end + 3)), S3UrlSchemeOrigin::ALIAS};
+}
+
+vector<string> S3SecretConfig::DefaultSecretScope(const string &secret_type) {
 	if (secret_type == S3_SECRET_TYPE) {
 		return {"s3://", "s3n://", "s3a://"};
 	}
@@ -178,7 +190,7 @@ vector<string> S3Provider::DefaultSecretScope(const string &secret_type) {
 	throw InternalException("Unknown secret type found in httpfs extension: '%s'", secret_type);
 }
 
-void S3Provider::SetSecretNamedParameters(const string &secret_type, CreateSecretFunction &function) {
+void S3SecretConfig::SetSecretNamedParameters(const string &secret_type, CreateSecretFunction &function) {
 	if (secret_type == R2_SECRET_TYPE) {
 		function.named_parameters["account_id"] = LogicalType::VARCHAR;
 	} else if (secret_type == GCS_SECRET_TYPE) {
@@ -187,7 +199,7 @@ void S3Provider::SetSecretNamedParameters(const string &secret_type, CreateSecre
 	}
 }
 
-void S3Provider::ApplySecretDefaults(const CreateSecretInput &input, KeyValueSecret &secret) {
+void S3SecretConfig::ApplySecretDefaults(const CreateSecretInput &input, KeyValueSecret &secret) {
 	if (input.type != R2_SECRET_TYPE) {
 		return;
 	}
@@ -199,8 +211,8 @@ void S3Provider::ApplySecretDefaults(const CreateSecretInput &input, KeyValueSec
 	secret.secret_map["url_style"] = "path";
 }
 
-bool S3Provider::TryApplySecretOption(const CreateSecretInput &input, const string &name, const Value &value,
-                                      KeyValueSecret &secret) {
+bool S3SecretConfig::TryApplySecretOption(const CreateSecretInput &input, const string &name, const Value &value,
+                                          KeyValueSecret &secret) {
 	if (name == "account_id" && input.type == R2_SECRET_TYPE) {
 		return true;
 	}
@@ -216,130 +228,19 @@ bool S3Provider::TryApplySecretOption(const CreateSecretInput &input, const stri
 	return false;
 }
 
-void S3Provider::ReadAuthParams(S3KeyValueReader &secret_reader, const string &file_path, S3AuthParams &result) {
-	// Routing already accepted the path, so a non-built-in scheme is an alias served by plain S3
-	auto provider_match = TryMatchUrl(file_path);
-	result.provider_type = provider_match ? provider_match->type : S3ProviderType::S3;
-	result.scheme_is_alias = !provider_match;
-	secret_reader.TryGetSecretKeyOrSetting("region", "s3_region", result.region);
-	secret_reader.TryGetSecretKeyOrSetting("key_id", "s3_access_key_id", result.access_key_id);
-	secret_reader.TryGetSecretKeyOrSetting("secret", "s3_secret_access_key", result.secret_access_key);
-	secret_reader.TryGetSecretKeyOrSetting("session_token", "s3_session_token", result.session_token);
-	secret_reader.TryGetSecretKeyOrSetting("use_ssl", "s3_use_ssl", result.use_ssl);
-	secret_reader.TryGetSecretKeyOrSetting("kms_key_id", "s3_kms_key_id", result.kms_key_id);
-	secret_reader.TryGetSecretKeysOrSetting("url_compatibility_mode", "s3_url_compatibility_mode",
-	                                        "s3_url_compatibility_mode", result.s3_url_compatibility_mode);
-	secret_reader.TryGetSecretKeyOrSetting("requester_pays", "s3_requester_pays", result.requester_pays);
-
-	string endpoint;
-	auto endpoint_result = secret_reader.TryGetSecretKeyOrSetting("endpoint", "s3_endpoint", endpoint);
-	auto url_style_result = secret_reader.TryGetSecretKeyOrSetting("url_style", "s3_url_style", result.url_style);
-	if (result.provider_type == S3ProviderType::GCS) {
-		if (endpoint_result && endpoint_result.GetScope() == SettingScope::SECRET) {
-			result.SetEndpoint(std::move(endpoint));
-		}
-		if (result.url_style.empty() || !url_style_result || url_style_result.GetScope() != SettingScope::SECRET) {
-			result.url_style = "path";
-		}
-		secret_reader.TryGetSecretKeyOrSetting("user_project", "gcs_user_project", result.user_project);
-		secret_reader.TryGetSecretKey("bearer_token", result.oauth2_bearer_token);
-	} else {
-		result.SetEndpoint(std::move(endpoint));
-	}
-	InitializeAuthParams(result);
+S3Provider::S3Provider() : S3Provider(S3ProviderMatch {S3ProviderType::S3, "s3://"}, S3CompatibilityProfile::S3) {
 }
 
-static bool EndpointIsAWS(const NormalizedS3Endpoint &endpoint) {
-	if (endpoint.IsEmpty()) {
-		return true;
-	}
-	return StringUtil::StartsWith(endpoint.GetHost(), "s3.") &&
-	       StringUtil::EndsWith(endpoint.GetHost(), ".amazonaws.com");
+S3Provider::S3Provider(S3ProviderMatch route_p, S3CompatibilityProfile profile_p)
+    : route(std::move(route_p)), profile(profile_p) {
 }
 
-//! Not AWS, so deriving an AWS endpoint would sign a request to the wrong host
-static bool RequiresExplicitEndpoint(const S3AuthParams &auth_params) {
-	return auth_params.scheme_is_alias || auth_params.provider_type == S3ProviderType::R2;
-}
-
-static bool EndpointIsUnresolved(const string &endpoint_source) {
-	auto endpoint = endpoint_source;
-	StringUtil::Trim(endpoint);
-	return endpoint.empty();
-}
-
-void S3Provider::InitializeAuthParams(S3AuthParams &auth_params) {
-	if (auth_params.provider_type == S3ProviderType::GCS) {
-		if (EndpointIsUnresolved(auth_params.endpoint_source)) {
-			auth_params.endpoint_source = "storage.googleapis.com";
-			auth_params.endpoint = NormalizedS3Endpoint();
-			auth_params.endpoint_mode = S3EndpointMode::AUTOMATIC;
-		}
-		if (auth_params.url_style.empty()) {
-			auth_params.url_style = "path";
-		}
-		if (auth_params.region.empty() && GetAuthType(auth_params) == S3AuthType::SIGV4) {
-			auth_params.region = "auto";
-		}
-	}
-	ParseURLStyle(auth_params.url_style);
-}
-
-void S3Provider::FinalizeAuthParams(S3AuthParams &auth_params) {
-	InitializeAuthParams(auth_params);
-	if (auth_params.provider_type == S3ProviderType::GCS && auth_params.requester_pays &&
-	    auth_params.user_project.empty()) {
-		throw InvalidInputException(
-		    "GCS Requester Pays requires a billing project; set USER_PROJECT in the GCS secret, "
-		    "set gcs_user_project, or pass gcs_user_project in the URL.");
-	}
-	if (RequiresExplicitEndpoint(auth_params) && EndpointIsUnresolved(auth_params.endpoint_source)) {
-		if (auth_params.provider_type == S3ProviderType::R2) {
-			throw IOException("R2 requires an endpoint; provide account_id in the secret or s3_endpoint in the URL");
-		}
-		throw IOException("An aliased URL scheme requires an endpoint; provide ENDPOINT in the secret, set "
-		                  "s3_endpoint, or pass s3_endpoint in the URL");
-	}
-
-	auto endpoint = NormalizedS3Endpoint::Parse(auth_params.endpoint_source, auth_params.use_ssl);
-	if (auth_params.provider_type == S3ProviderType::S3 && !auth_params.scheme_is_alias &&
-	    endpoint.GetHost() == "s3.amazonaws.com" && endpoint.GetBasePath().empty() && endpoint.IsDefaultPort()) {
-		auth_params.endpoint_mode = S3EndpointMode::AUTOMATIC;
-	}
-	if (auth_params.provider_type == S3ProviderType::S3 &&
-	    (auth_params.endpoint_mode == S3EndpointMode::AUTOMATIC || EndpointIsAWS(endpoint))) {
-		if (auth_params.region.empty()) {
-			if (auth_params.access_key_id.empty()) {
-				if (auth_params.endpoint_mode == S3EndpointMode::AUTOMATIC) {
-					endpoint.SetHost("s3.amazonaws.com");
-				}
-			} else {
-				auth_params.region = "us-east-1";
-			}
-		}
-		if (auth_params.endpoint_mode == S3EndpointMode::AUTOMATIC && !auth_params.region.empty()) {
-			endpoint.SetHost(StringUtil::Format("s3.%s.amazonaws.com", auth_params.region));
-		}
-	}
-	auth_params.endpoint = std::move(endpoint);
-}
-
-S3URLStyle S3Provider::ParseURLStyle(const string &url_style) {
-	if (url_style.empty() || url_style == "vhost" || url_style == "virtual") {
-		return S3URLStyle::VIRTUAL_HOSTED;
-	}
-	if (url_style == "path") {
-		return S3URLStyle::PATH;
-	}
-	throw InvalidInputException("Invalid S3 URL style '%s': expected 'vhost', 'virtual', 'path', or an empty string",
-	                            url_style);
-}
-
-S3AuthType S3Provider::GetAuthType(const S3AuthParams &auth_params) {
-	if (auth_params.provider_type == S3ProviderType::GCS && !auth_params.oauth2_bearer_token.empty()) {
+S3AuthType S3Provider::GetAuthType(const S3AuthParams &auth_params) const {
+	auto &credentials = auth_params.GetCredentials();
+	if (GetType() == S3ProviderType::GCS && !credentials.oauth2_bearer_token.empty()) {
 		return S3AuthType::BEARER;
 	}
-	if (auth_params.secret_access_key.empty() && auth_params.access_key_id.empty()) {
+	if (credentials.secret_access_key.empty() && credentials.access_key_id.empty()) {
 		return S3AuthType::ANONYMOUS;
 	}
 	return S3AuthType::SIGV4;
@@ -363,9 +264,14 @@ static bool EndpointIsR2(const NormalizedS3Endpoint &endpoint) {
 	return jurisdiction == "eu" || jurisdiction == "us" || jurisdiction == "fedramp";
 }
 
-static bool UsesR2CompatibilityProfile(const S3AuthParams &auth_params) {
-	return auth_params.provider_type == S3ProviderType::R2 ||
-	       (auth_params.provider_type == S3ProviderType::S3 && EndpointIsR2(auth_params.GetEndpoint()));
+S3Provider S3Provider::Resolve(S3ProviderMatch route, const NormalizedS3Endpoint &endpoint) {
+	auto profile = S3CompatibilityProfile::S3;
+	if (route.type == S3ProviderType::GCS) {
+		profile = S3CompatibilityProfile::GCS;
+	} else if (route.type == S3ProviderType::R2 || EndpointIsR2(endpoint)) {
+		profile = S3CompatibilityProfile::R2;
+	}
+	return S3Provider(std::move(route), profile);
 }
 
 static S3MultipartUploadPolicy DefaultMultipartUploadPolicy() {
@@ -382,26 +288,27 @@ static S3MultipartUploadPolicy R2MultipartUploadPolicy() {
 	return {S3MultipartPartSizeStrategy::FIXED, 8ULL * MIB, MAXIMUM_PART_SIZE, 10000, MAXIMUM_OBJECT_SIZE};
 }
 
-S3MultipartUploadPolicy S3Provider::GetMultipartUploadPolicy(const S3AuthParams &auth_params) {
-	if (UsesR2CompatibilityProfile(auth_params)) {
+S3MultipartUploadPolicy S3Provider::GetMultipartUploadPolicy() const {
+	if (profile == S3CompatibilityProfile::R2) {
 		return R2MultipartUploadPolicy();
 	}
 	return DefaultMultipartUploadPolicy();
 }
 
-idx_t S3Provider::GetBulkDeleteMaxBatchSize(const S3AuthParams &auth_params) {
-	return UsesR2CompatibilityProfile(auth_params) ? 700 : 1000;
+idx_t S3Provider::GetBulkDeleteMaxBatchSize() const {
+	return profile == S3CompatibilityProfile::R2 ? 700 : 1000;
 }
 
-string S3Provider::GetBadRequestError(const S3AuthParams &auth_params, const string &correct_region) {
-	if (auth_params.provider_type != S3ProviderType::S3) {
+string S3Provider::GetBadRequestError(const S3AuthParams &auth_params, const string &correct_region) const {
+	if (GetType() != S3ProviderType::S3) {
 		return {};
 	}
+	auto &credentials = auth_params.GetCredentials();
 	string extra_text = "\n\nBad Request - this can be caused by the S3 region being set incorrectly.";
-	if (auth_params.region.empty()) {
+	if (credentials.region.empty()) {
 		extra_text += "\n* No region is provided.";
 	} else {
-		extra_text += "\n* Provided region is: \"" + auth_params.region + "\"";
+		extra_text += "\n* Provided region is: \"" + credentials.region + "\"";
 	}
 	if (!correct_region.empty()) {
 		extra_text += "\n* Correct region is: \"" + correct_region + "\"";
@@ -409,15 +316,16 @@ string S3Provider::GetBadRequestError(const S3AuthParams &auth_params, const str
 	return extra_text;
 }
 
-string S3Provider::GetAuthError(const S3AuthParams &auth_params) {
-	if (auth_params.provider_type == S3ProviderType::GCS) {
+string S3Provider::GetAuthError(const S3AuthParams &auth_params) const {
+	auto &credentials = auth_params.GetCredentials();
+	if (GetType() == S3ProviderType::GCS) {
 		string extra_text = "\n\nAuthentication Failure - GCS authentication failed.";
-		if (auth_params.oauth2_bearer_token.empty() && auth_params.secret_access_key.empty() &&
-		    auth_params.access_key_id.empty()) {
+		if (credentials.oauth2_bearer_token.empty() && credentials.secret_access_key.empty() &&
+		    credentials.access_key_id.empty()) {
 			extra_text += "\n* No credentials provided.";
 			extra_text += "\n* For OAuth2: CREATE SECRET (TYPE GCS, bearer_token 'your-token')";
 			extra_text += "\n* For HMAC: CREATE SECRET (TYPE GCS, key_id 'key', secret 'secret')";
-		} else if (!auth_params.oauth2_bearer_token.empty()) {
+		} else if (!credentials.oauth2_bearer_token.empty()) {
 			extra_text += "\n* Bearer token was provided but authentication failed.";
 			extra_text += "\n* Ensure your OAuth2 token is valid and not expired.";
 		} else {
@@ -426,9 +334,9 @@ string S3Provider::GetAuthError(const S3AuthParams &auth_params) {
 		}
 		return extra_text;
 	}
-	if (auth_params.provider_type == S3ProviderType::R2) {
+	if (GetType() == S3ProviderType::R2) {
 		string extra_text = "\n\nAuthentication Failure - R2 authentication failed.";
-		if (auth_params.secret_access_key.empty() && auth_params.access_key_id.empty()) {
+		if (credentials.secret_access_key.empty() && credentials.access_key_id.empty()) {
 			extra_text += "\n* No credentials are provided.";
 			extra_text += "\n* Create an R2 secret with account_id, key_id, and secret.";
 		} else {
@@ -438,13 +346,18 @@ string S3Provider::GetAuthError(const S3AuthParams &auth_params) {
 	}
 
 	string extra_text = "\n\nAuthentication Failure - this is usually caused by invalid or missing credentials.";
-	if (auth_params.secret_access_key.empty() && auth_params.access_key_id.empty()) {
+	if (credentials.secret_access_key.empty() && credentials.access_key_id.empty()) {
 		extra_text += "\n* No credentials are provided.";
 	} else {
 		extra_text += "\n* Credentials are provided, but they did not work.";
 	}
 	extra_text += "\n* See https://duckdb.org/docs/stable/extensions/httpfs/s3api.html";
 	return extra_text;
+}
+
+bool S3Provider::operator==(const S3Provider &other) const {
+	return route.type == other.route.type && route.prefix == other.route.prefix && route.origin == other.route.origin &&
+	       profile == other.profile;
 }
 
 } // namespace duckdb

--- a/src/s3/s3_request.cpp
+++ b/src/s3/s3_request.cpp
@@ -42,7 +42,6 @@ void S3RefreshableHTTPParams::Apply(HTTPFSParams &target) const {
 	target.override_verify_ssl = override_verify_ssl;
 	target.verify_ssl = verify_ssl;
 	target.bearer_token = bearer_token;
-	target.pre_merged_headers = false;
 }
 
 bool S3RefreshableHTTPParams::operator==(const S3RefreshableHTTPParams &other) const {
@@ -316,11 +315,11 @@ private:
 	HTTPHeaders &headers;
 };
 
-static HTTPHeaders CreateConfiguredS3Headers(const unordered_map<string, string> &extra_headers,
-                                             const string &user_agent, S3ProviderType provider_type) {
+static HTTPHeaders CreateConfiguredS3Headers(const HTTPConfiguredHeaders &configured_headers,
+                                             S3ProviderType provider_type) {
 	vector<pair<string, string>> sorted_headers;
-	sorted_headers.reserve(extra_headers.size());
-	for (const auto &header : extra_headers) {
+	sorted_headers.reserve(configured_headers.extra_headers.size());
+	for (const auto &header : configured_headers.extra_headers) {
 		sorted_headers.emplace_back(header.first, header.second);
 	}
 	std::sort(sorted_headers.begin(), sorted_headers.end(), [](const auto &left, const auto &right) {
@@ -348,8 +347,8 @@ static HTTPHeaders CreateConfiguredS3Headers(const unordered_map<string, string>
 	for (auto &header : sorted_headers) {
 		result[header.first] = header.second;
 	}
-	if (!user_agent.empty()) {
-		result.Insert("User-Agent", user_agent);
+	if (!configured_headers.user_agent.empty()) {
+		result.Insert("User-Agent", configured_headers.user_agent);
 	}
 	return result;
 }
@@ -358,7 +357,7 @@ HTTPHeaders S3RequestUtil::CreateHeaders(EncryptionUtil &encryption_util, const 
                                          S3RequestOperation operation, const S3RequestQuery &query,
                                          const S3AuthParams &auth_params, string date_now, string datetime_now,
                                          string payload_hash, string content_type, string content_md5,
-                                         const unordered_map<string, string> &extra_headers, const string &user_agent) {
+                                         const HTTPConfiguredHeaders &configured_headers) {
 	const auto &host = parsed_url.GetHost();
 	auto &operation_info = GetOperationInfo(operation);
 	const auto &encoded_path = operation_info.target == S3RequestTarget::BUCKET ? parsed_url.GetEncodedBucketPath()
@@ -366,7 +365,7 @@ HTTPHeaders S3RequestUtil::CreateHeaders(EncryptionUtil &encryption_util, const 
 	auto &provider = auth_params.GetProvider();
 	auto &credentials = auth_params.GetCredentials();
 	auto &request_options = auth_params.GetRequestOptions();
-	auto headers = CreateConfiguredS3Headers(extra_headers, user_agent, provider.GetType());
+	auto headers = CreateConfiguredS3Headers(configured_headers, provider.GetType());
 	if (provider.GetType() == S3ProviderType::GCS && !request_options.user_project.empty()) {
 		headers["x-goog-user-project"] = request_options.user_project;
 	}
@@ -516,17 +515,17 @@ S3RequestData S3RequestExecutor::CreateRequestData(EncryptionUtil &encryption_ut
 	auto &operation_info = S3RequestUtil::GetOperationInfo(spec.operation);
 	S3RequestData result {spec.operation, snapshot.auth_params};
 	result.captured = captured;
-	result.http_params = snapshot.CreateRequestParams();
+	auto session_request = snapshot.CreateRequest();
+	result.http_params = std::move(session_request.params);
 	auto parsed_s3_url = S3Url::Parse(spec.url, result.auth_params);
 	result.display_url = S3Url::GetDisplayUrl(spec.url, result.auth_params);
 	auto query = spec.create_query ? spec.create_query(parsed_s3_url) : S3RequestQuery();
 	result.http_url = operation_info.target == S3RequestTarget::BUCKET
 	                      ? parsed_s3_url.GetBucketHTTPUrl(query.WireQuery())
 	                      : parsed_s3_url.GetHTTPUrl(query.WireQuery());
-	auto &http_params = result.http_params->Cast<HTTPFSParams>();
 	result.headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_s3_url, spec.operation, query,
 	                                              result.auth_params, "", "", spec.payload_hash, spec.content_type,
-	                                              spec.content_md5, http_params.extra_headers, http_params.user_agent);
+	                                              spec.content_md5, session_request.configured_headers);
 	return result;
 }
 
@@ -709,14 +708,14 @@ bool S3RequestExecutor::TryRefreshSession(HTTPRequestSession &session, const S3R
 	}
 	ClientContextFileOpener opener(*context);
 	auto refreshed_auth_params = current_snapshot.auth_params;
-	auto refreshed_http_params = current_snapshot.CreateRequestParams();
+	auto refreshed_http_params = current_snapshot.Params();
 	if (!TryRefreshS3AuthMaterial(context, opener, current_snapshot.refresh_path, refreshed_auth_params,
-	                              *refreshed_http_params, current_snapshot.credential_refresh_enabled,
+	                              refreshed_http_params, current_snapshot.credential_refresh_enabled,
 	                              current_snapshot.region_redirected)) {
 		return session.Capture().snapshot->Cast<S3RequestSnapshot>().credential_generation !=
 		       failed_snapshot.credential_generation;
 	}
-	auto refreshed_http_material = S3RefreshableHTTPParams(*refreshed_http_params);
+	auto refreshed_http_material = S3RefreshableHTTPParams(refreshed_http_params);
 	for (;;) {
 		current = session.Capture();
 		auto &latest = current.snapshot->Cast<S3RequestSnapshot>();
@@ -733,10 +732,10 @@ bool S3RequestExecutor::TryRefreshSession(HTTPRequestSession &session, const S3R
 			throw IOException("Cannot refresh credentials for an active S3 upload because the refreshed endpoint "
 			                  "requires a different multipart upload policy");
 		}
-		auto merged_http_params = latest.CreateRequestParams();
-		refreshed_http_material.Apply(*merged_http_params);
+		auto merged_http_params = latest.Params();
+		refreshed_http_material.Apply(merged_http_params);
 		auto replacement = make_shared_ptr<S3RequestSnapshot>(
-		    *merged_http_params, merged_auth_params, latest.refresh_path, latest.client_context,
+		    merged_http_params, merged_auth_params, latest.refresh_path, latest.client_context,
 		    latest.credential_refresh_enabled, latest.region_redirected, latest.credential_generation + 1,
 		    latest.multipart_upload_policy);
 		auto publication = session.TryPublish(current.snapshot, std::move(replacement));
@@ -758,9 +757,8 @@ bool S3RequestExecutor::SetSessionRegion(HTTPRequestSession &session, const stri
 		auto auth_params = snapshot.auth_params;
 		previous_region = auth_params.GetCredentials().region;
 		auth_params = auth_params.WithRegion(correct_region);
-		auto http_params = snapshot.CreateRequestParams();
 		auto replacement =
-		    make_shared_ptr<S3RequestSnapshot>(*http_params, auth_params, snapshot.refresh_path,
+		    make_shared_ptr<S3RequestSnapshot>(snapshot.Params(), auth_params, snapshot.refresh_path,
 		                                       snapshot.client_context, snapshot.credential_refresh_enabled, true,
 		                                       snapshot.credential_generation, snapshot.multipart_upload_policy);
 		auto publication = session.TryPublish(current.snapshot, std::move(replacement));

--- a/src/s3/s3_request.cpp
+++ b/src/s3/s3_request.cpp
@@ -81,6 +81,29 @@ const string &S3RequestQuery::CanonicalQuery() const {
 	return canonical_query;
 }
 
+const S3RequestOperationInfo &S3RequestUtil::GetOperationInfo(S3RequestOperation operation) {
+	static const array<S3RequestOperationInfo, 10> OPERATION_INFO = {
+	    S3RequestOperationInfo {RequestType::HEAD_REQUEST, S3RequestTarget::OBJECT, "checking", true, false, false},
+	    S3RequestOperationInfo {RequestType::GET_REQUEST, S3RequestTarget::OBJECT, "reading", true, false, false},
+	    S3RequestOperationInfo {RequestType::PUT_REQUEST, S3RequestTarget::OBJECT, "uploading to", true, false, true},
+	    S3RequestOperationInfo {RequestType::DELETE_REQUEST, S3RequestTarget::OBJECT, "deleting", true, false, false},
+	    S3RequestOperationInfo {RequestType::GET_REQUEST, S3RequestTarget::BUCKET, "listing", true, false, false},
+	    S3RequestOperationInfo {RequestType::POST_REQUEST, S3RequestTarget::BUCKET, "bulk-deleting from", false, false,
+	                            false},
+	    S3RequestOperationInfo {RequestType::POST_REQUEST, S3RequestTarget::OBJECT, "initializing multipart upload for",
+	                            false, false, true},
+	    S3RequestOperationInfo {RequestType::PUT_REQUEST, S3RequestTarget::OBJECT, "uploading to", true, false, false},
+	    S3RequestOperationInfo {RequestType::POST_REQUEST, S3RequestTarget::OBJECT, "completing multipart upload for",
+	                            false, true, false},
+	    S3RequestOperationInfo {RequestType::DELETE_REQUEST, S3RequestTarget::OBJECT, "aborting multipart upload for",
+	                            true, false, false}};
+	auto index = static_cast<idx_t>(operation);
+	if (index >= OPERATION_INFO.size()) {
+		throw InternalException("Unknown S3 request operation");
+	}
+	return OPERATION_INFO[index];
+}
+
 bool S3RequestQuery::HasParameter(const string &name) const {
 	for (const auto &parameter : parameters) {
 		if (parameter.first == name) {
@@ -135,17 +158,17 @@ struct S3HeaderBuilder {
 
 public:
 	S3HeaderBuilder(EncryptionUtil &encryption_util_p, string encoded_url_p, const S3RequestQuery &query_p,
-	                string host_p, string service_p, RequestType request_type_p, const S3AuthParams &auth_params_p,
+	                string host_p, string service_p, S3RequestOperation operation_p, const S3AuthParams &auth_params_p,
 	                string date_now_p, string datetime_now_p, string payload_hash_p, string content_type_p,
 	                string content_md5_p, HTTPHeaders &headers_p)
 	    : encryption_util(encryption_util_p), encoded_url(std::move(encoded_url_p)), query(query_p.CanonicalQuery()),
-	      host(std::move(host_p)), service(std::move(service_p)), method(HTTPFSUtil::GetRequestMethod(request_type_p)),
+	      host(std::move(host_p)), service(std::move(service_p)),
+	      method(HTTPFSUtil::GetRequestMethod(S3RequestUtil::GetOperationInfo(operation_p).request_type)),
 	      auth_params(auth_params_p), date_now(std::move(date_now_p)), datetime_now(std::move(datetime_now_p)),
 	      payload_hash(std::move(payload_hash_p)), content_type(std::move(content_type_p)),
 	      content_md5(std::move(content_md5_p)),
-	      use_sse_kms(!auth_params.kms_key_id.empty() &&
-	                  (request_type_p == RequestType::POST_REQUEST || request_type_p == RequestType::PUT_REQUEST) &&
-	                  !query_p.HasParameter("uploadId")),
+	      use_sse_kms(!auth_params.GetRequestOptions().kms_key_id.empty() &&
+	                  S3RequestUtil::GetOperationInfo(operation_p).uses_kms_headers),
 	      headers(headers_p) {
 	}
 
@@ -158,7 +181,7 @@ public:
 		auto signed_headers = BuildSignedHeaders(canonical_headers);
 		auto canonical_request = BuildCanonicalRequest(canonical_headers, signed_headers);
 		auto signature = CreateSignature(canonical_request);
-		headers["Authorization"] = "AWS4-HMAC-SHA256 Credential=" + auth_params.access_key_id + "/" +
+		headers["Authorization"] = "AWS4-HMAC-SHA256 Credential=" + auth_params.GetCredentials().access_key_id + "/" +
 		                           CredentialScope() + ", SignedHeaders=" + signed_headers + ", Signature=" + signature;
 	}
 
@@ -177,14 +200,16 @@ private:
 	void AddRequestHeaders() {
 		headers["x-amz-date"] = datetime_now;
 		headers["x-amz-content-sha256"] = payload_hash;
-		if (!auth_params.session_token.empty()) {
-			headers["x-amz-security-token"] = auth_params.session_token;
+		auto &credentials = auth_params.GetCredentials();
+		auto &request_options = auth_params.GetRequestOptions();
+		if (!credentials.session_token.empty()) {
+			headers["x-amz-security-token"] = credentials.session_token;
 		}
 		if (use_sse_kms) {
 			headers["x-amz-server-side-encryption"] = "aws:kms";
-			headers["x-amz-server-side-encryption-aws-kms-key-id"] = auth_params.kms_key_id;
+			headers["x-amz-server-side-encryption-aws-kms-key-id"] = request_options.kms_key_id;
 		}
-		if (auth_params.requester_pays && auth_params.provider_type != S3ProviderType::GCS) {
+		if (request_options.requester_pays && auth_params.GetProvider().GetType() != S3ProviderType::GCS) {
 			headers["x-amz-request-payer"] = "requester";
 		}
 		if (!content_md5.empty()) {
@@ -225,7 +250,7 @@ private:
 				continue;
 			}
 			auto value = header.second;
-			if (!HTTPFSOwnedS3Headers::Contains(header.first, auth_params.provider_type)) {
+			if (!HTTPFSOwnedS3Headers::Contains(header.first, auth_params.GetProvider().GetType())) {
 				value = NormalizeHeaderValue(value);
 			}
 			result.push_back({StringUtil::Lower(header.first), std::move(value)});
@@ -261,16 +286,17 @@ private:
 		SignatureV4Params sig_params;
 		sig_params.canonical_request = canonical_request;
 		sig_params.credential_scope = CredentialScope();
-		sig_params.region = auth_params.region;
+		auto &credentials = auth_params.GetCredentials();
+		sig_params.region = credentials.region;
 		sig_params.service = service;
-		sig_params.secret_access_key = auth_params.secret_access_key;
+		sig_params.secret_access_key = credentials.secret_access_key;
 		sig_params.date_now = date_now;
 		sig_params.datetime_now = datetime_now;
 		return HTTPUtil::CreateSignatureV4(encryption_util, sig_params);
 	}
 
 	string CredentialScope() const {
-		return date_now + "/" + auth_params.region + "/" + service + "/aws4_request";
+		return date_now + "/" + auth_params.GetCredentials().region + "/" + service + "/aws4_request";
 	}
 
 private:
@@ -329,31 +355,35 @@ static HTTPHeaders CreateConfiguredS3Headers(const unordered_map<string, string>
 }
 
 HTTPHeaders S3RequestUtil::CreateHeaders(EncryptionUtil &encryption_util, const ParsedS3Url &parsed_url,
-                                         S3RequestTarget target, const S3RequestQuery &query, RequestType request_type,
+                                         S3RequestOperation operation, const S3RequestQuery &query,
                                          const S3AuthParams &auth_params, string date_now, string datetime_now,
                                          string payload_hash, string content_type, string content_md5,
                                          const unordered_map<string, string> &extra_headers, const string &user_agent) {
 	const auto &host = parsed_url.GetHost();
-	const auto &encoded_path =
-	    target == S3RequestTarget::BUCKET ? parsed_url.GetEncodedBucketPath() : parsed_url.GetEncodedPath();
-	auto headers = CreateConfiguredS3Headers(extra_headers, user_agent, auth_params.provider_type);
-	if (auth_params.provider_type == S3ProviderType::GCS && !auth_params.user_project.empty()) {
-		headers["x-goog-user-project"] = auth_params.user_project;
+	auto &operation_info = GetOperationInfo(operation);
+	const auto &encoded_path = operation_info.target == S3RequestTarget::BUCKET ? parsed_url.GetEncodedBucketPath()
+	                                                                            : parsed_url.GetEncodedPath();
+	auto &provider = auth_params.GetProvider();
+	auto &credentials = auth_params.GetCredentials();
+	auto &request_options = auth_params.GetRequestOptions();
+	auto headers = CreateConfiguredS3Headers(extra_headers, user_agent, provider.GetType());
+	if (provider.GetType() == S3ProviderType::GCS && !request_options.user_project.empty()) {
+		headers["x-goog-user-project"] = request_options.user_project;
 	}
-	switch (S3Provider::GetAuthType(auth_params)) {
+	switch (provider.GetAuthType(auth_params)) {
 	case S3AuthType::ANONYMOUS: {
 		headers["Host"] = host;
 		return headers;
 	}
 	case S3AuthType::SIGV4: {
-		S3HeaderBuilder(encryption_util, encoded_path, query, host, "s3", request_type, auth_params,
-		                std::move(date_now), std::move(datetime_now), std::move(payload_hash), std::move(content_type),
+		S3HeaderBuilder(encryption_util, encoded_path, query, host, "s3", operation, auth_params, std::move(date_now),
+		                std::move(datetime_now), std::move(payload_hash), std::move(content_type),
 		                std::move(content_md5), headers)
 		    .Create();
 		return headers;
 	}
 	case S3AuthType::BEARER: {
-		headers["Authorization"] = "Bearer " + auth_params.oauth2_bearer_token;
+		headers["Authorization"] = "Bearer " + credentials.oauth2_bearer_token;
 		headers["Host"] = host;
 		if (!content_type.empty()) {
 			headers["Content-Type"] = content_type;
@@ -373,24 +403,6 @@ static bool IsAuthRefreshErrorBody(const string &body) {
 		return false;
 	}
 	return error.code == "ExpiredToken" || error.code == "InvalidToken" || error.code == "TokenRefreshRequired";
-}
-
-static const char *S3RequestOperation(RequestType request_type) {
-	switch (request_type) {
-	case RequestType::GET_REQUEST:
-		return "reading";
-	case RequestType::HEAD_REQUEST:
-		return "checking";
-	case RequestType::PUT_REQUEST:
-		return "uploading to";
-	case RequestType::DELETE_REQUEST:
-		return "deleting";
-	case RequestType::POST_REQUEST:
-		return "sending a request to";
-	case RequestType::OPTIONS_REQUEST:
-		return "checking options for";
-	}
-	throw InternalException("Unsupported S3 request type");
 }
 
 static bool IsAuthRefreshStatus(const ErrorData &error) {
@@ -418,9 +430,7 @@ static bool IsAuthRefreshStatus(const HTTPResponse &response) {
 
 static S3AuthParams ReadS3AuthParams(optional_ptr<FileOpener> opener, const string &path) {
 	FileOpenerInfo info = {path};
-	auto auth_params = S3AuthParams::ReadFrom(opener, info);
-	S3Url::Resolve(path, auth_params);
-	return auth_params;
+	return S3AuthResolver::Resolve(opener, info);
 }
 
 S3RefreshableHTTPParams S3RequestExecutor::ReadRefreshableHTTPParams(optional_ptr<FileOpener> opener,
@@ -434,7 +444,7 @@ S3RefreshableHTTPParams S3RequestExecutor::ReadRefreshableHTTPParams(optional_pt
 static bool TryRefreshS3SecretForPath(ClientContext &context, const string &path) {
 	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
 	bool refreshed_secret = false;
-	for (const auto type : S3Provider::SecretTypes()) {
+	for (const auto type : S3SecretConfig::SecretTypes()) {
 		auto res = context.db->GetSecretManager().LookupSecret(transaction, path, type);
 		if (res.HasMatch()) {
 			refreshed_secret |= CreateS3SecretFunctions::TryRefreshS3Secret(context, *res.secret_entry);
@@ -457,10 +467,11 @@ static bool ReloadS3AuthMaterial(optional_ptr<FileOpener> opener, const string &
 		return false;
 	}
 
-	auto previous_region = auth_params.region;
+	auto previous_region = auth_params.GetCredentials().region;
 	auto reloaded_auth_params = ReadS3AuthParams(opener, path);
-	if (preserve_region && !previous_region.empty() && reloaded_auth_params.region != previous_region) {
-		reloaded_auth_params.SetRegion(std::move(previous_region));
+	if (preserve_region && !previous_region.empty() &&
+	    reloaded_auth_params.GetCredentials().region != previous_region) {
+		reloaded_auth_params = reloaded_auth_params.WithRegion(std::move(previous_region));
 	}
 	auto reloaded_http_params = S3RequestExecutor::ReadRefreshableHTTPParams(opener, path);
 
@@ -499,36 +510,30 @@ static bool TryRefreshS3AuthMaterial(optional_ptr<ClientContext> context, option
 }
 
 S3RequestData S3RequestExecutor::CreateRequestData(EncryptionUtil &encryption_util,
-                                                   const CapturedHTTPRequestSnapshot &captured, const string &s3_url,
-                                                   RequestType request_type, S3RequestTarget target,
-                                                   const CreateQueryCallback &create_query, const string &payload_hash,
-                                                   const string &content_type, const string &content_md5) {
+                                                   const CapturedHTTPRequestSnapshot &captured,
+                                                   const S3RequestSpec &spec) {
 	auto &snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
-	S3RequestData result;
-	result.request_type = request_type;
+	auto &operation_info = S3RequestUtil::GetOperationInfo(spec.operation);
+	S3RequestData result {spec.operation, snapshot.auth_params};
 	result.captured = captured;
-	result.auth_params = snapshot.auth_params;
 	result.http_params = snapshot.CreateRequestParams();
-	auto parsed_s3_url = S3Url::Parse(s3_url, result.auth_params);
-	result.display_url = S3Url::GetDisplayUrl(s3_url, result.auth_params);
-	auto query = create_query(parsed_s3_url);
-	result.http_url = target == S3RequestTarget::BUCKET ? parsed_s3_url.GetBucketHTTPUrl(query.WireQuery())
-	                                                    : parsed_s3_url.GetHTTPUrl(query.WireQuery());
+	auto parsed_s3_url = S3Url::Parse(spec.url, result.auth_params);
+	result.display_url = S3Url::GetDisplayUrl(spec.url, result.auth_params);
+	auto query = spec.create_query ? spec.create_query(parsed_s3_url) : S3RequestQuery();
+	result.http_url = operation_info.target == S3RequestTarget::BUCKET
+	                      ? parsed_s3_url.GetBucketHTTPUrl(query.WireQuery())
+	                      : parsed_s3_url.GetHTTPUrl(query.WireQuery());
 	auto &http_params = result.http_params->Cast<HTTPFSParams>();
-	result.headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_s3_url, target, query, request_type,
-	                                              result.auth_params, "", "", payload_hash, content_type, content_md5,
-	                                              http_params.extra_headers, http_params.user_agent);
+	result.headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_s3_url, spec.operation, query,
+	                                              result.auth_params, "", "", spec.payload_hash, spec.content_type,
+	                                              spec.content_md5, http_params.extra_headers, http_params.user_agent);
 	return result;
 }
 
 S3RequestData S3RequestExecutor::CreateHandleRequestData(EncryptionUtil &encryption_util, S3FileHandle &s3_handle,
-                                                         const string &s3_url, RequestType request_type,
-                                                         const string &version_id) {
+                                                         const S3RequestSpec &spec) {
 	auto captured = s3_handle.request_session->Capture();
-	return S3RequestExecutor::CreateRequestData(
-	    encryption_util, captured, s3_url, request_type, S3RequestTarget::OBJECT, [&](const ParsedS3Url &) {
-		    return version_id.empty() ? S3RequestQuery() : S3RequestQuery({{"versionId", version_id}});
-	    });
+	return S3RequestExecutor::CreateRequestData(encryption_util, captured, spec);
 }
 
 static optional_idx GetRegionRedirect(const HTTPResponse &response, const S3AuthParams &auth_params,
@@ -540,7 +545,7 @@ static optional_idx GetRegionRedirect(const HTTPResponse &response, const S3Auth
 		return {};
 	}
 	auto response_region = response.GetHeaderValue("x-amz-bucket-region");
-	if (response_region.empty() || response_region == auth_params.region) {
+	if (response_region.empty() || response_region == auth_params.GetCredentials().region) {
 		return {};
 	}
 	region_out = std::move(response_region);
@@ -554,7 +559,8 @@ static optional_idx GetRegionRedirect(const ErrorData &error, const S3AuthParams
 		return {};
 	}
 	auto new_region = extra_info.find("header_x-amz-bucket-region");
-	if (new_region == extra_info.end() || new_region->second.empty() || new_region->second == auth_params.region) {
+	if (new_region == extra_info.end() || new_region->second.empty() ||
+	    new_region->second == auth_params.GetCredentials().region) {
 		return {};
 	}
 	region_out = new_region->second;
@@ -608,28 +614,21 @@ void S3RequestExecutor::SleepForRetry(const HTTPParams &http_params, idx_t retri
 	wait_ms *= http_params.retry_backoff;
 }
 
-static bool IsTransientRetryEligibleMethod(RequestType request_type) {
-	return request_type == RequestType::GET_REQUEST || request_type == RequestType::HEAD_REQUEST ||
-	       request_type == RequestType::PUT_REQUEST || request_type == RequestType::DELETE_REQUEST;
-}
-
-static bool ShouldRetryReceivedResponse(const S3RequestData &request_data, const HTTPResponse &response,
-                                        S3PostRequestMode post_request_mode) {
+static bool ShouldRetryReceivedResponse(const S3RequestData &request_data, const HTTPResponse &response) {
 	if (response.HasRequestError()) {
 		return false;
 	}
-	if (IsTransientRetryEligibleMethod(request_data.request_type) && S3RequestUtil::IsRequestTimeout(response)) {
+	auto &operation_info = S3RequestUtil::GetOperationInfo(request_data.operation);
+	if (operation_info.retry_timeout && S3RequestUtil::IsRequestTimeout(response)) {
 		return true;
 	}
-	return post_request_mode == S3PostRequestMode::RETRY_RECEIVED_RESPONSES &&
-	       S3RequestUtil::IsRetryableReceivedResponse(response);
+	return operation_info.retry_received_response && S3RequestUtil::IsRetryableReceivedResponse(response);
 }
 
-unique_ptr<HTTPResponse>
-S3RequestExecutor::Run(const string &s3_url, const CreateDataCallback &create_data, const RequestCallback &request,
-                       const RefreshCallback &refresh_auth_params, const SetRegionCallback &set_region,
-                       const FinalRequestCallback &final_request, const FreshConnectionCallback &fresh_connection,
-                       S3PostRequestMode post_request_mode, const ReceivedResponseCallback &response_callback) {
+S3RequestResult S3RequestExecutor::Run(const CreateDataCallback &create_data, const RequestCallback &request,
+                                       const RefreshCallback &refresh_auth_params, const SetRegionCallback &set_region,
+                                       const FreshConnectionCallback &fresh_connection,
+                                       const ReceivedResponseCallback &response_callback) {
 	// Auth refresh and region redirect are one-shot; transient responses follow the configured HTTP retry policy.
 	bool retried_auth_refresh = false;
 	bool retried_region = false;
@@ -654,7 +653,7 @@ S3RequestExecutor::Run(const string &s3_url, const CreateDataCallback &create_da
 				continue;
 			}
 			if (received_response && transient_retries < http_params.retries &&
-			    ShouldRetryReceivedResponse(request_data, *result, post_request_mode)) {
+			    ShouldRetryReceivedResponse(request_data, *result)) {
 				SleepForRetry(http_params, transient_retries, transient_wait_ms);
 				transient_retries++;
 				continue;
@@ -668,10 +667,8 @@ S3RequestExecutor::Run(const string &s3_url, const CreateDataCallback &create_da
 				transient_retries++;
 				continue;
 			}
-			if (final_request) {
-				final_request(request_data);
-			}
-			return result;
+			return {std::move(result), S3RequestContext {request_data.operation, std::move(request_data.captured),
+			                                             std::move(request_data.display_url)}};
 		} catch (std::exception &ex) {
 			ErrorData error(ex);
 			if (!retried_auth_refresh && IsAuthRefreshStatus(error) && refresh_auth_params(request_data)) {
@@ -684,8 +681,8 @@ S3RequestExecutor::Run(const string &s3_url, const CreateDataCallback &create_da
 				retried_region = true;
 				continue;
 			}
-			if (IsTransientRetryEligibleMethod(request_data.request_type) && transient_retries < http_params.retries &&
-			    IsS3RequestTimeoutError(error)) {
+			if (S3RequestUtil::GetOperationInfo(request_data.operation).retry_timeout &&
+			    transient_retries < http_params.retries && IsS3RequestTimeoutError(error)) {
 				SleepForRetry(http_params, transient_retries, transient_wait_ms);
 				transient_retries++;
 				continue;
@@ -729,10 +726,10 @@ bool S3RequestExecutor::TryRefreshSession(HTTPRequestSession &session, const S3R
 
 		auto merged_auth_params = refreshed_auth_params;
 		if (latest.region_redirected) {
-			merged_auth_params.SetRegion(latest.auth_params.region);
+			merged_auth_params = merged_auth_params.WithRegion(latest.auth_params.GetCredentials().region);
 		}
 		if (latest.multipart_upload_policy &&
-		    !(S3Provider::GetMultipartUploadPolicy(merged_auth_params) == *latest.multipart_upload_policy)) {
+		    !(merged_auth_params.GetProvider().GetMultipartUploadPolicy() == *latest.multipart_upload_policy)) {
 			throw IOException("Cannot refresh credentials for an active S3 upload because the refreshed endpoint "
 			                  "requires a different multipart upload policy");
 		}
@@ -754,13 +751,13 @@ bool S3RequestExecutor::SetSessionRegion(HTTPRequestSession &session, const stri
 	for (;;) {
 		auto current = session.Capture();
 		auto &snapshot = current.snapshot->Cast<S3RequestSnapshot>();
-		if (snapshot.auth_params.region == correct_region) {
+		if (snapshot.auth_params.GetCredentials().region == correct_region) {
 			return false;
 		}
 
 		auto auth_params = snapshot.auth_params;
-		previous_region = auth_params.region;
-		auth_params.SetRegion(correct_region);
+		previous_region = auth_params.GetCredentials().region;
+		auth_params = auth_params.WithRegion(correct_region);
 		auto http_params = snapshot.CreateRequestParams();
 		auto replacement =
 		    make_shared_ptr<S3RequestSnapshot>(*http_params, auth_params, snapshot.refresh_path,
@@ -773,20 +770,12 @@ bool S3RequestExecutor::SetSessionRegion(HTTPRequestSession &session, const stri
 	}
 }
 
-unique_ptr<HTTPResponse>
-S3RequestExecutor::RunSession(EncryptionUtil &encryption_util, HTTPRequestSession &session, const string &s3_url,
-                              RequestType request_type, S3RequestTarget target, const CreateQueryCallback &create_query,
-                              const string &payload_hash, const string &content_type, const string &content_md5,
-                              const RequestCallback &request, const RegionRedirectCallback &region_redirect,
-                              optional_ptr<S3RequestContext> request_context, S3PostRequestMode post_request_mode,
-                              const ReceivedResponseCallback &response_callback) {
+S3RequestResult S3RequestExecutor::RunSession(EncryptionUtil &encryption_util, HTTPRequestSession &session,
+                                              const S3RequestSpec &spec, const RequestCallback &request,
+                                              const RegionRedirectCallback &region_redirect,
+                                              const ReceivedResponseCallback &response_callback) {
 	return S3RequestExecutor::Run(
-	    s3_url,
-	    [&]() {
-		    return S3RequestExecutor::CreateRequestData(encryption_util, session.Capture(), s3_url, request_type,
-		                                                target, create_query, payload_hash, content_type, content_md5);
-	    },
-	    request,
+	    [&]() { return S3RequestExecutor::CreateRequestData(encryption_util, session.Capture(), spec); }, request,
 	    [&](const S3RequestData &request_data) { return S3RequestExecutor::TryRefreshSession(session, request_data); },
 	    [&](const S3RequestData &request_data, const string &correct_region) {
 		    string previous_region;
@@ -795,29 +784,16 @@ S3RequestExecutor::RunSession(EncryptionUtil &encryption_util, HTTPRequestSessio
 		    }
 	    },
 	    [&](const S3RequestData &request_data) {
-		    if (request_context) {
-			    request_context->request_type = request_data.request_type;
-			    request_context->auth_params = request_data.auth_params;
-			    request_context->display_url = request_data.display_url;
-		    }
-	    },
-	    [&](const S3RequestData &request_data) {
 		    auto &params = request_data.http_params->Cast<HTTPFSParams>();
 		    S3RequestExecutor::InvalidateSessionConnections(session, params);
 	    },
-	    post_request_mode, response_callback);
+	    response_callback);
 }
 
-unique_ptr<HTTPResponse> S3RequestExecutor::RunHandle(EncryptionUtil &encryption_util, S3FileHandle &s3_handle,
-                                                      const string &s3_url, RequestType request_type,
-                                                      const string &version_id, const RequestCallback &request) {
+S3RequestResult S3RequestExecutor::RunHandle(EncryptionUtil &encryption_util, S3FileHandle &s3_handle,
+                                             const S3RequestSpec &spec, const RequestCallback &request) {
 	return S3RequestExecutor::Run(
-	    s3_url,
-	    [&]() {
-		    return S3RequestExecutor::CreateHandleRequestData(encryption_util, s3_handle, s3_url, request_type,
-		                                                      version_id);
-	    },
-	    request,
+	    [&]() { return S3RequestExecutor::CreateHandleRequestData(encryption_util, s3_handle, spec); }, request,
 	    [&](const S3RequestData &request_data) {
 		    return S3RequestExecutor::TryRefreshSession(*s3_handle.request_session, request_data);
 	    },
@@ -832,7 +808,7 @@ unique_ptr<HTTPResponse> S3RequestExecutor::RunHandle(EncryptionUtil &encryption
 			        request_data.display_url, previous_region, correct_region);
 		    }
 	    },
-	    {}, {}, S3PostRequestMode::DEFAULT);
+	    {});
 }
 
 void S3RequestExecutor::InvalidateSessionConnections(HTTPRequestSession &session, HTTPFSParams &params) {
@@ -876,8 +852,15 @@ unique_ptr<HTTPResponse> S3RequestExecutor::SendHandleRequest(S3FileHandle &s3_h
 }
 
 HTTPException S3RequestUtil::GetRequestError(const S3RequestData &request_data, const HTTPResponse &response) {
-	return S3RequestUtil::GetError(request_data.auth_params, response, request_data.request_type,
-	                               S3RequestOperation(request_data.request_type), request_data.display_url);
+	auto &operation_info = GetOperationInfo(request_data.operation);
+	return S3RequestUtil::GetError(request_data.auth_params, response, operation_info.request_type,
+	                               operation_info.description, request_data.display_url);
+}
+
+HTTPException S3RequestUtil::GetRequestError(const S3RequestContext &request_context, const HTTPResponse &response) {
+	auto &operation_info = GetOperationInfo(request_context.operation);
+	return S3RequestUtil::GetError(request_context.GetAuthParams(), response, operation_info.request_type,
+	                               operation_info.description, request_context.display_url);
 }
 
 S3RequestSnapshot::S3RequestSnapshot(const HTTPFSParams &http_params, const S3AuthParams &auth_params_p,
@@ -903,15 +886,17 @@ string S3RequestUtil::GetPayloadHash(EncryptionUtil &encryption_util, const_data
 	}
 }
 
-unique_ptr<HTTPResponse> S3FileSystem::PostRequest(HTTPRequestSession &session, const string &url, string &result,
-                                                   const_data_ptr_t buffer_in, idx_t buffer_in_len,
-                                                   const S3RequestQuery &query, S3PostRequestMode mode,
-                                                   optional_ptr<S3RequestContext> request_context) {
+S3RequestResult S3FileSystem::PostRequest(HTTPRequestSession &session, S3RequestOperation operation, const string &url,
+                                          string &result, const_data_ptr_t buffer_in, idx_t buffer_in_len,
+                                          const S3RequestQuery &query) {
+	if (S3RequestUtil::GetOperationInfo(operation).request_type != RequestType::POST_REQUEST) {
+		throw InternalException("S3 PostRequest requires a POST operation");
+	}
 	auto payload_hash = S3RequestUtil::GetPayloadHash(GetEncryptionUtil(), buffer_in, buffer_in_len);
 	const string content_type = "application/octet-stream";
 	return S3RequestExecutor::RunSession(
-	    GetEncryptionUtil(), session, url, RequestType::POST_REQUEST, S3RequestTarget::OBJECT,
-	    [&](const ParsedS3Url &) { return query; }, payload_hash, content_type, "",
+	    GetEncryptionUtil(), session,
+	    S3RequestSpec {url, operation, [&](const ParsedS3Url &) { return query; }, payload_hash, content_type, ""},
 	    [&](S3RequestData &request_data) {
 		    result.clear();
 		    auto &params = request_data.http_params->Cast<HTTPFSParams>();
@@ -921,19 +906,19 @@ unique_ptr<HTTPResponse> S3FileSystem::PostRequest(HTTPRequestSession &session, 
 			                          return S3RequestExecutor::SendSessionRequest(session, request_data.captured,
 			                                                                       params, request);
 		                          });
-	    },
-	    {}, request_context, mode);
+	    });
 }
 
-unique_ptr<HTTPResponse> S3FileSystem::PutRequest(HTTPRequestSession &session, const string &url,
-                                                  const_data_ptr_t buffer_in, idx_t buffer_in_len,
-                                                  const S3RequestQuery &query,
-                                                  optional_ptr<S3RequestContext> request_context) {
+S3RequestResult S3FileSystem::PutRequest(HTTPRequestSession &session, S3RequestOperation operation, const string &url,
+                                         const_data_ptr_t buffer_in, idx_t buffer_in_len, const S3RequestQuery &query) {
+	if (S3RequestUtil::GetOperationInfo(operation).request_type != RequestType::PUT_REQUEST) {
+		throw InternalException("S3 PutRequest requires a PUT operation");
+	}
 	auto payload_hash = S3RequestUtil::GetPayloadHash(GetEncryptionUtil(), buffer_in, buffer_in_len);
 	const string content_type = "application/octet-stream";
 	return S3RequestExecutor::RunSession(
-	    GetEncryptionUtil(), session, url, RequestType::PUT_REQUEST, S3RequestTarget::OBJECT,
-	    [&](const ParsedS3Url &) { return query; }, payload_hash, content_type, "",
+	    GetEncryptionUtil(), session,
+	    S3RequestSpec {url, operation, [&](const ParsedS3Url &) { return query; }, payload_hash, content_type, ""},
 	    [&](S3RequestData &request_data) {
 		    auto &params = request_data.http_params->Cast<HTTPFSParams>();
 		    return RunPutRequest(request_data.http_url, request_data.headers, params, buffer_in, buffer_in_len,
@@ -942,19 +927,22 @@ unique_ptr<HTTPResponse> S3FileSystem::PutRequest(HTTPRequestSession &session, c
 			                         return S3RequestExecutor::SendSessionRequest(session, request_data.captured,
 			                                                                      params, request);
 		                         });
-	    },
-	    {}, request_context);
+	    });
 }
 
 unique_ptr<HTTPResponse> S3FileSystem::HeadRequest(FileHandle &handle, const string &s3_url, HTTPHeaders header_map) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
 	return S3RequestExecutor::RunHandle(
-	    GetEncryptionUtil(), s3_handle, s3_url, RequestType::HEAD_REQUEST, {}, [&](S3RequestData &request_data) {
-		    auto &params = request_data.http_params->Cast<HTTPFSParams>();
-		    return RunHeadRequest(request_data.http_url, request_data.headers, params, [&](BaseRequest &request) {
-			    return S3RequestExecutor::SendHandleRequest(s3_handle, request_data.captured, params, request);
-		    });
-	    });
+	           GetEncryptionUtil(), s3_handle, S3RequestSpec {s3_url, S3RequestOperation::HEAD_OBJECT, {}, "", "", ""},
+	           [&](S3RequestData &request_data) {
+		           auto &params = request_data.http_params->Cast<HTTPFSParams>();
+		           return RunHeadRequest(request_data.http_url, request_data.headers, params,
+		                                 [&](BaseRequest &request) {
+			                                 return S3RequestExecutor::SendHandleRequest(
+			                                     s3_handle, request_data.captured, params, request);
+		                                 });
+	           })
+	    .response;
 }
 
 unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
@@ -963,15 +951,26 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_
 	const auto version_id =
 	    read_config.condition.type == HTTPReadConditionType::S3_VERSION_ID ? read_config.condition.value : string();
 	return S3RequestExecutor::RunHandle(
-	    GetEncryptionUtil(), s3_handle, s3_url, RequestType::GET_REQUEST, version_id, [&](S3RequestData &request_data) {
-		    auto &params = request_data.http_params->Cast<HTTPFSParams>();
-		    return RunGetRequest(
-		        s3_handle, request_data.http_url, request_data.headers, params, read_config, download,
-		        [&](const HTTPResponse &response) { return S3RequestUtil::GetRequestError(request_data, response); },
-		        [&](BaseRequest &request) {
-			        return S3RequestExecutor::SendHandleRequest(s3_handle, request_data.captured, params, request);
-		        });
-	    });
+	           GetEncryptionUtil(), s3_handle,
+	           S3RequestSpec {
+	               s3_url, S3RequestOperation::GET_OBJECT,
+	               [&](const ParsedS3Url &) {
+		               return version_id.empty() ? S3RequestQuery() : S3RequestQuery({{"versionId", version_id}});
+	               },
+	               "", "", ""},
+	           [&](S3RequestData &request_data) {
+		           auto &params = request_data.http_params->Cast<HTTPFSParams>();
+		           return RunGetRequest(
+		               s3_handle, request_data.http_url, request_data.headers, params, read_config, download,
+		               [&](const HTTPResponse &response) {
+			               return S3RequestUtil::GetRequestError(request_data, response);
+		               },
+		               [&](BaseRequest &request) {
+			               return S3RequestExecutor::SendHandleRequest(s3_handle, request_data.captured, params,
+			                                                           request);
+		               });
+	           })
+	    .response;
 }
 
 unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
@@ -981,42 +980,59 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, strin
 	const auto version_id =
 	    read_config.condition.type == HTTPReadConditionType::S3_VERSION_ID ? read_config.condition.value : string();
 	return S3RequestExecutor::RunHandle(
-	    GetEncryptionUtil(), s3_handle, s3_url, RequestType::GET_REQUEST, version_id, [&](S3RequestData &request_data) {
-		    auto &params = request_data.http_params->Cast<HTTPFSParams>();
-		    return RunGetRangeRequest(
-		        s3_handle, request_data.http_url, request_data.headers, params, read_config, file_offset, buffer_out,
-		        buffer_out_len,
-		        [&](const HTTPResponse &response) { return S3RequestUtil::GetRequestError(request_data, response); },
-		        [&](BaseRequest &request) {
-			        return S3RequestExecutor::SendHandleRequest(s3_handle, request_data.captured, params, request);
-		        });
-	    });
+	           GetEncryptionUtil(), s3_handle,
+	           S3RequestSpec {
+	               s3_url, S3RequestOperation::GET_OBJECT,
+	               [&](const ParsedS3Url &) {
+		               return version_id.empty() ? S3RequestQuery() : S3RequestQuery({{"versionId", version_id}});
+	               },
+	               "", "", ""},
+	           [&](S3RequestData &request_data) {
+		           auto &params = request_data.http_params->Cast<HTTPFSParams>();
+		           return RunGetRangeRequest(
+		               s3_handle, request_data.http_url, request_data.headers, params, read_config, file_offset,
+		               buffer_out, buffer_out_len,
+		               [&](const HTTPResponse &response) {
+			               return S3RequestUtil::GetRequestError(request_data, response);
+		               },
+		               [&](BaseRequest &request) {
+			               return S3RequestExecutor::SendHandleRequest(s3_handle, request_data.captured, params,
+			                                                           request);
+		               });
+	           })
+	    .response;
 }
 
 unique_ptr<HTTPResponse> S3FileSystem::DeleteRequest(FileHandle &handle, const string &s3_url, HTTPHeaders header_map) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
-	return S3RequestExecutor::RunHandle(
-	    GetEncryptionUtil(), s3_handle, s3_url, RequestType::DELETE_REQUEST, {}, [&](S3RequestData &request_data) {
-		    auto &params = request_data.http_params->Cast<HTTPFSParams>();
-		    return RunDeleteRequest(request_data.http_url, request_data.headers, params, [&](BaseRequest &request) {
-			    return S3RequestExecutor::SendHandleRequest(s3_handle, request_data.captured, params, request);
-		    });
-	    });
+	return S3RequestExecutor::RunHandle(GetEncryptionUtil(), s3_handle,
+	                                    S3RequestSpec {s3_url, S3RequestOperation::DELETE_OBJECT, {}, "", "", ""},
+	                                    [&](S3RequestData &request_data) {
+		                                    auto &params = request_data.http_params->Cast<HTTPFSParams>();
+		                                    return RunDeleteRequest(request_data.http_url, request_data.headers, params,
+		                                                            [&](BaseRequest &request) {
+			                                                            return S3RequestExecutor::SendHandleRequest(
+			                                                                s3_handle, request_data.captured, params,
+			                                                                request);
+		                                                            });
+	                                    })
+	    .response;
 }
 
-unique_ptr<HTTPResponse> S3FileSystem::DeleteRequest(HTTPRequestSession &session, const string &s3_url,
-                                                     const S3RequestQuery &query,
-                                                     optional_ptr<S3RequestContext> request_context) {
+S3RequestResult S3FileSystem::DeleteRequest(HTTPRequestSession &session, S3RequestOperation operation,
+                                            const string &s3_url, const S3RequestQuery &query) {
+	if (S3RequestUtil::GetOperationInfo(operation).request_type != RequestType::DELETE_REQUEST) {
+		throw InternalException("S3 DeleteRequest requires a DELETE operation");
+	}
 	return S3RequestExecutor::RunSession(
-	    GetEncryptionUtil(), session, s3_url, RequestType::DELETE_REQUEST, S3RequestTarget::OBJECT,
-	    [&](const ParsedS3Url &) { return query; }, "", "", "",
+	    GetEncryptionUtil(), session,
+	    S3RequestSpec {s3_url, operation, [&](const ParsedS3Url &) { return query; }, "", "", ""},
 	    [&](S3RequestData &request_data) {
 		    auto &params = request_data.http_params->Cast<HTTPFSParams>();
 		    return RunDeleteRequest(request_data.http_url, request_data.headers, params, [&](BaseRequest &request) {
 			    return S3RequestExecutor::SendSessionRequest(session, request_data.captured, params, request);
 		    });
-	    },
-	    {}, request_context);
+	    });
 }
 
 string S3RequestUtil::ParseError(const string &error) {
@@ -1038,10 +1054,10 @@ HTTPException S3RequestUtil::GetError(const S3AuthParams &s3_auth_params, const 
                                       RequestType request_type, const string &operation, const string &display_url) {
 	string extra_text = S3RequestUtil::ParseError(response.body);
 	if (response.status == HTTPStatusCode::BadRequest_400) {
-		extra_text += S3Provider::GetBadRequestError(s3_auth_params);
+		extra_text += s3_auth_params.GetProvider().GetBadRequestError(s3_auth_params);
 	}
 	if (response.status == HTTPStatusCode::Unauthorized_401 || response.status == HTTPStatusCode::Forbidden_403) {
-		extra_text += S3Provider::GetAuthError(s3_auth_params);
+		extra_text += s3_auth_params.GetProvider().GetAuthError(s3_auth_params);
 	}
 	return HTTPFSUtil::GetHTTPStatusError(response, request_type, operation, display_url, extra_text);
 }
@@ -1051,7 +1067,17 @@ HTTPException S3FileSystem::GetHTTPError(FileHandle &handle, const HTTPResponse 
 	auto &s3_handle = handle.Cast<S3FileHandle>();
 	auto captured = s3_handle.request_session->Capture();
 	auto auth_params = captured.snapshot->Cast<S3RequestSnapshot>().auth_params;
-	return S3RequestUtil::GetError(auth_params, response, request_type, S3RequestOperation(request_type),
+	const char *description = "sending a request to";
+	if (request_type == RequestType::HEAD_REQUEST) {
+		description = "checking";
+	} else if (request_type == RequestType::GET_REQUEST) {
+		description = "reading";
+	} else if (request_type == RequestType::PUT_REQUEST) {
+		description = "uploading to";
+	} else if (request_type == RequestType::DELETE_REQUEST) {
+		description = "deleting";
+	}
+	return S3RequestUtil::GetError(auth_params, response, request_type, description,
 	                               S3Url::GetDisplayUrl(url, auth_params));
 }
 

--- a/src/s3/s3_settings.cpp
+++ b/src/s3/s3_settings.cpp
@@ -104,7 +104,7 @@ static void ValidateMultipartUploadPolicy(const S3MultipartUploadPolicy &policy)
 } // namespace
 
 static void SetS3URLStyle(ClientContext &, SetScope, Value &parameter) {
-	S3Provider::ParseURLStyle(StringValue::Get(parameter));
+	S3AuthURLParams::ParseStyle(StringValue::Get(parameter));
 }
 
 S3UploadConfig S3UploadConfig::Create(uint64_t max_file_size, uint64_t max_parts,
@@ -205,7 +205,7 @@ void S3Settings::Register(DBConfig &config) {
 			    throw InvalidInputException("s3_url_scheme_aliases can only be set globally");
 		    }
 		    // Validate only: routing reads the stored value from DBConfig
-		    parameter = S3Provider::NormalizeSchemeAliases(parameter);
+		    parameter = S3UrlScheme::NormalizeAliases(parameter);
 	    },
 	    SetScope::GLOBAL);
 	config.AddExtensionOption(

--- a/src/s3/s3_upload_session.cpp
+++ b/src/s3/s3_upload_session.cpp
@@ -241,12 +241,13 @@ void S3UploadSession::FailOperation(ErrorData error, FailureDisposition disposit
 shared_ptr<const ErrorData> S3UploadSession::AbortMultipartUpload(const string &upload_id) {
 	S3RequestQuery query {{"uploadId", upload_id}};
 	try {
-		S3RequestContext request_context;
-		auto response = s3fs.get().DeleteRequest(*request_session, path, query, request_context);
+		auto request_result =
+		    s3fs.get().DeleteRequest(*request_session, S3RequestOperation::ABORT_MULTIPART_UPLOAD, path, query);
+		auto &response = request_result.response;
 		if (response->status == HTTPStatusCode::NoContent_204) {
 			return nullptr;
 		}
-		auto status_error = ErrorData(GetStatusError(*response, request_context, "aborting multipart upload for"));
+		auto status_error = ErrorData(GetStatusError(*response, request_result.context));
 		auto contextual_error = Exception(status_error.ExtraInfo(), status_error.Type(),
 		                                  "Failed to abort S3 multipart upload: " + status_error.RawMessage());
 		return make_shared_ptr<const ErrorData>(contextual_error);
@@ -350,10 +351,10 @@ S3UploadSession::PreparedWrite S3UploadSession::PrepareWrite(const_data_ptr_t da
 
 string S3UploadSession::InitializeMultipartUpload() {
 	string result;
-	S3RequestContext request_context;
-	auto response =
-	    s3fs.get().PostRequest(*request_session, path, result, nullptr, 0, S3RequestQuery({{"uploads", ""}}),
-	                           S3PostRequestMode::DEFAULT, request_context);
+	auto request_result = s3fs.get().PostRequest(*request_session, S3RequestOperation::CREATE_MULTIPART_UPLOAD, path,
+	                                             result, nullptr, 0, S3RequestQuery({{"uploads", ""}}));
+	auto &response = request_result.response;
+	auto &request_context = request_result.context;
 	if (response->HasRequestError()) {
 		throw S3AmbiguousUploadException(StringUtil::Format(
 		    "S3 multipart upload initialization for \"%s\" has an unknown outcome because the response was not "
@@ -361,7 +362,7 @@ string S3UploadSession::InitializeMultipartUpload() {
 		    request_context.display_url));
 	}
 	if (!IsSuccessfulStatus(response->status)) {
-		throw GetStatusError(*response, request_context, "initializing multipart upload for");
+		throw GetStatusError(*response, request_context);
 	}
 
 	S3XMLResponse parsed_response;
@@ -455,21 +456,20 @@ void S3UploadSession::ThrowIfFailed() DUCKDB_EXCLUDES(state_lock) {
 	}
 }
 
-unique_ptr<HTTPResponse> S3UploadSession::RunUploadRequest(const_data_ptr_t data, idx_t size,
-                                                           const S3RequestQuery &query,
-                                                           S3RequestContext &request_context) {
-	auto response = s3fs.get().PutRequest(*request_session, path, data, size, query, request_context);
-	if (response->HasRequestError()) {
-		throw IOException("S3 upload request for \"%s\" could not be completed", request_context.display_url);
+S3RequestResult S3UploadSession::RunUploadRequest(S3RequestOperation operation, const_data_ptr_t data, idx_t size,
+                                                  const S3RequestQuery &query) {
+	auto result = s3fs.get().PutRequest(*request_session, operation, path, data, size, query);
+	if (result.response->HasRequestError()) {
+		throw IOException("S3 upload request for \"%s\" could not be completed", result.context.display_url);
 	}
-	return response;
+	return result;
 }
 
 void S3UploadSession::UploadObject(const_data_ptr_t data, idx_t size) {
-	S3RequestContext request_context;
-	auto response = RunUploadRequest(data, size, S3RequestQuery(), request_context);
+	auto request_result = RunUploadRequest(S3RequestOperation::PUT_OBJECT, data, size, S3RequestQuery());
+	auto &response = request_result.response;
 	if (response->status != HTTPStatusCode::OK_200 && response->status != HTTPStatusCode::Created_201) {
-		throw GetStatusError(*response, request_context, "uploading to");
+		throw GetStatusError(*response, request_result.context);
 	}
 }
 
@@ -478,10 +478,10 @@ void S3UploadSession::UploadPart(PreparedPart &part) {
 	ThrowIfFailed();
 	D_ASSERT(upload_id);
 	S3RequestQuery query {{"partNumber", to_string(part.part_number)}, {"uploadId", *upload_id}};
-	S3RequestContext request_context;
-	auto response = RunUploadRequest(part.data, part.size, query, request_context);
+	auto request_result = RunUploadRequest(S3RequestOperation::UPLOAD_PART, part.data, part.size, query);
+	auto &response = request_result.response;
 	if (response->status != HTTPStatusCode::OK_200) {
-		throw GetStatusError(*response, request_context, "uploading to");
+		throw GetStatusError(*response, request_result.context);
 	}
 	if (!response->headers.HasHeader("ETag")) {
 		throw IOException("Unexpected response when uploading to S3");
@@ -529,10 +529,11 @@ void S3UploadSession::CompleteMultipartUpload() {
 
 	S3RequestQuery query {{"uploadId", *snapshot.upload_id}};
 	string result;
-	S3RequestContext request_context;
-	auto response = s3fs.get().PostRequest(*request_session, path, result, const_data_ptr_cast(completion_body.data()),
-	                                       completion_body.size(), query, S3PostRequestMode::RETRY_RECEIVED_RESPONSES,
-	                                       request_context);
+	auto request_result =
+	    s3fs.get().PostRequest(*request_session, S3RequestOperation::COMPLETE_MULTIPART_UPLOAD, path, result,
+	                           const_data_ptr_cast(completion_body.data()), completion_body.size(), query);
+	auto &response = request_result.response;
+	auto &request_context = request_result.context;
 	if (response->HasRequestError()) {
 		throw S3AmbiguousUploadException(
 		    StringUtil::Format("S3 multipart upload completion for \"%s\" has an unknown outcome because the "
@@ -541,7 +542,7 @@ void S3UploadSession::CompleteMultipartUpload() {
 		                       request_context.display_url));
 	}
 	if (!IsSuccessfulStatus(response->status)) {
-		throw GetStatusError(*response, request_context, "completing multipart upload for");
+		throw GetStatusError(*response, request_context);
 	}
 
 	S3XMLResponse parsed_response;
@@ -570,10 +571,8 @@ string S3UploadSession::GetDisplayPath() const {
 	return S3Url::GetDisplayUrl(path, snapshot.auth_params);
 }
 
-HTTPException S3UploadSession::GetStatusError(const HTTPResponse &response, const S3RequestContext &request_context,
-                                              const string &operation) {
-	return S3RequestUtil::GetError(request_context.auth_params, response, request_context.request_type, operation,
-	                               request_context.display_url);
+HTTPException S3UploadSession::GetStatusError(const HTTPResponse &response, const S3RequestContext &request_context) {
+	return S3RequestUtil::GetRequestError(request_context, response);
 }
 
 S3UploadSession::WriteClaim S3UploadSession::Write(const_data_ptr_t data, idx_t size, idx_t location) {

--- a/src/s3/s3_upload_session.cpp
+++ b/src/s3/s3_upload_session.cpp
@@ -262,7 +262,7 @@ shared_ptr<const ErrorData> S3UploadSession::AbortMultipartUpload(const string &
 }
 
 unique_ptr<S3UploadSession::BufferedPart> S3UploadSession::AllocateBufferedPart(idx_t capacity) {
-	auto buffer = s3fs.get().buffer_manager.Allocate(MemoryTag::EXTENSION, capacity);
+	auto buffer = s3fs.get().GetBufferManager().Allocate(MemoryTag::EXTENSION, capacity);
 	return make_uniq<BufferedPart>(std::move(buffer), capacity);
 }
 

--- a/src/s3/s3_url.cpp
+++ b/src/s3/s3_url.cpp
@@ -48,23 +48,25 @@ unordered_map<string, string> S3Url::ParseQueryParameters(const string &url_quer
 	return result;
 }
 
-void S3Url::ReadQueryParams(const string &url_query_param, S3AuthParams &params) {
+void S3Url::ReadQueryParams(const string &url_query_param, S3AuthConfig &config) {
 	if (url_query_param.empty()) {
 		return;
 	}
 
 	auto query_params = ParseQueryParameters(url_query_param);
+	auto &credentials = config.credentials;
+	auto &request_options = config.request_options;
 
-	GetQueryParam("s3_region", params.region, query_params);
-	GetQueryParam("s3_access_key_id", params.access_key_id, query_params);
-	GetQueryParam("s3_secret_access_key", params.secret_access_key, query_params);
-	GetQueryParam("s3_session_token", params.session_token, query_params);
+	GetQueryParam("s3_region", credentials.region, query_params);
+	GetQueryParam("s3_access_key_id", credentials.access_key_id, query_params);
+	GetQueryParam("s3_secret_access_key", credentials.secret_access_key, query_params);
+	GetQueryParam("s3_session_token", credentials.session_token, query_params);
 	auto found_param = query_params.find("s3_use_ssl");
 	if (found_param != query_params.end()) {
 		if (found_param->second == "true") {
-			params.use_ssl = true;
+			config.use_ssl = true;
 		} else if (found_param->second == "false") {
-			params.use_ssl = false;
+			config.use_ssl = false;
 		} else {
 			throw IOException("Incorrect setting found for s3_use_ssl, allowed values are: 'true' or 'false'");
 		}
@@ -72,53 +74,49 @@ void S3Url::ReadQueryParams(const string &url_query_param, S3AuthParams &params)
 	}
 	string endpoint;
 	if (GetQueryParam("s3_endpoint", endpoint, query_params)) {
-		params.SetEndpoint(std::move(endpoint));
+		config.endpoint = std::move(endpoint);
+		auto trimmed_endpoint = config.endpoint;
+		StringUtil::Trim(trimmed_endpoint);
+		config.endpoint_mode = trimmed_endpoint.empty() ? S3EndpointMode::AUTOMATIC : S3EndpointMode::EXPLICIT;
 	}
-	if (GetQueryParam("s3_url_style", params.url_style, query_params)) {
-		S3Provider::ParseURLStyle(params.url_style);
-	}
+	GetQueryParam("s3_url_style", config.url_style, query_params);
 	auto found_requester_pays_param = query_params.find("s3_requester_pays");
 	if (found_requester_pays_param != query_params.end()) {
 		if (found_requester_pays_param->second == "true") {
-			params.requester_pays = true;
+			request_options.requester_pays = true;
 		} else if (found_requester_pays_param->second == "false") {
-			params.requester_pays = false;
+			request_options.requester_pays = false;
 		} else {
 			throw IOException("Incorrect setting found for s3_requester_pays, allowed values are: 'true' or 'false'");
 		}
 		query_params.erase(found_requester_pays_param);
 	}
-	if (params.provider_type == S3ProviderType::GCS) {
-		GetQueryParam("gcs_user_project", params.user_project, query_params);
+	if (config.route.type == S3ProviderType::GCS) {
+		GetQueryParam("gcs_user_project", request_options.user_project, query_params);
 	}
 	if (!query_params.empty()) {
 		auto supported_parameters =
 		    string("'s3_region', 's3_access_key_id', 's3_secret_access_key', 's3_session_token',\n's3_endpoint', "
 		           "'s3_url_style', 's3_use_ssl', 's3_requester_pays'");
-		if (params.provider_type == S3ProviderType::GCS) {
+		if (config.route.type == S3ProviderType::GCS) {
 			supported_parameters += ", 'gcs_user_project'";
 		}
 		throw IOException("Invalid query parameters found. Supported parameters are:\n%s", supported_parameters);
 	}
 }
 
-ParsedS3Url S3Url::Resolve(const string &url, S3AuthParams &params) {
-	S3Provider::ParseURLStyle(params.url_style);
-	// The last source of an endpoint, so validation happens after it
-	string query_param;
-	if (!params.s3_url_compatibility_mode) {
-		auto question_pos = url.find_first_of('?');
-		if (question_pos != string::npos) {
-			query_param = url.substr(question_pos + 1);
-		}
+void S3Url::ApplyAuthQueryParameters(const string &url, S3AuthConfig &config) {
+	if (config.compatibility_mode) {
+		return;
 	}
-	ReadQueryParams(query_param, params);
-	S3Provider::FinalizeAuthParams(params);
-	return Parse(url, params);
+	auto question_pos = url.find_first_of('?');
+	if (question_pos != string::npos) {
+		ReadQueryParams(url.substr(question_pos + 1), config);
+	}
 }
 
 string S3Url::GetDisplayUrl(const string &url, const S3AuthParams &params) {
-	if (params.s3_url_compatibility_mode) {
+	if (params.GetURLParams().compatibility_mode) {
 		return url;
 	}
 	auto query_position = url.find('?');
@@ -128,19 +126,9 @@ string S3Url::GetDisplayUrl(const string &url, const S3AuthParams &params) {
 ParsedS3Url S3Url::Parse(const string &url, const S3AuthParams &params) {
 	string prefix, host, bucket, key, encoded_path, encoded_bucket_path, query_string;
 
-	auto provider_match = S3Provider::TryMatchUrl(url);
-	if (provider_match) {
-		D_ASSERT(provider_match->type == params.provider_type);
-		prefix = std::move(provider_match->prefix);
-	} else {
-		// Alias-routed url: the caller already matched it against 's3_url_scheme_aliases'
-		D_ASSERT(params.provider_type == S3ProviderType::S3);
-		auto scheme_end = url.find("://");
-		if (scheme_end == string::npos) {
-			S3Provider::MatchUrl(url); // throws with the expected-prefixes message
-		}
-		prefix = StringUtil::Lower(url.substr(0, scheme_end + 3));
-	}
+	auto &route = params.GetProvider().GetRoute();
+	prefix = route.prefix;
+	D_ASSERT(StringUtil::CIStartsWith(url, prefix));
 	auto prefix_end_pos = url.find("//") + 2;
 	auto slash_pos = url.find('/', prefix_end_pos);
 	if (slash_pos == string::npos) {
@@ -151,7 +139,7 @@ ParsedS3Url S3Url::Parse(const string &url, const S3AuthParams &params) {
 		throw IOException("URL needs to contain a bucket name");
 	}
 
-	if (params.s3_url_compatibility_mode) {
+	if (params.GetURLParams().compatibility_mode) {
 		// In url compatibility mode, we will ignore any special chars, so query param strings are disabled
 		key += url.substr(slash_pos);
 	} else {
@@ -173,8 +161,9 @@ ParsedS3Url S3Url::Parse(const string &url, const S3AuthParams &params) {
 	}
 
 	// Derived host and path based on the normalized endpoint
-	host = params.GetEndpoint().GetAuthority();
-	auto &base_path = params.GetEndpoint().GetBasePath();
+	auto &url_params = params.GetURLParams();
+	host = url_params.endpoint.GetAuthority();
+	auto &base_path = url_params.endpoint.GetBasePath();
 	for (idx_t i = 0; i < base_path.size(); i++) {
 		if (base_path[i] == '%' && i + 2 < base_path.size()) {
 			encoded_path += base_path.substr(i, 3);
@@ -186,14 +175,14 @@ ParsedS3Url S3Url::Parse(const string &url, const S3AuthParams &params) {
 
 	// Update host and path according to the url style
 	// See https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
-	auto url_style = S3Provider::ParseURLStyle(params.url_style);
+	auto url_style = url_params.style;
 	bool use_vhost = url_style == S3URLStyle::VIRTUAL_HOSTED;
-	if (use_vhost && params.GetEndpoint().IsIPv6()) {
+	if (use_vhost && url_params.endpoint.IsIPv6()) {
 		throw InvalidInputException("IPv6 S3 endpoints require path-style URLs");
 	}
 	// A bucket name containing periods (.) is not addressable vhost-style over TLS. Fallback to path style url
 	bool use_path = url_style == S3URLStyle::PATH ||
-	                (use_vhost && params.GetEndpoint().UsesSSL() && bucket.find('.') != string::npos);
+	                (use_vhost && url_params.endpoint.UsesSSL() && bucket.find('.') != string::npos);
 	if (use_path) {
 		encoded_path += "/" + Encode(bucket, S3URLEncodeMode::PATH);
 	} else if (use_vhost) {
@@ -215,7 +204,7 @@ ParsedS3Url S3Url::Parse(const string &url, const S3AuthParams &params) {
 	result.host = std::move(host);
 	result.encoded_path = std::move(encoded_path);
 	result.encoded_bucket_path = std::move(encoded_bucket_path);
-	result.use_ssl = params.GetEndpoint().UsesSSL();
+	result.use_ssl = url_params.endpoint.UsesSSL();
 	return result;
 }
 

--- a/src/s3/s3fs.cpp
+++ b/src/s3/s3fs.cpp
@@ -179,16 +179,14 @@ EncryptionUtil &S3FileSystem::GetEncryptionUtil() {
 unique_ptr<HTTPFileHandle> S3FileSystem::CreateHandle(const OpenFileInfo &file, FileOpenFlags flags,
                                                       optional_ptr<FileOpener> opener) {
 	FileOpenerInfo info = {file.path};
-	S3AuthParams auth_params = S3AuthParams::ReadFrom(opener, info);
-
-	S3Url::Resolve(file.path, auth_params);
+	auto auth_params = S3AuthResolver::Resolve(opener, info);
 
 	auto &http_util = HTTPFSUtil::GetHTTPUtil(opener);
 	auto params = http_util.InitializeParameters(opener, info);
 	S3UploadConfig upload_config;
 	optional<S3MultipartUploadPolicy> multipart_upload_policy;
 	if (flags.OpenForWriting()) {
-		multipart_upload_policy = S3Provider::GetMultipartUploadPolicy(auth_params);
+		multipart_upload_policy = auth_params.GetProvider().GetMultipartUploadPolicy();
 		upload_config = S3UploadConfig::ReadFrom(opener, *multipart_upload_policy);
 	}
 
@@ -209,8 +207,8 @@ HTTPMetadataCacheEntry S3FileHandle::GetCacheEntry() const {
 	auto captured = request_session->Capture();
 	auto &snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
 	if (snapshot.region_redirected) {
-		D_ASSERT(!snapshot.auth_params.region.empty());
-		result.properties["s3_region"] = snapshot.auth_params.region;
+		D_ASSERT(!snapshot.auth_params.GetCredentials().region.empty());
+		result.properties["s3_region"] = snapshot.auth_params.GetCredentials().region;
 	}
 	return result;
 }
@@ -238,14 +236,14 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 bool S3FileSystem::CanHandleFile(const string &fpath) {
 	// This runs for every path the VFS probes, so keep local paths and built-in schemes off the
 	// setting lookup, which takes the database-wide settings lock
-	if (S3Provider::TryMatchUrl(fpath)) {
+	if (S3UrlScheme::TryMatch(fpath)) {
 		return true;
 	}
 	if (fpath.find("://") == string::npos) {
 		return false;
 	}
 	auto &config = DBConfig::GetConfig(buffer_manager.GetDatabase());
-	return S3Provider::TryMatchUrl(fpath, S3Provider::GetSchemeAliasPrefixes(config)).has_value();
+	return S3UrlScheme::TryMatch(fpath, S3UrlScheme::GetAliasPrefixes(config)).has_value();
 }
 
 bool S3FileSystem::OnDiskFile(FileHandle &) {

--- a/src/s3/s3fs.cpp
+++ b/src/s3/s3fs.cpp
@@ -35,10 +35,9 @@ S3FileHandle::S3FileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFla
                            optional<S3MultipartUploadPolicy> multipart_upload_policy)
     : HTTPFileHandle(fs, file, flags, std::move(http_params_p)) {
 	auto captured = request_session->Capture();
-	auto request_params = captured.snapshot->CreateRequestParams();
 	request_session->TryPublish(captured.snapshot,
-	                            make_shared_ptr<S3RequestSnapshot>(*request_params, auth_params_p, file.path,
-	                                                               weak_ptr<ClientContext>(), true, false, 0,
+	                            make_shared_ptr<S3RequestSnapshot>(captured.snapshot->Params(), auth_params_p,
+	                                                               file.path, weak_ptr<ClientContext>(), true, false, 0,
 	                                                               std::move(multipart_upload_policy)));
 	auto_fallback_to_full_file_download = false;
 	if (flags.OpenForReading() && flags.OpenForWriting()) {
@@ -219,14 +218,13 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
 	{
 		auto captured = request_session->Capture();
 		auto &snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
-		auto request_params = snapshot.CreateRequestParams();
 		weak_ptr<ClientContext> weak_context;
 		if (context && refresh_enabled) {
 			weak_context = context->shared_from_this();
 		}
 		request_session->TryPublish(
 		    captured.snapshot,
-		    make_shared_ptr<S3RequestSnapshot>(*request_params, snapshot.auth_params, snapshot.refresh_path,
+		    make_shared_ptr<S3RequestSnapshot>(snapshot.Params(), snapshot.auth_params, snapshot.refresh_path,
 		                                       std::move(weak_context), refresh_enabled, snapshot.region_redirected,
 		                                       snapshot.credential_generation, snapshot.multipart_upload_policy));
 	}

--- a/src/s3/s3fs.cpp
+++ b/src/s3/s3fs.cpp
@@ -168,11 +168,15 @@ void S3FileHandle::AbortUpload() {
 }
 
 EncryptionUtil &S3FileSystem::GetEncryptionUtil() {
-	auto &config = DBConfig::GetConfig(buffer_manager.GetDatabase());
+	auto &config = DBConfig::GetConfig(GetBufferManager().GetDatabase());
 	if (!config.encryption_util) {
 		throw InternalException("HTTPFS encryption util has not been initialized");
 	}
 	return *config.encryption_util;
+}
+
+BufferManager &S3FileSystem::GetBufferManager() {
+	return buffer_manager;
 }
 
 unique_ptr<HTTPFileHandle> S3FileSystem::CreateHandle(const OpenFileInfo &file, FileOpenFlags flags,
@@ -240,7 +244,7 @@ bool S3FileSystem::CanHandleFile(const string &fpath) {
 	if (fpath.find("://") == string::npos) {
 		return false;
 	}
-	auto &config = DBConfig::GetConfig(buffer_manager.GetDatabase());
+	auto &config = DBConfig::GetConfig(GetBufferManager().GetDatabase());
 	return S3UrlScheme::TryMatch(fpath, S3UrlScheme::GetAliasPrefixes(config)).has_value();
 }
 

--- a/test/unittest/http/connection_reuse_test.cpp
+++ b/test/unittest/http/connection_reuse_test.cpp
@@ -107,6 +107,64 @@ static void RunCurlTerminalTransportErrorIsNotCached() {
 	HTTPTestHelper::RequireQueryOk(con, "COMMIT");
 }
 
+static void RunCurlExactEmptyResponseHeaderScenario() {
+	MockS3ServerConfig config;
+	config.metadata.exact_empty_response_headers = true;
+	config.metadata.response_headers.emplace_back("X-Empty", "");
+	MockS3Server server(std::move(config));
+
+	HTTPFSCurlUtil http_util;
+	HTTPFSParams params(http_util);
+	auto client = http_util.InitializeClient(params, "http://" + server.Endpoint());
+	HeadRequestInfo request(server.HTTPPath(), HTTPHeaders(), params);
+	auto response = http_util.Request(request, client);
+	REQUIRE(response);
+	REQUIRE(response->Success());
+	REQUIRE(response->headers.HasHeader("X-Empty"));
+	REQUIRE(response->headers.GetHeaderValue("X-Empty").empty());
+}
+
+static void RunCurlRedirectedResponseHeaderScenario() {
+	MockS3ServerConfig config;
+	config.metadata.redirect_head = true;
+	config.metadata.redirect_response_headers.emplace_back("X-Redirect-Only", "redirect");
+	config.metadata.response_headers.emplace_back("X-Repeated", "first");
+	config.metadata.response_headers.emplace_back("X-Repeated", "second");
+	MockS3Server server(std::move(config));
+
+	HTTPFSCurlUtil http_util;
+	HTTPFSParams params(http_util);
+	params.follow_location = true;
+	auto client = http_util.InitializeClient(params, "http://" + server.Endpoint());
+	HeadRequestInfo request(server.HTTPPath(), HTTPHeaders(), params);
+	auto response = http_util.Request(request, client);
+	REQUIRE(response);
+	REQUIRE(response->Success());
+	REQUIRE(response->headers.GetHeaderValues("X-Repeated") == vector<string> {"first", "second"});
+	REQUIRE_FALSE(response->headers.HasHeader("X-Redirect-Only"));
+}
+
+static void RunCurlRequestHeaderScenario() {
+	MockS3Server server {MockS3ServerConfig()};
+	HTTPFSCurlUtil http_util;
+	HTTPFSParams params(http_util);
+	auto client = http_util.InitializeClient(params, "http://" + server.Endpoint());
+	HTTPHeaders headers;
+	headers["X-Empty"] = "";
+	headers["X-Whitespace"] = " \t ";
+	headers["X-Value"] = "value";
+	HeadRequestInfo request(server.HTTPPath(), headers, params);
+	auto response = http_util.Request(request, client);
+	REQUIRE(response);
+	REQUIRE(response->Success());
+
+	auto observations = server.Observations();
+	REQUIRE(observations.size() == 1);
+	REQUIRE(MockS3HeaderValues(observations[0], "X-Empty") == vector<string> {""});
+	REQUIRE(MockS3HeaderValues(observations[0], "X-Whitespace") == vector<string> {""});
+	REQUIRE(MockS3HeaderValues(observations[0], "X-Value") == vector<string> {"value"});
+}
+
 } // namespace
 
 TEST_CASE("HTTP request sessions allow follow-up requests after completed errors", "[httpfs][request-session]") {
@@ -124,6 +182,18 @@ TEST_CASE("Curl retries bypass the shared connection cache", "[httpfs][request-s
 
 TEST_CASE("Curl terminal transport errors are not cached", "[httpfs][request-session]") {
 	RunCurlTerminalTransportErrorIsNotCached();
+}
+
+TEST_CASE("Curl response headers accept exact empty fields", "[httpfs][curl][headers]") {
+	RunCurlExactEmptyResponseHeaderScenario();
+}
+
+TEST_CASE("Curl response headers preserve repeated fields from the final redirect", "[httpfs][curl][headers]") {
+	RunCurlRedirectedResponseHeaderScenario();
+}
+
+TEST_CASE("Curl request headers preserve empty field values", "[httpfs][curl][headers]") {
+	RunCurlRequestHeaderScenario();
 }
 
 } // namespace duckdb

--- a/test/unittest/http/connection_reuse_test.cpp
+++ b/test/unittest/http/connection_reuse_test.cpp
@@ -1,6 +1,8 @@
 #include "catch.hpp"
 
 #include "http/http_test_helper.hpp"
+#include "http/http_metadata_cache.hpp"
+#include "http/http_state.hpp"
 #include "http/httpfs_client.hpp"
 
 namespace duckdb {
@@ -165,6 +167,85 @@ static void RunCurlRequestHeaderScenario() {
 	REQUIRE(MockS3HeaderValues(observations[0], "X-Value") == vector<string> {"value"});
 }
 
+static void RunHTTPStateCounterScenario(HTTPFSUtil &http_util) {
+	MockS3ServerConfig config;
+	config.http_response.object_put_body = "put response";
+	config.http_response.object_delete_body = "delete response";
+	config.http_response.options_body = "options response";
+	MockS3Server server(std::move(config));
+	auto state = make_shared_ptr<HTTPState>();
+	HTTPFSParams params(http_util);
+	params.state = state;
+	auto client = http_util.InitializeClient(params, "http://" + server.Endpoint());
+	const string put_body = "put";
+	const string post_body = "post";
+
+	HeadRequestInfo head(server.HTTPPath(), HTTPHeaders(), params);
+	auto head_response = http_util.Request(head, client);
+	REQUIRE(head_response);
+
+	GetRequestInfo get(server.HTTPPath(), HTTPHeaders(), params, nullptr, nullptr);
+	auto get_response = http_util.Request(get, client);
+	REQUIRE(get_response);
+
+	PutRequestInfo put(server.HTTPPath(), HTTPHeaders(), params, const_data_ptr_cast(put_body.data()), put_body.size(),
+	                   "application/octet-stream");
+	auto put_response = http_util.Request(put, client);
+	REQUIRE(put_response);
+
+	PostRequestInfo post(server.HTTPPath() + "?uploads=", HTTPHeaders(), params, const_data_ptr_cast(post_body.data()),
+	                     post_body.size());
+	auto post_response = http_util.Request(post, client);
+	REQUIRE(post_response);
+
+	DeleteRequestInfo delete_request(server.HTTPPath(), HTTPHeaders(), params);
+	auto delete_response = http_util.Request(delete_request, client);
+	REQUIRE(delete_response);
+
+	OptionsRequestInfo options(server.HTTPPath(), HTTPHeaders(), params);
+	auto options_response = http_util.Request(options, client);
+	REQUIRE(options_response);
+
+	auto counters = state->GetCounters();
+	REQUIRE(counters.head_count == 1);
+	REQUIRE(counters.get_count == 1);
+	REQUIRE(counters.put_count == 1);
+	REQUIRE(counters.post_count == 1);
+	REQUIRE(counters.delete_count == 1);
+	REQUIRE(counters.options_count == 1);
+	REQUIRE(counters.total_bytes_sent == put_body.size() + post_body.size());
+	REQUIRE(counters.total_bytes_received == head_response->body.size() + get_response->body.size() +
+	                                             put_response->body.size() + post_response->body.size() +
+	                                             delete_response->body.size() + options_response->body.size());
+	REQUIRE_FALSE(state->IsEmpty());
+	state->Reset();
+	REQUIRE(state->IsEmpty());
+}
+
+static void RunCurlConnectionCachingTransitionScenario() {
+	MockS3Server server {MockS3ServerConfig()};
+	HTTPFSCurlUtil http_util;
+	HTTPFSParams params(http_util);
+
+	auto first_client = http_util.InitializeClient(params, "http://" + server.Endpoint());
+	HeadRequestInfo first_request(server.HTTPPath(), HTTPHeaders(), params);
+	REQUIRE(http_util.Request(first_request, first_client));
+	http_util.CloseClient(std::move(first_client));
+
+	http_util.SetConnectionCachingEnabled(false);
+	REQUIRE(http_util.GetClientReuseMode() == HTTPClientReuseMode::SESSION_LOCAL);
+	http_util.SetConnectionCachingEnabled(true);
+	REQUIRE(http_util.GetClientReuseMode() == HTTPClientReuseMode::SHARED);
+
+	auto second_client = http_util.InitializeClient(params, "http://" + server.Endpoint());
+	HeadRequestInfo second_request(server.HTTPPath(), HTTPHeaders(), params);
+	REQUIRE(http_util.Request(second_request, second_client));
+
+	auto ports = HTTPTestHelper::RequestPorts(server.Observations(), "HEAD", 200);
+	REQUIRE(ports.size() == 2);
+	REQUIRE(ports[0] != ports[1]);
+}
+
 } // namespace
 
 TEST_CASE("HTTP request sessions allow follow-up requests after completed errors", "[httpfs][request-session]") {
@@ -194,6 +275,42 @@ TEST_CASE("Curl response headers preserve repeated fields from the final redirec
 
 TEST_CASE("Curl request headers preserve empty field values", "[httpfs][curl][headers]") {
 	RunCurlRequestHeaderScenario();
+}
+
+TEST_CASE("HTTP clients record request and byte counters", "[httpfs][http-state]") {
+	SECTION("httplib") {
+		HTTPFSUtil http_util;
+		RunHTTPStateCounterScenario(http_util);
+	}
+	SECTION("curl") {
+		HTTPFSCurlUtil http_util;
+		RunHTTPStateCounterScenario(http_util);
+	}
+}
+
+TEST_CASE("Disabling curl connection caching clears pooled clients", "[httpfs][connection-cache]") {
+	RunCurlConnectionCachingTransitionScenario();
+}
+
+TEST_CASE("HTTP metadata cache mode controls query-end clearing", "[httpfs][metadata-cache]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	HTTPMetadataCacheEntry entry;
+	entry.length = 42;
+	entry.last_modified = timestamp_t(0);
+	HTTPMetadataCacheEntry result;
+
+	HTTPMetadataCache global_cache(HTTPMetadataCacheMode::GLOBAL);
+	global_cache.Insert("global", entry);
+	global_cache.QueryEnd(*con.context);
+	REQUIRE(global_cache.Find("global", result));
+	global_cache.Clear();
+	REQUIRE_FALSE(global_cache.Find("global", result));
+
+	HTTPMetadataCache query_cache(HTTPMetadataCacheMode::QUERY_LOCAL);
+	query_cache.Insert("query", entry);
+	query_cache.QueryEnd(*con.context);
+	REQUIRE_FALSE(query_cache.Find("query", result));
 }
 
 } // namespace duckdb

--- a/test/unittest/http/hffs_test.cpp
+++ b/test/unittest/http/hffs_test.cpp
@@ -55,7 +55,7 @@ TEST_CASE("Hugging Face list status errors preserve HTTP metadata", "[httpfs][hf
 	string next_page_url = url.endpoint + "/missing-hugging-face-page";
 
 	try {
-		TestHuggingFaceFileSystem::ListHFRequest(url, httpfs_params, next_page_url, nullptr);
+		TestHuggingFaceFileSystem::ListHFRequest(url, httpfs_params, next_page_url);
 		FAIL("Expected the missing page to fail");
 	} catch (std::exception &ex) {
 		ErrorData error(ex);

--- a/test/unittest/http/http_request_session_test.cpp
+++ b/test/unittest/http/http_request_session_test.cpp
@@ -145,16 +145,27 @@ TEST_CASE("HTTP request snapshots are immutable and checked", "[httpfs][request-
 	REQUIRE(publication.published);
 	auto current = publication.current;
 
-	HTTPHeaders initial_headers;
-	initial.snapshot->AddConfiguredHeaders(initial_headers);
-	REQUIRE(initial_headers.GetHeaderValue("User-Agent") == "httpfs-session-test");
-	REQUIRE(initial_headers.GetHeaderValue("X-Test") == "first");
+	auto initial_request = initial.snapshot->CreateRequest();
+	REQUIRE(initial_request.headers.GetHeaderValue("User-Agent") == "httpfs-session-test");
+	REQUIRE(initial_request.headers.GetHeaderValue("X-Test") == "first");
+	REQUIRE(initial_request.configured_headers.user_agent == "httpfs-session-test");
+	REQUIRE(initial_request.configured_headers.extra_headers.at("X-Test") == "first");
+	REQUIRE(initial_request.params->user_agent.empty());
+	REQUIRE(initial_request.params->extra_headers.empty());
 
-	HTTPHeaders current_headers;
-	current.snapshot->AddConfiguredHeaders(current_headers);
-	current.snapshot->AddConfiguredHeaders(current_headers);
-	REQUIRE(current_headers.GetHeaderValue("User-Agent") == "httpfs-session-test");
-	REQUIRE(current_headers.GetHeaderValue("X-Test") == "second");
+	HTTPHeaders caller_headers;
+	caller_headers["User-Agent"] = "caller-agent";
+	caller_headers["X-Test"] = "caller";
+	auto current_request = current.snapshot->CreateRequest(std::move(caller_headers));
+	REQUIRE(current_request.headers.GetHeaderValue("User-Agent") == "caller-agent");
+	REQUIRE(current_request.headers.GetHeaderValue("X-Test") == "second");
+
+	params.extra_headers["uSeR-aGeNt"] = "extra-agent";
+	auto override_snapshot = make_shared_ptr<HTTPRequestSnapshot>(params);
+	HTTPHeaders overridden_headers;
+	overridden_headers["USER-AGENT"] = "caller-agent";
+	auto override_request = override_snapshot->CreateRequest(std::move(overridden_headers));
+	REQUIRE(override_request.headers.GetHeaderValue("User-Agent") == "extra-agent");
 
 	auto stale_replacement = make_shared_ptr<HTTPRequestSnapshot>(CreateParams(http_util));
 	auto stale_publication = session->TryPublish(initial.snapshot, stale_replacement);
@@ -189,9 +200,9 @@ TEST_CASE("HTTP client leases obey snapshot generations", "[httpfs][request-sess
 
 	{
 		auto captured = session->Capture();
-		auto request_params = captured.snapshot->CreateRequestParams();
-		REQUIRE(&request_params->http_util == &http_util);
-		auto lease = session->AcquireClient(captured, *request_params, "http://localhost");
+		auto request = captured.snapshot->CreateRequest();
+		REQUIRE(&request.params->http_util == &http_util);
+		auto lease = session->AcquireClient(captured, *request.params, "http://localhost");
 		REQUIRE(lease.Client());
 	}
 	REQUIRE(lifecycle.initialized == 1);
@@ -200,8 +211,8 @@ TEST_CASE("HTTP client leases obey snapshot generations", "[httpfs][request-sess
 
 	{
 		auto captured = session->Capture();
-		auto request_params = captured.snapshot->CreateRequestParams();
-		auto lease = session->AcquireClient(captured, *request_params, "http://localhost");
+		auto request = captured.snapshot->CreateRequest();
+		auto lease = session->AcquireClient(captured, *request.params, "http://localhost");
 		REQUIRE(lease.Client());
 		REQUIRE(lifecycle.initialized == 1);
 		lease.Invalidate();
@@ -211,8 +222,8 @@ TEST_CASE("HTTP client leases obey snapshot generations", "[httpfs][request-sess
 
 	{
 		auto captured = session->Capture();
-		auto request_params = captured.snapshot->CreateRequestParams();
-		auto lease = session->AcquireClient(captured, *request_params, "http://localhost");
+		auto request = captured.snapshot->CreateRequest();
+		auto lease = session->AcquireClient(captured, *request.params, "http://localhost");
 		REQUIRE(lease.Client());
 
 		auto incompatible_params = CreateParams(other_http_util);
@@ -225,8 +236,8 @@ TEST_CASE("HTTP client leases obey snapshot generations", "[httpfs][request-sess
 
 	{
 		auto captured = session->Capture();
-		auto request_params = captured.snapshot->CreateRequestParams();
-		auto lease = session->AcquireClient(captured, *request_params, "http://localhost");
+		auto request = captured.snapshot->CreateRequest();
+		auto lease = session->AcquireClient(captured, *request.params, "http://localhost");
 		REQUIRE(lease.Client());
 	}
 	REQUIRE(lifecycle.initialized == 3);
@@ -253,8 +264,8 @@ TEST_CASE("HTTP request sessions reinitialize reused clients", "[httpfs][request
 
 	{
 		auto captured = session->Capture();
-		auto request_params = captured.snapshot->CreateRequestParams();
-		auto lease = session->AcquireClient(captured, *request_params, "http://localhost");
+		auto request = captured.snapshot->CreateRequest();
+		auto lease = session->AcquireClient(captured, *request.params, "http://localhost");
 		REQUIRE(lease.Client());
 	}
 	REQUIRE(lifecycle.initialized == 1);
@@ -271,8 +282,8 @@ TEST_CASE("HTTP request sessions reinitialize reused clients", "[httpfs][request
 
 	{
 		auto current = session->Capture();
-		auto request_params = current.snapshot->CreateRequestParams();
-		auto lease = session->AcquireClient(current, *request_params, "http://localhost");
+		auto request = current.snapshot->CreateRequest();
+		auto lease = session->AcquireClient(current, *request.params, "http://localhost");
 		REQUIRE(lease.Client());
 	}
 	REQUIRE(lifecycle.initialized == 1);
@@ -295,22 +306,22 @@ TEST_CASE("HTTP request sessions discard clients that fail reinitialization", "[
 
 	{
 		auto captured = session->Capture();
-		auto request_params = captured.snapshot->CreateRequestParams();
-		auto lease = session->AcquireClient(captured, *request_params, "http://localhost");
+		auto request = captured.snapshot->CreateRequest();
+		auto lease = session->AcquireClient(captured, *request.params, "http://localhost");
 		REQUIRE(lease.Client());
 	}
 
 	auto captured = session->Capture();
-	auto request_params = captured.snapshot->CreateRequestParams();
-	REQUIRE_THROWS(session->AcquireClient(captured, *request_params, "http://localhost"));
+	auto request = captured.snapshot->CreateRequest();
+	REQUIRE_THROWS(session->AcquireClient(captured, *request.params, "http://localhost"));
 	REQUIRE(lifecycle.initialized == 1);
 	REQUIRE(lifecycle.client_initializations == 2);
 	REQUIRE(lifecycle.destroyed == 1);
 
 	captured = session->Capture();
-	request_params = captured.snapshot->CreateRequestParams();
+	request = captured.snapshot->CreateRequest();
 	{
-		auto lease = session->AcquireClient(captured, *request_params, "http://localhost");
+		auto lease = session->AcquireClient(captured, *request.params, "http://localhost");
 		REQUIRE(lease.Client());
 	}
 	REQUIRE(lifecycle.initialized == 2);
@@ -392,22 +403,25 @@ TEST_CASE("HTTP request snapshots copy HTTPFS parameters through one source", "[
 	params.state = make_shared_ptr<HTTPState>();
 
 	HTTPRequestSnapshot snapshot(params);
-	auto request_params = snapshot.CreateRequestParams();
-	REQUIRE(&request_params->http_util == &http_util);
-	REQUIRE(request_params->timeout == 17);
-	REQUIRE(request_params->timeout_usec == 23);
-	REQUIRE(request_params->retries == 5);
-	REQUIRE(request_params->http_proxy == "proxy.test");
-	REQUIRE(request_params->http_proxy_port == 8123);
-	REQUIRE(request_params->http_proxy_username == "user");
-	REQUIRE(request_params->http_proxy_password == "password");
-	REQUIRE(request_params->user_agent == "snapshot-agent");
-	REQUIRE(request_params->extra_headers == params.extra_headers);
-	REQUIRE(request_params->force_download);
-	REQUIRE(request_params->force_download_threshold == 42);
-	REQUIRE(request_params->hf_max_per_page == 99);
-	REQUIRE(request_params->state == params.state);
-	REQUIRE(request_params->pre_merged_headers);
+	auto request = snapshot.CreateRequest();
+	REQUIRE(&request.params->http_util == &http_util);
+	REQUIRE(request.params->timeout == 17);
+	REQUIRE(request.params->timeout_usec == 23);
+	REQUIRE(request.params->retries == 5);
+	REQUIRE(request.params->http_proxy == "proxy.test");
+	REQUIRE(request.params->http_proxy_port == 8123);
+	REQUIRE(request.params->http_proxy_username == "user");
+	REQUIRE(request.params->http_proxy_password == "password");
+	REQUIRE(request.params->user_agent.empty());
+	REQUIRE(request.params->extra_headers.empty());
+	REQUIRE(request.configured_headers.user_agent == "snapshot-agent");
+	REQUIRE(request.configured_headers.extra_headers == params.extra_headers);
+	REQUIRE(request.headers.GetHeaderValue("User-Agent") == "snapshot-agent");
+	REQUIRE(request.headers.GetHeaderValue("X-Snapshot") == "present");
+	REQUIRE(request.params->force_download);
+	REQUIRE(request.params->force_download_threshold == 42);
+	REQUIRE(request.params->hf_max_per_page == 99);
+	REQUIRE(request.params->state == params.state);
 }
 
 TEST_CASE("HTTP client leases preserve backend reuse policy", "[httpfs][request-session]") {
@@ -419,9 +433,9 @@ TEST_CASE("HTTP client leases preserve backend reuse policy", "[httpfs][request-
 		auto session = make_shared_ptr<HTTPRequestSession>(make_shared_ptr<HTTPRequestSnapshot>(params));
 
 		auto captured = session->Capture();
-		auto request_params = captured.snapshot->CreateRequestParams();
+		auto request = captured.snapshot->CreateRequest();
 		{
-			auto lease = session->AcquireClient(captured, *request_params, "http://localhost");
+			auto lease = session->AcquireClient(captured, *request.params, "http://localhost");
 			REQUIRE(lease.Client());
 		}
 		REQUIRE(lifecycle.initialized == 1);
@@ -437,9 +451,9 @@ TEST_CASE("HTTP client leases preserve backend reuse policy", "[httpfs][request-
 		auto session = make_shared_ptr<HTTPRequestSession>(make_shared_ptr<HTTPRequestSnapshot>(params));
 
 		auto captured = session->Capture();
-		auto request_params = captured.snapshot->CreateRequestParams();
+		auto request = captured.snapshot->CreateRequest();
 		{
-			auto lease = session->AcquireClient(captured, *request_params, "http://localhost");
+			auto lease = session->AcquireClient(captured, *request.params, "http://localhost");
 			REQUIRE_FALSE(lease.Client());
 		}
 		REQUIRE(lifecycle.initialized == 0);

--- a/test/unittest/http/http_request_session_test.cpp
+++ b/test/unittest/http/http_request_session_test.cpp
@@ -1,7 +1,6 @@
 #include "catch.hpp"
 
 #include "http/http_request_session.hpp"
-#include "http/httpfs_curl_client.hpp"
 #include "s3/s3fs.hpp"
 
 #include <functional>
@@ -460,17 +459,6 @@ TEST_CASE("HTTP client leases preserve backend reuse policy", "[httpfs][request-
 		REQUIRE(lifecycle.closed == 0);
 		REQUIRE(lifecycle.destroyed == 0);
 	}
-}
-
-TEST_CASE("CURL request headers preserve empty field values", "[httpfs][curl][headers]") {
-	CURLRequestHeaders headers;
-	headers.Add("X-Empty", "");
-	headers.Add("X-Whitespace", " \t ");
-	headers.Add("X-Value", "value");
-
-	REQUIRE(string(headers.headers->data) == "X-Empty;");
-	REQUIRE(string(headers.headers->next->data) == "X-Whitespace;");
-	REQUIRE(string(headers.headers->next->next->data) == "X-Value: value");
 }
 
 } // namespace duckdb

--- a/test/unittest/s3/mock_s3_server.cpp
+++ b/test/unittest/s3/mock_s3_server.cpp
@@ -21,6 +21,20 @@ namespace duckdb {
 
 namespace {
 
+static ssize_t WriteMockResponseHeaders(httplib::Stream &stream, httplib::Headers &headers) {
+	ssize_t total_size = 0;
+	for (const auto &header : headers) {
+		auto field = header.first + (header.second.empty() ? ":\r\n" : ": " + header.second + "\r\n");
+		auto field_size = stream.write(field.data(), field.size());
+		if (field_size < 0) {
+			return field_size;
+		}
+		total_size += field_size;
+	}
+	auto end_size = stream.write("\r\n", 2);
+	return end_size < 0 ? end_size : total_size + end_size;
+}
+
 static string ExtractCredentialKey(const string &authorization) {
 	auto credential_pos = authorization.find("Credential=");
 	if (credential_pos == string::npos) {
@@ -264,6 +278,9 @@ public:
 		if (config.range.behavior == MockS3RangeBehavior::SHORT_SUCCESS && config.range.behavior_requests > 0) {
 			server.set_keep_alive_max_count(1);
 		}
+		if (config.metadata.exact_empty_response_headers) {
+			server.set_header_writer(WriteMockResponseHeaders);
+		}
 		RegisterRoutes();
 		port = server.bind_to_any_port("127.0.0.1");
 		if (port <= 0) {
@@ -457,6 +474,9 @@ public:
 		response.set_header("ETag", config.metadata.etag);
 		if (config.metadata.version_on_head && !config.metadata.version_id.empty()) {
 			response.set_header("x-amz-version-id", config.metadata.version_id);
+		}
+		for (const auto &header : config.metadata.response_headers) {
+			response.set_header(header.first, header.second);
 		}
 	}
 
@@ -893,6 +913,14 @@ public:
 		server.set_pre_routing_handler([this, path](const httplib::Request &request, httplib::Response &response) {
 			if (request.method != "HEAD" || request.path != path) {
 				return httplib::Server::HandlerResponse::Unhandled;
+			}
+			if (config.metadata.redirect_head && !request.has_param("redirected")) {
+				response.set_redirect(path + "?redirected=true");
+				for (const auto &header : config.metadata.redirect_response_headers) {
+					response.set_header(header.first, header.second);
+				}
+				Record(request, response.status);
+				return httplib::Server::HandlerResponse::Handled;
 			}
 			if (ShouldRedirectRegion(request)) {
 				SendRegionRedirect(request, response);

--- a/test/unittest/s3/mock_s3_server.cpp
+++ b/test/unittest/s3/mock_s3_server.cpp
@@ -534,6 +534,9 @@ public:
 			SetETagHeader(response, response_config.etag, "\"httpfs-refresh-test-upload-etag\"");
 			annotated_lock_guard<annotated_mutex> lock(upload_lock);
 			uploaded_object = request.body;
+			if (!config.http_response.object_put_body.empty()) {
+				response.set_content(config.http_response.object_put_body, "application/octet-stream");
+			}
 		}
 		Record(request, response.status);
 	}
@@ -884,7 +887,12 @@ public:
 			SendS3Error400(request, response, config.failures.failure_is_request_timeout);
 			return;
 		}
-		response.status = 204;
+		if (config.http_response.object_delete_body.empty()) {
+			response.status = 204;
+		} else {
+			response.status = 200;
+			response.set_content(config.http_response.object_delete_body, "application/octet-stream");
+		}
 		Record(request, response.status);
 	}
 
@@ -1182,6 +1190,14 @@ public:
 		server.Delete(proxy_path, [this](const httplib::Request &request, httplib::Response &response) {
 			HandleObjectDelete(request, response);
 		});
+
+		if (!config.http_response.options_body.empty()) {
+			server.Options(path, [this](const httplib::Request &request, httplib::Response &response) {
+				response.status = 200;
+				response.set_content(config.http_response.options_body, "application/octet-stream");
+				Record(request, response.status);
+			});
+		}
 	}
 
 public:

--- a/test/unittest/s3/mock_s3_server.hpp
+++ b/test/unittest/s3/mock_s3_server.hpp
@@ -154,6 +154,12 @@ struct MockS3PutResponseConfig {
 	MockS3ETagBehavior etag = MockS3ETagBehavior::VALUE;
 };
 
+struct MockS3HTTPResponseConfig {
+	string object_put_body;
+	string object_delete_body;
+	string options_body;
+};
+
 struct MockS3UploadConfig {
 	//! PUT response behavior
 	MockS3PutResponseConfig object_put;
@@ -189,6 +195,7 @@ struct MockS3ServerConfig {
 	MockS3RangeConfig range;
 	MockS3FullGetConfig full_get;
 	MockS3UploadConfig upload;
+	MockS3HTTPResponseConfig http_response;
 };
 
 struct MockS3RequestObservation {

--- a/test/unittest/s3/mock_s3_server.hpp
+++ b/test/unittest/s3/mock_s3_server.hpp
@@ -70,6 +70,13 @@ struct MockS3MetadataConfig {
 	bool enforce_if_match = false;
 	//! Override the Content-Length reported by HEAD while keeping the GET body unchanged
 	optional_idx head_content_length;
+	//! Extra HEAD response headers, including repeated field lines
+	vector<std::pair<string, string>> response_headers;
+	//! Write empty response fields without optional whitespace after the colon
+	bool exact_empty_response_headers = false;
+	//! Emit one HTTP redirect before the successful HEAD response
+	bool redirect_head = false;
+	vector<std::pair<string, string>> redirect_response_headers;
 };
 
 struct MockS3CompletionFaultConfig {

--- a/test/unittest/s3/s3_refresh_test.cpp
+++ b/test/unittest/s3/s3_refresh_test.cpp
@@ -442,9 +442,8 @@ static void PublishTestS3Region(const shared_ptr<HTTPRequestSession> &session, c
 			return;
 		}
 		auto auth_params = snapshot.auth_params.WithRegion(region);
-		auto http_params = snapshot.CreateRequestParams();
 		auto replacement = make_shared_ptr<S3RequestSnapshot>(
-		    *http_params, auth_params, snapshot.refresh_path, snapshot.client_context,
+		    snapshot.Params(), auth_params, snapshot.refresh_path, snapshot.client_context,
 		    snapshot.credential_refresh_enabled, true, snapshot.credential_generation);
 		if (session->TryPublish(captured.snapshot, std::move(replacement)).published) {
 			return;

--- a/test/unittest/s3/s3_refresh_test.cpp
+++ b/test/unittest/s3/s3_refresh_test.cpp
@@ -438,11 +438,10 @@ static void PublishTestS3Region(const shared_ptr<HTTPRequestSession> &session, c
 	for (;;) {
 		auto captured = session->Capture();
 		auto &snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
-		if (snapshot.auth_params.region == region) {
+		if (snapshot.auth_params.GetCredentials().region == region) {
 			return;
 		}
-		auto auth_params = snapshot.auth_params;
-		auth_params.SetRegion(region);
+		auto auth_params = snapshot.auth_params.WithRegion(region);
 		auto http_params = snapshot.CreateRequestParams();
 		auto replacement = make_shared_ptr<S3RequestSnapshot>(
 		    *http_params, auth_params, snapshot.refresh_path, snapshot.client_context,
@@ -488,10 +487,10 @@ static void RunRefreshPublicationScenario(const string &client_implementation, b
 	S3TestHelper::RequireQueryOk(con, "COMMIT");
 
 	auto &snapshot = session->Capture().snapshot->Cast<S3RequestSnapshot>();
-	REQUIRE(snapshot.auth_params.access_key_id == S3TestHelper::FRESH_KEY_ID);
+	REQUIRE(snapshot.auth_params.GetCredentials().access_key_id == S3TestHelper::FRESH_KEY_ID);
 	REQUIRE(snapshot.credential_generation == 1);
 	if (publish_region) {
-		REQUIRE(snapshot.auth_params.region == "eu-west-1");
+		REQUIRE(snapshot.auth_params.GetCredentials().region == "eu-west-1");
 		REQUIRE(snapshot.region_redirected);
 	}
 
@@ -547,9 +546,8 @@ CREATE SECRET refresh_s3_endpoint_mode (
 	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
 	ClientContextFileOpener opener(*con.context);
 	FileOpenerInfo info = {S3TestHelper::S3_PATH};
-	auto auth_params = S3AuthParams::ReadFrom(opener, info);
-	S3Url::Resolve(S3TestHelper::S3_PATH, auth_params);
-	REQUIRE(auth_params.endpoint_mode == initial_mode);
+	auto auth_params = S3AuthResolver::Resolve(opener, info);
+	REQUIRE(auth_params.GetURLParams().endpoint_mode == initial_mode);
 	auto session = S3RequestExecutor::CreateSession(opener, S3TestHelper::S3_PATH, auth_params);
 	if (!published_region.empty()) {
 		string previous_region;
@@ -560,29 +558,32 @@ CREATE SECRET refresh_s3_endpoint_mode (
 	vector<S3EndpointMode> observed_modes;
 	vector<string> observed_endpoints;
 	vector<string> observed_regions;
-	auto response = S3RequestExecutor::RunSession(
-	    encryption_util, *session, S3TestHelper::S3_PATH, RequestType::GET_REQUEST, S3RequestTarget::OBJECT,
-	    [](const ParsedS3Url &) { return S3RequestQuery(); }, "", "", "",
-	    [&](S3RequestData &request_data) {
-		    observed_modes.push_back(request_data.auth_params.endpoint_mode);
-		    observed_endpoints.push_back(request_data.auth_params.GetEndpoint().GetHost());
-		    observed_regions.push_back(request_data.auth_params.region);
-		    if (observed_modes.size() == 1) {
-			    auto result = make_uniq<HTTPResponse>(HTTPStatusCode::Forbidden_403);
-			    result->body = "<Error><Code>AccessDenied</Code><Message>stale credentials</Message></Error>";
-			    return result;
-		    }
-		    return make_uniq<HTTPResponse>(HTTPStatusCode::OK_200);
-	    });
-	REQUIRE(response);
-	REQUIRE(response->status == HTTPStatusCode::OK_200);
+	S3RequestSpec spec {S3TestHelper::S3_PATH,
+	                    S3RequestOperation::GET_OBJECT,
+	                    [](const ParsedS3Url &) { return S3RequestQuery(); },
+	                    "",
+	                    "",
+	                    ""};
+	auto result = S3RequestExecutor::RunSession(encryption_util, *session, spec, [&](S3RequestData &request_data) {
+		observed_modes.push_back(request_data.auth_params.GetURLParams().endpoint_mode);
+		observed_endpoints.push_back(request_data.auth_params.GetURLParams().endpoint.GetHost());
+		observed_regions.push_back(request_data.auth_params.GetCredentials().region);
+		if (observed_modes.size() == 1) {
+			auto result = make_uniq<HTTPResponse>(HTTPStatusCode::Forbidden_403);
+			result->body = "<Error><Code>AccessDenied</Code><Message>stale credentials</Message></Error>";
+			return result;
+		}
+		return make_uniq<HTTPResponse>(HTTPStatusCode::OK_200);
+	});
+	REQUIRE(result.response);
+	REQUIRE(result.response->status == HTTPStatusCode::OK_200);
 	REQUIRE(observed_modes == vector<S3EndpointMode> {initial_mode, refreshed_mode});
 	REQUIRE(observed_endpoints == vector<string> {initial_resolved_endpoint, refreshed_resolved_endpoint});
 	auto expected_region = published_region.empty() ? string("us-east-1") : published_region;
 	REQUIRE(observed_regions == vector<string> {expected_region, expected_region});
 	auto &snapshot = session->Capture().snapshot->Cast<S3RequestSnapshot>();
-	REQUIRE(snapshot.auth_params.endpoint_mode == refreshed_mode);
-	REQUIRE(snapshot.auth_params.GetEndpoint().GetHost() == refreshed_resolved_endpoint);
+	REQUIRE(snapshot.auth_params.GetURLParams().endpoint_mode == refreshed_mode);
+	REQUIRE(snapshot.auth_params.GetURLParams().endpoint.GetHost() == refreshed_resolved_endpoint);
 	S3TestHelper::RequireQueryOk(con, "COMMIT");
 	S3TestHelper::AssertSingleRefresh(test_id);
 }

--- a/test/unittest/s3/s3_request_test.cpp
+++ b/test/unittest/s3/s3_request_test.cpp
@@ -29,11 +29,33 @@ namespace duckdb {
 
 namespace {
 
+static S3AuthConfig TestAuthConfig(S3ProviderType provider_type = S3ProviderType::S3, bool scheme_is_alias = false) {
+	S3AuthConfig config;
+	const char *prefix = provider_type == S3ProviderType::GCS  ? "gcs://"
+	                     : provider_type == S3ProviderType::R2 ? "r2://"
+	                                                           : "s3://";
+	config.route = {provider_type, scheme_is_alias ? "alias://" : prefix,
+	                scheme_is_alias ? S3UrlSchemeOrigin::ALIAS : S3UrlSchemeOrigin::BUILTIN};
+	if (provider_type == S3ProviderType::R2) {
+		config.endpoint = "account.r2.cloudflarestorage.com";
+		config.endpoint_mode = S3EndpointMode::EXPLICIT;
+	}
+	return config;
+}
+
+static S3AuthParams ResolveTestAuth(S3AuthConfig config, string path = "") {
+	if (path.empty()) {
+		path = config.route.prefix + "bucket/key";
+	}
+	return S3AuthResolver::Resolve(std::move(config), path);
+}
+
 static ParsedS3Url ParseTestS3Url(const string &url, const string &endpoint, const string &url_style) {
-	S3AuthParams auth_params;
-	auth_params.SetEndpoint(endpoint);
-	auth_params.url_style = url_style;
-	S3Provider::FinalizeAuthParams(auth_params);
+	auto config = TestAuthConfig();
+	config.endpoint = endpoint;
+	config.endpoint_mode = endpoint.empty() ? S3EndpointMode::AUTOMATIC : S3EndpointMode::EXPLICIT;
+	config.url_style = url_style;
+	auto auth_params = ResolveTestAuth(std::move(config), url);
 	return S3Url::Parse(url, auth_params);
 }
 
@@ -823,9 +845,7 @@ static S3AuthParams ReadSecretAuthParams(Connection &con, KeyValueSecret &secret
                                          const string &path = "s3://bucket/key") {
 	ClientContextFileOpener opener(*con.context);
 	S3KeyValueReader secret_reader {KeyValueSecretReader(secret, opener)};
-	auto result = S3AuthParams::ReadFrom(secret_reader, path);
-	S3Url::Resolve(path, result);
-	return result;
+	return S3AuthResolver::Resolve(secret_reader, path);
 }
 
 } // namespace
@@ -837,17 +857,17 @@ TEST_CASE("S3 provider policy resolves URL aliases and default scopes", "[httpfs
 	                          pair<string, S3ProviderType> {"gcs://bucket/key", S3ProviderType::GCS},
 	                          pair<string, S3ProviderType> {"GS://bucket/key", S3ProviderType::GCS},
 	                          pair<string, S3ProviderType> {"r2://bucket/key", S3ProviderType::R2}}) {
-		auto provider_match = S3Provider::MatchUrl(entry.first);
+		auto provider_match = S3UrlScheme::Match(entry.first);
 		REQUIRE(provider_match.type == entry.second);
 	}
-	REQUIRE_FALSE(S3Provider::TryMatchUrl("https://bucket/key"));
-	REQUIRE_FALSE(S3Provider::TryMatchUrl("aws://bucket/key"));
-	REQUIRE(S3Provider::DefaultSecretScope("s3") == vector<string> {"s3://", "s3n://", "s3a://"});
-	REQUIRE(S3Provider::DefaultSecretScope("gcs") == vector<string> {"gcs://", "gs://"});
-	REQUIRE(S3Provider::DefaultSecretScope("r2") == vector<string> {"r2://"});
-	REQUIRE(S3Provider::DefaultSecretScope("aws") == vector<string> {""});
+	REQUIRE_FALSE(S3UrlScheme::TryMatch("https://bucket/key"));
+	REQUIRE_FALSE(S3UrlScheme::TryMatch("aws://bucket/key"));
+	REQUIRE(S3SecretConfig::DefaultSecretScope("s3") == vector<string> {"s3://", "s3n://", "s3a://"});
+	REQUIRE(S3SecretConfig::DefaultSecretScope("gcs") == vector<string> {"gcs://", "gs://"});
+	REQUIRE(S3SecretConfig::DefaultSecretScope("r2") == vector<string> {"r2://"});
+	REQUIRE(S3SecretConfig::DefaultSecretScope("aws") == vector<string> {""});
 	try {
-		S3Provider::MatchUrl("https://bucket/key");
+		S3UrlScheme::Match("https://bucket/key");
 		FAIL("Unsupported URL should fail");
 	} catch (std::exception &ex) {
 		auto error = string(ex.what());
@@ -866,13 +886,12 @@ TEST_CASE("S3 provider selects multipart upload policy", "[httpfs][s3][provider]
 	                                            5115ULL * GIB};
 	auto require_policy = [](S3ProviderType provider_type, const string &endpoint,
 	                         const S3MultipartUploadPolicy &expected, bool scheme_is_alias = false) {
-		S3AuthParams auth_params;
-		auth_params.provider_type = provider_type;
-		auth_params.scheme_is_alias = scheme_is_alias;
-		auth_params.SetEndpoint(endpoint);
-		S3Provider::FinalizeAuthParams(auth_params);
+		auto config = TestAuthConfig(provider_type, scheme_is_alias);
+		config.endpoint = endpoint;
+		config.endpoint_mode = S3EndpointMode::EXPLICIT;
+		auto auth_params = ResolveTestAuth(std::move(config));
 		INFO(endpoint);
-		auto policy = S3Provider::GetMultipartUploadPolicy(auth_params);
+		auto policy = auth_params.GetProvider().GetMultipartUploadPolicy();
 		REQUIRE(policy.part_size_strategy == expected.part_size_strategy);
 		REQUIRE(policy.minimum_part_size == expected.minimum_part_size);
 		REQUIRE(policy.maximum_part_size == expected.maximum_part_size);
@@ -898,12 +917,12 @@ TEST_CASE("S3 provider selects multipart upload policy", "[httpfs][s3][provider]
 
 TEST_CASE("S3 provider selects bulk delete limits", "[httpfs][s3][provider][delete]") {
 	auto require_limit = [](S3ProviderType provider_type, const string &endpoint, idx_t expected) {
-		S3AuthParams auth_params;
-		auth_params.provider_type = provider_type;
-		auth_params.SetEndpoint(endpoint);
-		S3Provider::FinalizeAuthParams(auth_params);
+		auto config = TestAuthConfig(provider_type);
+		config.endpoint = endpoint;
+		config.endpoint_mode = S3EndpointMode::EXPLICIT;
+		auto auth_params = ResolveTestAuth(std::move(config));
 		INFO(endpoint);
-		REQUIRE(S3Provider::GetBulkDeleteMaxBatchSize(auth_params) == expected);
+		REQUIRE(auth_params.GetProvider().GetBulkDeleteMaxBatchSize() == expected);
 	};
 
 	require_limit(S3ProviderType::R2, "localhost:9000", 700);
@@ -922,78 +941,84 @@ TEST_CASE("S3 provider selects bulk delete limits", "[httpfs][s3][provider][dele
 
 TEST_CASE("S3 endpoint provenance controls AWS endpoint derivation", "[httpfs][s3][provider][endpoint]") {
 	SECTION("automatic endpoints retain the existing region defaults") {
-		S3AuthParams anonymous;
-		anonymous.SetEndpoint("  ");
-		S3Provider::FinalizeAuthParams(anonymous);
-		REQUIRE(anonymous.endpoint_mode == S3EndpointMode::AUTOMATIC);
-		REQUIRE(anonymous.region.empty());
-		REQUIRE(anonymous.GetEndpoint().GetHost() == "s3.amazonaws.com");
+		auto anonymous_config = TestAuthConfig();
+		anonymous_config.endpoint = "  ";
+		auto anonymous = ResolveTestAuth(std::move(anonymous_config));
+		REQUIRE(anonymous.GetURLParams().endpoint_mode == S3EndpointMode::AUTOMATIC);
+		REQUIRE(anonymous.GetCredentials().region.empty());
+		REQUIRE(anonymous.GetURLParams().endpoint.GetHost() == "s3.amazonaws.com");
 
-		S3AuthParams credentialed;
-		credentialed.SetEndpoint("s3.amazonaws.com");
-		credentialed.access_key_id = "key";
-		S3Provider::FinalizeAuthParams(credentialed);
-		REQUIRE(credentialed.endpoint_mode == S3EndpointMode::AUTOMATIC);
-		REQUIRE(credentialed.region == "us-east-1");
-		REQUIRE(credentialed.GetEndpoint().GetHost() == "s3.us-east-1.amazonaws.com");
+		auto credentialed_config = TestAuthConfig();
+		credentialed_config.endpoint = "s3.amazonaws.com";
+		credentialed_config.endpoint_mode = S3EndpointMode::EXPLICIT;
+		credentialed_config.credentials.access_key_id = "key";
+		auto credentialed = ResolveTestAuth(std::move(credentialed_config));
+		REQUIRE(credentialed.GetURLParams().endpoint_mode == S3EndpointMode::AUTOMATIC);
+		REQUIRE(credentialed.GetCredentials().region == "us-east-1");
+		REQUIRE(credentialed.GetURLParams().endpoint.GetHost() == "s3.us-east-1.amazonaws.com");
 	}
 
 	SECTION("explicit endpoints keep their host") {
 		for (const auto &endpoint : {"s3.dualstack.us-east-1.amazonaws.com", "s3-fips.us-east-1.amazonaws.com",
 		                             "s3.eu-west-1.amazonaws.com", "storage.example.com"}) {
-			S3AuthParams auth_params;
-			auth_params.SetEndpoint(endpoint);
-			S3Provider::FinalizeAuthParams(auth_params);
+			auto config = TestAuthConfig();
+			config.endpoint = endpoint;
+			config.endpoint_mode = S3EndpointMode::EXPLICIT;
+			auto auth_params = ResolveTestAuth(std::move(config));
 			INFO(endpoint);
-			REQUIRE(auth_params.endpoint_mode == S3EndpointMode::EXPLICIT);
-			REQUIRE(auth_params.GetEndpoint().GetHost() == endpoint);
-			REQUIRE(auth_params.region.empty());
-			auth_params.SetRegion("ap-southeast-2");
-			REQUIRE(auth_params.GetEndpoint().GetHost() == endpoint);
+			REQUIRE(auth_params.GetURLParams().endpoint_mode == S3EndpointMode::EXPLICIT);
+			REQUIRE(auth_params.GetURLParams().endpoint.GetHost() == endpoint);
+			REQUIRE(auth_params.GetCredentials().region.empty());
+			auth_params = auth_params.WithRegion("ap-southeast-2");
+			REQUIRE(auth_params.GetURLParams().endpoint.GetHost() == endpoint);
 		}
 	}
 
 	SECTION("AWS-shaped explicit endpoints retain the old credentialed region fallback") {
-		S3AuthParams dualstack;
-		dualstack.SetEndpoint("s3.dualstack.us-east-1.amazonaws.com");
-		dualstack.access_key_id = "key";
-		S3Provider::FinalizeAuthParams(dualstack);
-		REQUIRE(dualstack.region == "us-east-1");
-		REQUIRE(dualstack.GetEndpoint().GetHost() == "s3.dualstack.us-east-1.amazonaws.com");
+		auto dualstack_config = TestAuthConfig();
+		dualstack_config.endpoint = "s3.dualstack.us-east-1.amazonaws.com";
+		dualstack_config.endpoint_mode = S3EndpointMode::EXPLICIT;
+		dualstack_config.credentials.access_key_id = "key";
+		auto dualstack = ResolveTestAuth(std::move(dualstack_config));
+		REQUIRE(dualstack.GetCredentials().region == "us-east-1");
+		REQUIRE(dualstack.GetURLParams().endpoint.GetHost() == "s3.dualstack.us-east-1.amazonaws.com");
 
-		S3AuthParams fips;
-		fips.SetEndpoint("s3-fips.us-east-1.amazonaws.com");
-		fips.access_key_id = "key";
-		S3Provider::FinalizeAuthParams(fips);
-		REQUIRE(fips.region.empty());
-		REQUIRE(fips.GetEndpoint().GetHost() == "s3-fips.us-east-1.amazonaws.com");
+		auto fips_config = TestAuthConfig();
+		fips_config.endpoint = "s3-fips.us-east-1.amazonaws.com";
+		fips_config.endpoint_mode = S3EndpointMode::EXPLICIT;
+		fips_config.credentials.access_key_id = "key";
+		auto fips = ResolveTestAuth(std::move(fips_config));
+		REQUIRE(fips.GetCredentials().region.empty());
+		REQUIRE(fips.GetURLParams().endpoint.GetHost() == "s3-fips.us-east-1.amazonaws.com");
 	}
 
 	SECTION("endpoint mode participates in authentication identity") {
-		S3AuthParams automatic;
-		automatic.region = "us-east-1";
-		S3Provider::FinalizeAuthParams(automatic);
-		S3AuthParams explicit_endpoint;
-		explicit_endpoint.region = "us-east-1";
-		explicit_endpoint.SetEndpoint("s3.us-east-1.amazonaws.com");
-		S3Provider::FinalizeAuthParams(explicit_endpoint);
-		REQUIRE(automatic.GetEndpoint().GetHost() == explicit_endpoint.GetEndpoint().GetHost());
+		auto automatic_config = TestAuthConfig();
+		automatic_config.credentials.region = "us-east-1";
+		auto automatic = ResolveTestAuth(std::move(automatic_config));
+		auto explicit_config = TestAuthConfig();
+		explicit_config.credentials.region = "us-east-1";
+		explicit_config.endpoint = "s3.us-east-1.amazonaws.com";
+		explicit_config.endpoint_mode = S3EndpointMode::EXPLICIT;
+		auto explicit_endpoint = ResolveTestAuth(std::move(explicit_config));
+		REQUIRE(automatic.GetURLParams().endpoint.GetHost() == explicit_endpoint.GetURLParams().endpoint.GetHost());
 		REQUIRE_FALSE(automatic == explicit_endpoint);
 	}
 }
 
 TEST_CASE("S3 endpoints are normalized once for routing and signing", "[httpfs][s3][provider][endpoint]") {
 	SECTION("full URI schemes override the legacy SSL flag") {
-		S3AuthParams auth_params;
-		auth_params.use_ssl = false;
-		auth_params.url_style = "path";
-		auth_params.SetEndpoint("HTTPS://Storage.EXAMPLE.com:443/gateway/%2f//base///");
-		S3Provider::FinalizeAuthParams(auth_params);
+		auto config = TestAuthConfig();
+		config.use_ssl = false;
+		config.url_style = "path";
+		config.endpoint = "HTTPS://Storage.EXAMPLE.com:443/gateway/%2f//base///";
+		config.endpoint_mode = S3EndpointMode::EXPLICIT;
+		auto auth_params = ResolveTestAuth(std::move(config));
 
-		REQUIRE(auth_params.GetEndpoint().UsesSSL());
-		REQUIRE(auth_params.GetEndpoint().GetHost() == "storage.example.com");
-		REQUIRE(auth_params.GetEndpoint().GetAuthority() == "storage.example.com");
-		REQUIRE(auth_params.GetEndpoint().GetBasePath() == "/gateway/%2f//base");
+		REQUIRE(auth_params.GetURLParams().endpoint.UsesSSL());
+		REQUIRE(auth_params.GetURLParams().endpoint.GetHost() == "storage.example.com");
+		REQUIRE(auth_params.GetURLParams().endpoint.GetAuthority() == "storage.example.com");
+		REQUIRE(auth_params.GetURLParams().endpoint.GetBasePath() == "/gateway/%2f//base");
 
 		auto parsed_url = S3Url::Parse("s3://bucket/key with space", auth_params);
 		REQUIRE(parsed_url.GetEncodedBucketPath() == "/gateway/%2f//base/bucket/");
@@ -1002,42 +1027,46 @@ TEST_CASE("S3 endpoints are normalized once for routing and signing", "[httpfs][
 	}
 
 	SECTION("schemeless endpoints retain the SSL fallback and non-default ports") {
-		S3AuthParams auth_params;
-		auth_params.use_ssl = false;
-		auth_params.url_style = "path";
-		auth_params.SetEndpoint("Storage.EXAMPLE.com:8443/base/");
-		S3Provider::FinalizeAuthParams(auth_params);
+		auto config = TestAuthConfig();
+		config.use_ssl = false;
+		config.url_style = "path";
+		config.endpoint = "Storage.EXAMPLE.com:8443/base/";
+		config.endpoint_mode = S3EndpointMode::EXPLICIT;
+		auto auth_params = ResolveTestAuth(std::move(config));
 		auto parsed_url = S3Url::Parse("s3://bucket/key", auth_params);
 		REQUIRE(parsed_url.GetHost() == "storage.example.com:8443");
 		REQUIRE(parsed_url.GetHTTPUrl() == "http://storage.example.com:8443/base/bucket/key");
 	}
 
 	SECTION("legacy base paths remain opaque when they contain URI-like text") {
-		S3AuthParams auth_params;
-		auth_params.use_ssl = false;
-		auth_params.url_style = "path";
-		auth_params.SetEndpoint("storage.example.com/gateway/http://mirror");
-		S3Provider::FinalizeAuthParams(auth_params);
+		auto config = TestAuthConfig();
+		config.use_ssl = false;
+		config.url_style = "path";
+		config.endpoint = "storage.example.com/gateway/http://mirror";
+		config.endpoint_mode = S3EndpointMode::EXPLICIT;
+		auto auth_params = ResolveTestAuth(std::move(config));
 		auto parsed_url = S3Url::Parse("s3://bucket/key", auth_params);
-		REQUIRE(auth_params.GetEndpoint().GetBasePath() == "/gateway/http://mirror");
+		REQUIRE(auth_params.GetURLParams().endpoint.GetBasePath() == "/gateway/http://mirror");
 		REQUIRE(parsed_url.GetHTTPUrl() == "http://storage.example.com/gateway/http%3A//mirror/bucket/key");
 	}
 
 	SECTION("valid port boundaries are preserved") {
 		for (const auto &endpoint : {"storage.example.com:1", "storage.example.com:65535"}) {
-			S3AuthParams auth_params;
-			auth_params.SetEndpoint(endpoint);
-			S3Provider::FinalizeAuthParams(auth_params);
-			REQUIRE(auth_params.GetEndpoint().GetAuthority() == endpoint);
+			auto config = TestAuthConfig();
+			config.endpoint = endpoint;
+			config.endpoint_mode = S3EndpointMode::EXPLICIT;
+			auto auth_params = ResolveTestAuth(std::move(config));
+			REQUIRE(auth_params.GetURLParams().endpoint.GetAuthority() == endpoint);
 		}
 	}
 
 	SECTION("virtual-hosted endpoints keep their base path separate from the bucket") {
-		S3AuthParams auth_params;
-		auth_params.use_ssl = true;
-		auth_params.url_style = "virtual";
-		auth_params.SetEndpoint("http://storage.example.com:80/gateway/base/");
-		S3Provider::FinalizeAuthParams(auth_params);
+		auto config = TestAuthConfig();
+		config.use_ssl = true;
+		config.url_style = "virtual";
+		config.endpoint = "http://storage.example.com:80/gateway/base/";
+		config.endpoint_mode = S3EndpointMode::EXPLICIT;
+		auto auth_params = ResolveTestAuth(std::move(config));
 		auto parsed_url = S3Url::Parse("s3://bucket/key", auth_params);
 		REQUIRE(parsed_url.GetHost() == "bucket.storage.example.com");
 		REQUIRE(parsed_url.GetEncodedPath() == "/gateway/base/key");
@@ -1046,58 +1075,63 @@ TEST_CASE("S3 endpoints are normalized once for routing and signing", "[httpfs][
 	}
 
 	SECTION("full default AWS endpoints retain automatic region derivation") {
-		S3AuthParams auth_params;
-		auth_params.use_ssl = false;
-		auth_params.access_key_id = "key";
-		auth_params.SetEndpoint("HTTPS://S3.AMAZONAWS.COM:443/");
-		S3Provider::FinalizeAuthParams(auth_params);
-		REQUIRE(auth_params.endpoint_mode == S3EndpointMode::AUTOMATIC);
-		REQUIRE(auth_params.region == "us-east-1");
-		REQUIRE(auth_params.GetEndpoint().GetHost() == "s3.us-east-1.amazonaws.com");
-		REQUIRE(auth_params.GetEndpoint().GetProtocol() == "https://");
-		REQUIRE(auth_params.GetEndpoint().GetAuthority() == "s3.us-east-1.amazonaws.com");
+		auto config = TestAuthConfig();
+		config.use_ssl = false;
+		config.credentials.access_key_id = "key";
+		config.endpoint = "HTTPS://S3.AMAZONAWS.COM:443/";
+		config.endpoint_mode = S3EndpointMode::EXPLICIT;
+		auto auth_params = ResolveTestAuth(std::move(config));
+		REQUIRE(auth_params.GetURLParams().endpoint_mode == S3EndpointMode::AUTOMATIC);
+		REQUIRE(auth_params.GetCredentials().region == "us-east-1");
+		REQUIRE(auth_params.GetURLParams().endpoint.GetHost() == "s3.us-east-1.amazonaws.com");
+		REQUIRE(auth_params.GetURLParams().endpoint.GetProtocol() == "https://");
+		REQUIRE(auth_params.GetURLParams().endpoint.GetAuthority() == "s3.us-east-1.amazonaws.com");
 	}
 
 	SECTION("canonical endpoint forms share authentication identity") {
-		S3AuthParams legacy;
-		legacy.url_style = "path";
-		legacy.SetEndpoint("STORAGE.EXAMPLE.COM:443/base/");
-		S3Provider::FinalizeAuthParams(legacy);
+		auto legacy_config = TestAuthConfig();
+		legacy_config.url_style = "path";
+		legacy_config.endpoint = "STORAGE.EXAMPLE.COM:443/base/";
+		legacy_config.endpoint_mode = S3EndpointMode::EXPLICIT;
+		auto legacy = ResolveTestAuth(std::move(legacy_config));
 
-		S3AuthParams uri;
-		uri.use_ssl = false;
-		uri.url_style = "path";
-		uri.SetEndpoint("https://storage.example.com/base");
-		S3Provider::FinalizeAuthParams(uri);
-		legacy.use_ssl = false;
+		auto uri_config = TestAuthConfig();
+		uri_config.use_ssl = false;
+		uri_config.url_style = "path";
+		uri_config.endpoint = "https://storage.example.com/base";
+		uri_config.endpoint_mode = S3EndpointMode::EXPLICIT;
+		auto uri = ResolveTestAuth(std::move(uri_config));
 		REQUIRE(legacy == uri);
 	}
 
 	SECTION("a URL override replaces an invalid lower-precedence endpoint") {
-		S3AuthParams auth_params;
-		auth_params.SetEndpoint("ftp://invalid.example.com");
-		S3Provider::InitializeAuthParams(auth_params);
-		auto parsed_url =
-		    S3Url::Resolve("s3://bucket/key?s3_endpoint=http%3A%2F%2Fstorage.example.com%3A80%2Fbase&s3_use_ssl=true&"
-		                   "s3_url_style=path",
-		                   auth_params);
+		auto config = TestAuthConfig();
+		config.endpoint = "ftp://invalid.example.com";
+		config.endpoint_mode = S3EndpointMode::EXPLICIT;
+		auto url = string("s3://bucket/key?s3_endpoint=http%3A%2F%2Fstorage.example.com%3A80%2Fbase&") +
+		           "s3_use_ssl=true&s3_url_style=path";
+		auto auth_params = ResolveTestAuth(std::move(config), url);
+		auto parsed_url = S3Url::Parse(url, auth_params);
 		REQUIRE(parsed_url.GetHost() == "storage.example.com");
 		REQUIRE(parsed_url.GetEncodedPath() == "/base/bucket/key");
 		REQUIRE(parsed_url.GetHTTPUrl() == "http://storage.example.com/base/bucket/key");
 	}
 
 	SECTION("bracketed IPv6 is supported only with path-style addressing") {
-		S3AuthParams path_style;
-		path_style.url_style = "path";
-		path_style.SetEndpoint("http://[2001:DB8::1]:80/base");
-		S3Provider::FinalizeAuthParams(path_style);
+		auto path_config = TestAuthConfig();
+		path_config.url_style = "path";
+		path_config.endpoint = "http://[2001:DB8::1]:80/base";
+		path_config.endpoint_mode = S3EndpointMode::EXPLICIT;
+		auto path_style = ResolveTestAuth(std::move(path_config));
 		auto parsed_url = S3Url::Parse("s3://bucket/key", path_style);
 		REQUIRE(parsed_url.GetHost() == "[2001:db8::1]");
 		REQUIRE(parsed_url.GetHTTPUrl() == "http://[2001:db8::1]/base/bucket/key");
 
-		S3AuthParams vhost_style;
-		vhost_style.SetEndpoint("http://[::1]");
-		REQUIRE_THROWS(S3Url::Resolve("s3://bucket/key", vhost_style));
+		auto vhost_config = TestAuthConfig();
+		vhost_config.endpoint = "http://[::1]";
+		vhost_config.endpoint_mode = S3EndpointMode::EXPLICIT;
+		auto vhost_style = ResolveTestAuth(std::move(vhost_config));
+		REQUIRE_THROWS(S3Url::Parse("s3://bucket/key", vhost_style));
 	}
 }
 
@@ -1108,10 +1142,11 @@ TEST_CASE("Invalid S3 endpoints fail before request construction", "[httpfs][s3]
 	      "storage.example.com:65536", "storage.example.com:", "storage.example.com:port", "storage.example.com\\base",
 	      "storage.example.com/base/%", "storage.example.com/base/./key", "storage.example.com/base/../key",
 	      "2001:db8::1", "http://[fe80::1%25lo0]", "http://[2001:db8::1"}) {
-		S3AuthParams auth_params;
-		auth_params.SetEndpoint(endpoint);
+		auto config = TestAuthConfig();
+		config.endpoint = endpoint;
+		config.endpoint_mode = S3EndpointMode::EXPLICIT;
 		INFO(endpoint);
-		REQUIRE_THROWS(S3Provider::FinalizeAuthParams(auth_params));
+		REQUIRE_THROWS(ResolveTestAuth(std::move(config)));
 	}
 }
 
@@ -1124,16 +1159,16 @@ TEST_CASE("S3 provider endpoint precedence is preserved", "[httpfs][s3][provider
 	SECTION("GCS ignores the endpoint setting") {
 		KeyValueSecret secret({"gcs://"}, Identifier("gcs"), Identifier("config"), Identifier("gcs_default"));
 		auto auth_params = ReadSecretAuthParams(con, secret, "gcs://bucket/key");
-		REQUIRE(auth_params.GetEndpoint().GetHost() == "storage.googleapis.com");
-		REQUIRE(auth_params.endpoint_mode == S3EndpointMode::AUTOMATIC);
+		REQUIRE(auth_params.GetURLParams().endpoint.GetHost() == "storage.googleapis.com");
+		REQUIRE(auth_params.GetURLParams().endpoint_mode == S3EndpointMode::AUTOMATIC);
 	}
 
 	SECTION("GCS accepts a secret endpoint") {
 		KeyValueSecret secret({"gcs://"}, Identifier("gcs"), Identifier("config"), Identifier("gcs_explicit"));
 		secret.secret_map["endpoint"] = "gcs.example.com";
 		auto auth_params = ReadSecretAuthParams(con, secret, "gcs://bucket/key");
-		REQUIRE(auth_params.GetEndpoint().GetHost() == "gcs.example.com");
-		REQUIRE(auth_params.endpoint_mode == S3EndpointMode::EXPLICIT);
+		REQUIRE(auth_params.GetURLParams().endpoint.GetHost() == "gcs.example.com");
+		REQUIRE(auth_params.GetURLParams().endpoint_mode == S3EndpointMode::EXPLICIT);
 	}
 }
 
@@ -1146,49 +1181,44 @@ TEST_CASE("GCS billing projects follow provider configuration precedence",
 
 	KeyValueSecret secret({"gcs://"}, Identifier("gcs"), Identifier("config"), Identifier("gcs_billing"));
 	auto auth_params = ReadSecretAuthParams(con, secret, "gcs://bucket/key");
-	REQUIRE(auth_params.user_project == "setting-project");
+	REQUIRE(auth_params.GetRequestOptions().user_project == "setting-project");
 
 	secret.secret_map["user_project"] = "secret-project";
 	auth_params = ReadSecretAuthParams(con, secret, "gcs://bucket/key");
-	REQUIRE(auth_params.user_project == "secret-project");
+	REQUIRE(auth_params.GetRequestOptions().user_project == "secret-project");
 
-	S3Url::Resolve("gcs://bucket/key?gcs_user_project=url%2Dproject", auth_params);
-	REQUIRE(auth_params.user_project == "url-project");
+	auth_params = ReadSecretAuthParams(con, secret, "gcs://bucket/key?gcs_user_project=url%2Dproject");
+	REQUIRE(auth_params.GetRequestOptions().user_project == "url-project");
 
-	auth_params = ReadSecretAuthParams(con, secret, "gcs://bucket/key");
-	S3Url::Resolve("gcs://bucket/key?gcs_user_project=", auth_params);
-	REQUIRE(auth_params.user_project.empty());
+	auth_params = ReadSecretAuthParams(con, secret, "gcs://bucket/key?gcs_user_project=");
+	REQUIRE(auth_params.GetRequestOptions().user_project.empty());
 
-	auto distinct_project = auth_params;
-	distinct_project.user_project = "different-project";
+	auto distinct_project = ReadSecretAuthParams(con, secret, "gcs://bucket/key?gcs_user_project=different-project");
 	REQUIRE_FALSE(auth_params == distinct_project);
 
 	SECTION("the setting does not enter S3 or R2 authentication state") {
 		KeyValueSecret s3_secret({"s3://"}, Identifier("s3"), Identifier("config"), Identifier("s3_billing"));
-		REQUIRE(ReadSecretAuthParams(con, s3_secret).user_project.empty());
+		REQUIRE(ReadSecretAuthParams(con, s3_secret).GetRequestOptions().user_project.empty());
 
 		KeyValueSecret r2_secret({"r2://"}, Identifier("r2"), Identifier("config"), Identifier("r2_billing"));
 		r2_secret.secret_map["endpoint"] = "account.r2.cloudflarestorage.com";
-		REQUIRE(ReadSecretAuthParams(con, r2_secret, "r2://bucket/key").user_project.empty());
+		REQUIRE(ReadSecretAuthParams(con, r2_secret, "r2://bucket/key").GetRequestOptions().user_project.empty());
 	}
 
 	SECTION("the URL parameter is GCS-only") {
-		S3AuthParams s3_auth;
-		S3Provider::InitializeAuthParams(s3_auth);
-		REQUIRE_THROWS(S3Url::Resolve("s3://bucket/key?gcs_user_project=project", s3_auth));
+		REQUIRE_THROWS(ResolveTestAuth(TestAuthConfig(), "s3://bucket/key?gcs_user_project=project"));
 
-		S3AuthParams r2_auth;
-		r2_auth.provider_type = S3ProviderType::R2;
-		r2_auth.SetEndpoint("account.r2.cloudflarestorage.com");
-		S3Provider::InitializeAuthParams(r2_auth);
-		REQUIRE_THROWS(S3Url::Resolve("r2://bucket/key?gcs_user_project=project", r2_auth));
+		auto r2_config = TestAuthConfig(S3ProviderType::R2);
+		r2_config.endpoint = "account.r2.cloudflarestorage.com";
+		r2_config.endpoint_mode = S3EndpointMode::EXPLICIT;
+		REQUIRE_THROWS(ResolveTestAuth(std::move(r2_config), "r2://bucket/key?gcs_user_project=project"));
 	}
 
 	SECTION("legacy requester-pays requires a project after URL overrides") {
-		auto require_missing_project_error = [](const string &url, S3AuthParams &params) {
+		auto require_missing_project_error = [](const string &url, S3AuthConfig config) {
 			string error;
 			try {
-				S3Url::Resolve(url, params);
+				ResolveTestAuth(std::move(config), url);
 			} catch (std::exception &ex) {
 				error = ex.what();
 			}
@@ -1198,59 +1228,52 @@ TEST_CASE("GCS billing projects follow provider configuration precedence",
 			REQUIRE(StringUtil::Contains(error, "pass gcs_user_project in the URL"));
 		};
 
-		S3AuthParams requester_pays;
-		requester_pays.provider_type = S3ProviderType::GCS;
-		requester_pays.requester_pays = true;
-		S3Provider::InitializeAuthParams(requester_pays);
+		auto requester_pays = TestAuthConfig(S3ProviderType::GCS);
+		requester_pays.request_options.requester_pays = true;
 		require_missing_project_error("gcs://bucket/key", requester_pays);
 
-		requester_pays.user_project = "secret-project";
+		requester_pays.request_options.user_project = "secret-project";
 		require_missing_project_error("gcs://bucket/key?gcs_user_project=", requester_pays);
 
-		requester_pays.user_project = "secret-project";
-		S3Url::Resolve("gcs://bucket/key", requester_pays);
-		REQUIRE(requester_pays.user_project == "secret-project");
+		auto resolved = ResolveTestAuth(std::move(requester_pays), "gcs://bucket/key");
+		REQUIRE(resolved.GetRequestOptions().user_project == "secret-project");
 	}
 }
 
 TEST_CASE("S3 URL styles share one validation policy", "[httpfs][s3][provider][url-style]") {
 	for (const auto &url_style : {"", "vhost", "virtual"}) {
 		INFO(url_style);
-		REQUIRE(S3Provider::ParseURLStyle(url_style) == S3URLStyle::VIRTUAL_HOSTED);
+		REQUIRE(S3AuthURLParams::ParseStyle(url_style) == S3URLStyle::VIRTUAL_HOSTED);
 	}
-	REQUIRE(S3Provider::ParseURLStyle("path") == S3URLStyle::PATH);
+	REQUIRE(S3AuthURLParams::ParseStyle("path") == S3URLStyle::PATH);
 	for (const auto &url_style : {"default", "VHOST", "handwritten"}) {
 		INFO(url_style);
-		REQUIRE_THROWS(S3Provider::ParseURLStyle(url_style));
+		REQUIRE_THROWS(S3AuthURLParams::ParseStyle(url_style));
 	}
 
-	SECTION("defensive URL parsing rejects invalid runtime state") {
-		S3AuthParams auth_params;
-		auth_params.url_style = "handwritten";
-		REQUIRE_THROWS(S3Provider::FinalizeAuthParams(auth_params));
-		REQUIRE_THROWS(S3Url::Parse("s3://bucket/key", auth_params));
-		REQUIRE_THROWS(S3Url::Resolve("s3://bucket/key?s3_url_style=path", auth_params));
+	SECTION("invalid configuration is rejected before a runtime value is created") {
+		auto config = TestAuthConfig();
+		config.url_style = "handwritten";
+		REQUIRE_THROWS(ResolveTestAuth(std::move(config)));
 	}
 
 	SECTION("URL query values remain case-sensitive") {
-		S3AuthParams auth_params;
-		S3Provider::InitializeAuthParams(auth_params);
-		REQUIRE_THROWS(S3Url::Resolve("s3://bucket/key?s3_url_style=VHOST", auth_params));
+		REQUIRE_THROWS(ResolveTestAuth(TestAuthConfig(), "s3://bucket/key?s3_url_style=VHOST"));
 	}
 
 	SECTION("compatibility mode keeps query-looking key text literal") {
-		S3AuthParams auth_params;
-		auth_params.s3_url_compatibility_mode = true;
-		S3Provider::InitializeAuthParams(auth_params);
-		auto parsed = S3Url::Resolve("s3://bucket/key?s3_url_style=handwritten", auth_params);
+		auto config = TestAuthConfig();
+		config.compatibility_mode = true;
+		auto auth_params = ResolveTestAuth(std::move(config));
+		auto parsed = S3Url::Parse("s3://bucket/key?s3_url_style=handwritten", auth_params);
 		REQUIRE(parsed.GetQueryString().empty());
 		REQUIRE(parsed.GetKey() == "key?s3_url_style=handwritten");
 	}
 
 	SECTION("dotted buckets use path style over TLS") {
-		S3AuthParams auth_params;
-		auth_params.url_style = "virtual";
-		S3Provider::FinalizeAuthParams(auth_params);
+		auto config = TestAuthConfig();
+		config.url_style = "virtual";
+		auto auth_params = ResolveTestAuth(std::move(config));
 		auto parsed = S3Url::Parse("s3://bucket.with.dots/key", auth_params);
 		REQUIRE(parsed.GetHost() == "s3.amazonaws.com");
 		REQUIRE(parsed.GetEncodedPath() == "/bucket.with.dots/key");
@@ -1338,89 +1361,87 @@ CREATE SECRET invalid_gcs_requester_pays (
 
 TEST_CASE("S3 URL query settings are resolved independently of the HTTP client", "[httpfs][s3][url]") {
 	SECTION("query credentials initialize the AWS region and endpoint") {
-		S3AuthParams auth_params;
-		auth_params.SetEndpoint("s3.amazonaws.com");
-		auto parsed_url = S3Url::Resolve(
-		    "s3://bucket/key?s3_access_key_id=hello+world&s3_secret_access_key=secret%2Bvalue", auth_params);
-		REQUIRE(auth_params.access_key_id == "hello world");
-		REQUIRE(auth_params.secret_access_key == "secret+value");
-		REQUIRE(auth_params.region == "us-east-1");
-		REQUIRE(auth_params.GetEndpoint().GetHost() == "s3.us-east-1.amazonaws.com");
+		auto config = TestAuthConfig();
+		config.endpoint = "s3.amazonaws.com";
+		auto auth_params = ResolveTestAuth(
+		    std::move(config), "s3://bucket/key?s3_access_key_id=hello+world&s3_secret_access_key=secret%2Bvalue");
+		auto parsed_url = S3Url::Parse("s3://bucket/key", auth_params);
+		REQUIRE(auth_params.GetCredentials().access_key_id == "hello world");
+		REQUIRE(auth_params.GetCredentials().secret_access_key == "secret+value");
+		REQUIRE(auth_params.GetCredentials().region == "us-east-1");
+		REQUIRE(auth_params.GetURLParams().endpoint.GetHost() == "s3.us-east-1.amazonaws.com");
 		REQUIRE(parsed_url.GetHost() == "bucket.s3.us-east-1.amazonaws.com");
 	}
 
 	SECTION("routing overrides are reflected in the parsed URL") {
-		S3AuthParams auth_params;
-		auth_params.region = "us-west-2";
-		auth_params.SetEndpoint("s3.us-west-2.amazonaws.com");
-		auto parsed_url = S3Url::Resolve("s3://bucket/key?s3_region=eu-west-1&s3_endpoint=s3.amazonaws.com&"
-		                                 "s3_use_ssl=false&s3_url_style=path",
-		                                 auth_params);
-		REQUIRE(auth_params.region == "eu-west-1");
-		REQUIRE(auth_params.GetEndpoint().GetHost() == "s3.eu-west-1.amazonaws.com");
-		REQUIRE(auth_params.endpoint_mode == S3EndpointMode::AUTOMATIC);
+		auto config = TestAuthConfig();
+		config.credentials.region = "us-west-2";
+		config.endpoint = "s3.us-west-2.amazonaws.com";
+		auto auth_params =
+		    ResolveTestAuth(std::move(config), "s3://bucket/key?s3_region=eu-west-1&s3_endpoint=s3.amazonaws.com&"
+		                                       "s3_use_ssl=false&s3_url_style=path");
+		auto parsed_url = S3Url::Parse("s3://bucket/key", auth_params);
+		REQUIRE(auth_params.GetCredentials().region == "eu-west-1");
+		REQUIRE(auth_params.GetURLParams().endpoint.GetHost() == "s3.eu-west-1.amazonaws.com");
+		REQUIRE(auth_params.GetURLParams().endpoint_mode == S3EndpointMode::AUTOMATIC);
 		REQUIRE(parsed_url.GetHost() == "s3.eu-west-1.amazonaws.com");
 		REQUIRE(parsed_url.GetEncodedPath() == "/bucket/key");
 		REQUIRE(parsed_url.GetHTTPUrl() == "http://s3.eu-west-1.amazonaws.com/bucket/key");
 	}
 
 	SECTION("an endpoint override can switch from automatic to explicit") {
-		S3AuthParams auth_params;
-		auth_params.region = "us-east-1";
-		S3Provider::InitializeAuthParams(auth_params);
-		REQUIRE(auth_params.endpoint_mode == S3EndpointMode::AUTOMATIC);
-		auto parsed_url =
-		    S3Url::Resolve("s3://bucket/key?s3_endpoint=s3.dualstack.us-east-1.amazonaws.com", auth_params);
-		REQUIRE(auth_params.endpoint_mode == S3EndpointMode::EXPLICIT);
-		REQUIRE(auth_params.GetEndpoint().GetHost() == "s3.dualstack.us-east-1.amazonaws.com");
+		auto config = TestAuthConfig();
+		config.credentials.region = "us-east-1";
+		auto auth_params =
+		    ResolveTestAuth(std::move(config), "s3://bucket/key?s3_endpoint=s3.dualstack.us-east-1.amazonaws.com");
+		auto parsed_url = S3Url::Parse("s3://bucket/key", auth_params);
+		REQUIRE(auth_params.GetURLParams().endpoint_mode == S3EndpointMode::EXPLICIT);
+		REQUIRE(auth_params.GetURLParams().endpoint.GetHost() == "s3.dualstack.us-east-1.amazonaws.com");
 		REQUIRE(parsed_url.GetHost() == "bucket.s3.dualstack.us-east-1.amazonaws.com");
 	}
 
 	SECTION("empty GCS routing overrides restore provider defaults") {
-		S3AuthParams auth_params;
-		auth_params.provider_type = S3ProviderType::GCS;
-		auth_params.SetEndpoint("storage.googleapis.com");
-		auth_params.url_style = "path";
-		auto parsed_url = S3Url::Resolve("gcs://bucket/key?s3_endpoint=&s3_url_style=", auth_params);
-		REQUIRE(auth_params.GetEndpoint().GetHost() == "storage.googleapis.com");
-		REQUIRE(auth_params.url_style == "path");
+		auto config = TestAuthConfig(S3ProviderType::GCS);
+		config.endpoint = "storage.googleapis.com";
+		config.url_style = "path";
+		auto auth_params = ResolveTestAuth(std::move(config), "gcs://bucket/key?s3_endpoint=&s3_url_style=");
+		auto parsed_url = S3Url::Parse("gcs://bucket/key", auth_params);
+		REQUIRE(auth_params.GetURLParams().endpoint.GetHost() == "storage.googleapis.com");
+		REQUIRE(auth_params.GetURLParams().style == S3URLStyle::PATH);
 		REQUIRE(parsed_url.GetHost() == "storage.googleapis.com");
 		REQUIRE(parsed_url.GetEncodedPath() == "/bucket/key");
 	}
 
 	SECTION("empty R2 endpoints fail instead of routing to AWS") {
-		S3AuthParams auth_params;
-		auth_params.provider_type = S3ProviderType::R2;
-		auth_params.SetEndpoint("account.r2.cloudflarestorage.com");
-		auth_params.url_style = "path";
-		REQUIRE_THROWS(S3Url::Resolve("r2://bucket/key?s3_endpoint=", auth_params));
+		auto config = TestAuthConfig(S3ProviderType::R2);
+		config.endpoint = "account.r2.cloudflarestorage.com";
+		config.url_style = "path";
+		REQUIRE_THROWS(ResolveTestAuth(std::move(config), "r2://bucket/key?s3_endpoint="));
 	}
 
 	SECTION("empty values are accepted") {
-		S3AuthParams auth_params;
-		auth_params.SetEndpoint("s3.amazonaws.com");
-		S3Url::Resolve("s3://bucket/key?s3_access_key_id&s3_secret_access_key=", auth_params);
-		REQUIRE(auth_params.access_key_id.empty());
-		REQUIRE(auth_params.secret_access_key.empty());
+		auto config = TestAuthConfig();
+		config.endpoint = "s3.amazonaws.com";
+		auto auth_params = ResolveTestAuth(std::move(config), "s3://bucket/key?s3_access_key_id&s3_secret_access_key=");
+		REQUIRE(auth_params.GetCredentials().access_key_id.empty());
+		REQUIRE(auth_params.GetCredentials().secret_access_key.empty());
 	}
 
 	SECTION("duplicate decoded keys are rejected") {
-		S3AuthParams auth_params;
-		auth_params.SetEndpoint("s3.amazonaws.com");
-		REQUIRE_THROWS(S3Url::Resolve("s3://bucket/key?s3_region=one&s3%5Fregion=two", auth_params));
+		REQUIRE_THROWS(ResolveTestAuth(TestAuthConfig(), "s3://bucket/key?s3_region=one&s3%5Fregion=two"));
 	}
 
 	SECTION("query keys remain case-sensitive") {
-		S3AuthParams auth_params;
-		auth_params.SetEndpoint("s3.amazonaws.com");
-		REQUIRE_THROWS(S3Url::Resolve("s3://bucket/key?S3_region=one", auth_params));
+		REQUIRE_THROWS(ResolveTestAuth(TestAuthConfig(), "s3://bucket/key?S3_region=one"));
 	}
 
 	SECTION("display URLs redact parameters unless compatibility mode treats them as key bytes") {
-		S3AuthParams auth_params;
+		auto auth_params = ResolveTestAuth(TestAuthConfig());
 		REQUIRE(S3Url::GetDisplayUrl("s3://bucket/key?s3_secret_access_key=secret", auth_params) == "s3://bucket/key");
-		auth_params.s3_url_compatibility_mode = true;
-		REQUIRE(S3Url::GetDisplayUrl("s3://bucket/key?literal", auth_params) == "s3://bucket/key?literal");
+		auto compatibility_config = TestAuthConfig();
+		compatibility_config.compatibility_mode = true;
+		auto compatibility_params = ResolveTestAuth(std::move(compatibility_config));
+		REQUIRE(S3Url::GetDisplayUrl("s3://bucket/key?literal", compatibility_params) == "s3://bucket/key?literal");
 	}
 }
 
@@ -1432,26 +1453,26 @@ TEST_CASE("S3 URL compatibility mode reads canonical and legacy secret keys", "[
 	SECTION("canonical key") {
 		KeyValueSecret secret({"s3://"}, Identifier("s3"), Identifier("config"), Identifier("canonical"));
 		secret.secret_map["url_compatibility_mode"] = Value(true);
-		REQUIRE(ReadSecretAuthParams(con, secret).s3_url_compatibility_mode);
+		REQUIRE(ReadSecretAuthParams(con, secret).GetURLParams().compatibility_mode);
 	}
 
 	SECTION("canonical key takes precedence") {
 		KeyValueSecret secret({"s3://"}, Identifier("s3"), Identifier("config"), Identifier("precedence"));
 		secret.secret_map["url_compatibility_mode"] = Value(false);
 		secret.secret_map["s3_url_compatibility_mode"] = Value(true);
-		REQUIRE_FALSE(ReadSecretAuthParams(con, secret).s3_url_compatibility_mode);
+		REQUIRE_FALSE(ReadSecretAuthParams(con, secret).GetURLParams().compatibility_mode);
 	}
 
 	SECTION("legacy key") {
 		KeyValueSecret secret({"s3://"}, Identifier("s3"), Identifier("config"), Identifier("legacy"));
 		secret.secret_map["s3_url_compatibility_mode"] = Value(true);
-		REQUIRE(ReadSecretAuthParams(con, secret).s3_url_compatibility_mode);
+		REQUIRE(ReadSecretAuthParams(con, secret).GetURLParams().compatibility_mode);
 	}
 
 	SECTION("global setting fallback") {
 		S3TestHelper::RequireQueryOk(con, "SET s3_url_compatibility_mode=true");
 		KeyValueSecret secret({"s3://"}, Identifier("s3"), Identifier("config"), Identifier("setting"));
-		REQUIRE(ReadSecretAuthParams(con, secret).s3_url_compatibility_mode);
+		REQUIRE(ReadSecretAuthParams(con, secret).GetURLParams().compatibility_mode);
 	}
 
 	SECTION("invalid legacy URL style") {
@@ -1463,96 +1484,128 @@ TEST_CASE("S3 URL compatibility mode reads canonical and legacy secret keys", "[
 
 TEST_CASE("GCS HMAC signing region follows provider defaults", "[httpfs][s3][gcs][provider][signing]") {
 	SECTION("regionless HMAC uses auto") {
-		S3AuthParams auth_params;
-		auth_params.provider_type = S3ProviderType::GCS;
-		auth_params.access_key_id = "key";
-		auth_params.secret_access_key = "secret";
-		S3Provider::FinalizeAuthParams(auth_params);
-		REQUIRE(auth_params.region == "auto");
-		REQUIRE(auth_params.GetEndpoint().GetHost() == "storage.googleapis.com");
-		REQUIRE(auth_params.url_style == "path");
+		auto config = TestAuthConfig(S3ProviderType::GCS);
+		config.credentials.access_key_id = "key";
+		config.credentials.secret_access_key = "secret";
+		auto auth_params = ResolveTestAuth(std::move(config));
+		REQUIRE(auth_params.GetCredentials().region == "auto");
+		REQUIRE(auth_params.GetURLParams().endpoint.GetHost() == "storage.googleapis.com");
+		REQUIRE(auth_params.GetURLParams().style == S3URLStyle::PATH);
 	}
 
 	SECTION("explicit regions win") {
-		S3AuthParams auth_params;
-		auth_params.provider_type = S3ProviderType::GCS;
-		auth_params.access_key_id = "key";
-		auth_params.secret_access_key = "secret";
-		auth_params.region = "eu-west-1";
-		S3Provider::InitializeAuthParams(auth_params);
-		REQUIRE(auth_params.region == "eu-west-1");
+		auto config = TestAuthConfig(S3ProviderType::GCS);
+		config.credentials.access_key_id = "key";
+		config.credentials.secret_access_key = "secret";
+		config.credentials.region = "eu-west-1";
+		auto auth_params = ResolveTestAuth(std::move(config));
+		REQUIRE(auth_params.GetCredentials().region == "eu-west-1");
 	}
 
 	SECTION("partial HMAC material still selects signing") {
 		for (const auto &use_key_id : {false, true}) {
-			S3AuthParams auth_params;
-			auth_params.provider_type = S3ProviderType::GCS;
+			auto config = TestAuthConfig(S3ProviderType::GCS);
 			if (use_key_id) {
-				auth_params.access_key_id = "key";
+				config.credentials.access_key_id = "key";
 			} else {
-				auth_params.secret_access_key = "secret";
+				config.credentials.secret_access_key = "secret";
 			}
-			S3Provider::InitializeAuthParams(auth_params);
-			REQUIRE(S3Provider::GetAuthType(auth_params) == S3AuthType::SIGV4);
-			REQUIRE(auth_params.region == "auto");
+			auto auth_params = ResolveTestAuth(std::move(config));
+			REQUIRE(auth_params.GetProvider().GetAuthType(auth_params) == S3AuthType::SIGV4);
+			REQUIRE(auth_params.GetCredentials().region == "auto");
 		}
 	}
 
 	SECTION("URL overrides reapply or replace the default") {
-		S3AuthParams empty_override;
-		empty_override.provider_type = S3ProviderType::GCS;
-		empty_override.access_key_id = "key";
-		empty_override.secret_access_key = "secret";
-		empty_override.region = "eu-west-1";
-		S3Provider::InitializeAuthParams(empty_override);
-		S3Url::Resolve("gcs://bucket/key?s3_region=", empty_override);
-		REQUIRE(empty_override.region == "auto");
+		auto empty_config = TestAuthConfig(S3ProviderType::GCS);
+		empty_config.credentials.access_key_id = "key";
+		empty_config.credentials.secret_access_key = "secret";
+		empty_config.credentials.region = "eu-west-1";
+		auto empty_override = ResolveTestAuth(std::move(empty_config), "gcs://bucket/key?s3_region=");
+		REQUIRE(empty_override.GetCredentials().region == "auto");
 
-		S3AuthParams explicit_override;
-		explicit_override.provider_type = S3ProviderType::GCS;
-		explicit_override.access_key_id = "key";
-		explicit_override.secret_access_key = "secret";
-		S3Provider::InitializeAuthParams(explicit_override);
-		S3Url::Resolve("gcs://bucket/key?s3_region=asia-east1", explicit_override);
-		REQUIRE(explicit_override.region == "asia-east1");
+		auto explicit_config = TestAuthConfig(S3ProviderType::GCS);
+		explicit_config.credentials.access_key_id = "key";
+		explicit_config.credentials.secret_access_key = "secret";
+		auto explicit_override = ResolveTestAuth(std::move(explicit_config), "gcs://bucket/key?s3_region=asia-east1");
+		REQUIRE(explicit_override.GetCredentials().region == "asia-east1");
 	}
 
 	SECTION("URL credentials receive the default during finalization") {
-		S3AuthParams auth_params;
-		auth_params.provider_type = S3ProviderType::GCS;
-		S3Provider::InitializeAuthParams(auth_params);
-		REQUIRE(auth_params.region.empty());
-		S3Url::Resolve("gcs://bucket/key?s3_access_key_id=key&s3_secret_access_key=secret", auth_params);
-		REQUIRE(auth_params.region == "auto");
+		auto auth_params = ResolveTestAuth(TestAuthConfig(S3ProviderType::GCS),
+		                                   "gcs://bucket/key?s3_access_key_id=key&s3_secret_access_key=secret");
+		REQUIRE(auth_params.GetCredentials().region == "auto");
 	}
 
 	SECTION("authentication modes that do not sign remain unchanged") {
-		S3AuthParams bearer;
-		bearer.provider_type = S3ProviderType::GCS;
-		bearer.oauth2_bearer_token = "token";
-		bearer.access_key_id = "key";
-		bearer.secret_access_key = "secret";
-		S3Provider::InitializeAuthParams(bearer);
-		REQUIRE(S3Provider::GetAuthType(bearer) == S3AuthType::BEARER);
-		REQUIRE(bearer.region.empty());
+		auto bearer_config = TestAuthConfig(S3ProviderType::GCS);
+		bearer_config.credentials.oauth2_bearer_token = "token";
+		bearer_config.credentials.access_key_id = "key";
+		bearer_config.credentials.secret_access_key = "secret";
+		auto bearer = ResolveTestAuth(std::move(bearer_config));
+		REQUIRE(bearer.GetProvider().GetAuthType(bearer) == S3AuthType::BEARER);
+		REQUIRE(bearer.GetCredentials().region.empty());
 
-		S3AuthParams anonymous;
-		anonymous.provider_type = S3ProviderType::GCS;
-		S3Provider::InitializeAuthParams(anonymous);
-		REQUIRE(S3Provider::GetAuthType(anonymous) == S3AuthType::ANONYMOUS);
-		REQUIRE(anonymous.region.empty());
+		auto anonymous = ResolveTestAuth(TestAuthConfig(S3ProviderType::GCS));
+		REQUIRE(anonymous.GetProvider().GetAuthType(anonymous) == S3AuthType::ANONYMOUS);
+		REQUIRE(anonymous.GetCredentials().region.empty());
+	}
+
+	SECTION("region publication retains the GCS endpoint") {
+		auto config = TestAuthConfig(S3ProviderType::GCS);
+		config.credentials.oauth2_bearer_token = "token";
+		auto auth_params = ResolveTestAuth(std::move(config)).WithRegion("eu-west-1");
+		REQUIRE(auth_params.GetCredentials().region == "eu-west-1");
+		REQUIRE(auth_params.GetURLParams().endpoint.GetHost() == "storage.googleapis.com");
+		REQUIRE(auth_params.GetProvider().GetType() == S3ProviderType::GCS);
+		REQUIRE(auth_params.GetProvider().GetAuthType(auth_params) == S3AuthType::BEARER);
 	}
 
 	SECTION("other providers retain their custom-endpoint behavior") {
 		for (const auto provider_type : {S3ProviderType::S3, S3ProviderType::R2}) {
-			S3AuthParams auth_params;
-			auth_params.provider_type = provider_type;
-			auth_params.access_key_id = "key";
-			auth_params.secret_access_key = "secret";
-			auth_params.SetEndpoint("storage.example.com");
-			S3Provider::InitializeAuthParams(auth_params);
-			REQUIRE(auth_params.region.empty());
+			auto config = TestAuthConfig(provider_type);
+			config.credentials.access_key_id = "key";
+			config.credentials.secret_access_key = "secret";
+			config.endpoint = "storage.example.com";
+			config.endpoint_mode = S3EndpointMode::EXPLICIT;
+			auto auth_params = ResolveTestAuth(std::move(config));
+			REQUIRE(auth_params.GetCredentials().region.empty());
 		}
+	}
+}
+
+TEST_CASE("S3 request operations define transport and retry policy", "[httpfs][s3][request][retry]") {
+	struct ExpectedOperationInfo {
+		S3RequestOperation operation;
+		RequestType request_type;
+		S3RequestTarget target;
+		bool retry_timeout;
+		bool retry_received_response;
+		bool uses_kms_headers;
+	};
+	const array<ExpectedOperationInfo, 10> expected {{
+	    {S3RequestOperation::HEAD_OBJECT, RequestType::HEAD_REQUEST, S3RequestTarget::OBJECT, true, false, false},
+	    {S3RequestOperation::GET_OBJECT, RequestType::GET_REQUEST, S3RequestTarget::OBJECT, true, false, false},
+	    {S3RequestOperation::PUT_OBJECT, RequestType::PUT_REQUEST, S3RequestTarget::OBJECT, true, false, true},
+	    {S3RequestOperation::DELETE_OBJECT, RequestType::DELETE_REQUEST, S3RequestTarget::OBJECT, true, false, false},
+	    {S3RequestOperation::LIST_OBJECTS, RequestType::GET_REQUEST, S3RequestTarget::BUCKET, true, false, false},
+	    {S3RequestOperation::DELETE_OBJECTS, RequestType::POST_REQUEST, S3RequestTarget::BUCKET, false, false, false},
+	    {S3RequestOperation::CREATE_MULTIPART_UPLOAD, RequestType::POST_REQUEST, S3RequestTarget::OBJECT, false, false,
+	     true},
+	    {S3RequestOperation::UPLOAD_PART, RequestType::PUT_REQUEST, S3RequestTarget::OBJECT, true, false, false},
+	    {S3RequestOperation::COMPLETE_MULTIPART_UPLOAD, RequestType::POST_REQUEST, S3RequestTarget::OBJECT, false, true,
+	     false},
+	    {S3RequestOperation::ABORT_MULTIPART_UPLOAD, RequestType::DELETE_REQUEST, S3RequestTarget::OBJECT, true, false,
+	     false},
+	}};
+
+	for (const auto &entry : expected) {
+		auto &info = S3RequestUtil::GetOperationInfo(entry.operation);
+		REQUIRE(info.request_type == entry.request_type);
+		REQUIRE(info.target == entry.target);
+		REQUIRE(info.retry_timeout == entry.retry_timeout);
+		REQUIRE(info.retry_received_response == entry.retry_received_response);
+		REQUIRE(info.uses_kms_headers == entry.uses_kms_headers);
 	}
 }
 
@@ -1561,34 +1614,33 @@ TEST_CASE("S3 provider policy selects request authentication", "[httpfs][s3][pro
 	auto parsed_url = ParseTestS3Url("s3://bucket/key", "storage.example.com", "path");
 
 	SECTION("anonymous") {
-		S3AuthParams auth_params;
-		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
-		                                            S3RequestQuery(), RequestType::GET_REQUEST, auth_params);
+		auto auth_params = ResolveTestAuth(TestAuthConfig());
+		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT,
+		                                            S3RequestQuery(), auth_params);
 		REQUIRE(headers.GetHeaderValue("Host") == parsed_url.GetHost());
 		REQUIRE_FALSE(headers.HasHeader("Authorization"));
 	}
 
 	for (const auto provider_type : {S3ProviderType::S3, S3ProviderType::R2, S3ProviderType::GCS}) {
-		S3AuthParams auth_params;
-		auth_params.provider_type = provider_type;
-		auth_params.region = "auto";
-		auth_params.access_key_id = "key";
-		auth_params.secret_access_key = "secret";
-		auto headers =
-		    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT, S3RequestQuery(),
-		                                 RequestType::GET_REQUEST, auth_params, "20260806", "20260806T120000Z");
+		auto config = TestAuthConfig(provider_type);
+		config.credentials.region = "auto";
+		config.credentials.access_key_id = "key";
+		config.credentials.secret_access_key = "secret";
+		auto auth_params = ResolveTestAuth(std::move(config));
+		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT,
+		                                            S3RequestQuery(), auth_params, "20260806", "20260806T120000Z");
 		REQUIRE(StringUtil::StartsWith(headers.GetHeaderValue("Authorization"), "AWS4-HMAC-SHA256"));
 	}
 
 	SECTION("GCS bearer takes precedence over HMAC") {
-		S3AuthParams auth_params;
-		auth_params.provider_type = S3ProviderType::GCS;
-		auth_params.access_key_id = "key";
-		auth_params.secret_access_key = "secret";
-		auth_params.oauth2_bearer_token = "token";
-		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
-		                                            S3RequestQuery({{"delete", ""}}), RequestType::POST_REQUEST,
-		                                            auth_params, "", "", "payload", "application/xml", "content-md5");
+		auto config = TestAuthConfig(S3ProviderType::GCS);
+		config.credentials.access_key_id = "key";
+		config.credentials.secret_access_key = "secret";
+		config.credentials.oauth2_bearer_token = "token";
+		auto auth_params = ResolveTestAuth(std::move(config));
+		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::DELETE_OBJECTS,
+		                                            S3RequestQuery({{"delete", ""}}), auth_params, "", "", "payload",
+		                                            "application/xml", "content-md5");
 		REQUIRE(headers.GetHeaderValue("Authorization") == "Bearer token");
 		REQUIRE(headers.GetHeaderValue("Content-Type") == "application/xml");
 		REQUIRE(headers.GetHeaderValue("Content-MD5") == "content-md5");
@@ -1600,18 +1652,21 @@ TEST_CASE("S3 configured headers are validated before request authentication", "
 	::AESStateSSLFactory encryption_util;
 	auto parsed_url = ParseTestS3Url("s3://bucket/key", "storage.example.com", "path");
 
-	vector<S3AuthParams> auth_params(3);
-	auth_params[1].region = "us-east-1";
-	auth_params[1].access_key_id = "key";
-	auth_params[1].secret_access_key = "secret";
-	auth_params[2].provider_type = S3ProviderType::GCS;
-	auth_params[2].oauth2_bearer_token = "token";
+	auto signed_config = TestAuthConfig();
+	signed_config.credentials.region = "us-east-1";
+	signed_config.credentials.access_key_id = "key";
+	signed_config.credentials.secret_access_key = "secret";
+	auto bearer_config = TestAuthConfig(S3ProviderType::GCS);
+	bearer_config.credentials.oauth2_bearer_token = "token";
+	vector<S3AuthParams> auth_params;
+	auth_params.push_back(ResolveTestAuth(TestAuthConfig()));
+	auth_params.push_back(ResolveTestAuth(std::move(signed_config)));
+	auth_params.push_back(ResolveTestAuth(std::move(bearer_config)));
 
 	auto create_headers = [&](const S3AuthParams &auth, const unordered_map<string, string> &extra_headers,
 	                          const string &user_agent = "httpfs-agent") {
-		return S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT, S3RequestQuery(),
-		                                    RequestType::GET_REQUEST, auth, "", "", "", "", "", extra_headers,
-		                                    user_agent);
+		return S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT,
+		                                    S3RequestQuery(), auth, "", "", "", "", "", extra_headers, user_agent);
 	};
 	auto capture_error = [&](const S3AuthParams &auth, const unordered_map<string, string> &extra_headers) {
 		try {
@@ -1682,24 +1737,28 @@ TEST_CASE("S3 rejects configured header conflicts before request dispatch", "[ht
 	HTTPFSUtil http_util;
 	HTTPFSParams http_params(http_util);
 	http_params.extra_headers["hOsT"] = "override";
-	S3AuthParams auth_params;
-	auth_params.region = "us-east-1";
-	auth_params.SetEndpoint("s3.amazonaws.com");
-	auth_params.access_key_id = "key";
-	auth_params.secret_access_key = "secret";
+	auto config = TestAuthConfig();
+	config.credentials.region = "us-east-1";
+	config.endpoint = "s3.amazonaws.com";
+	config.credentials.access_key_id = "key";
+	config.credentials.secret_access_key = "secret";
+	auto auth_params = ResolveTestAuth(std::move(config));
 	auto snapshot = make_shared_ptr<S3RequestSnapshot>(http_params, auth_params, "s3://bucket/key",
 	                                                   weak_ptr<ClientContext>(), false);
 	HTTPRequestSession session(snapshot);
 	::AESStateSSLFactory encryption_util;
 	idx_t request_count = 0;
 
-	REQUIRE_THROWS(S3RequestExecutor::RunSession(
-	    encryption_util, session, "s3://bucket/key", RequestType::GET_REQUEST, S3RequestTarget::OBJECT,
-	    [](const ParsedS3Url &) { return S3RequestQuery(); }, "", "", "",
-	    [&](S3RequestData &) {
-		    request_count++;
-		    return make_uniq<HTTPResponse>(HTTPStatusCode::OK_200);
-	    }));
+	S3RequestSpec spec {"s3://bucket/key",
+	                    S3RequestOperation::GET_OBJECT,
+	                    [](const ParsedS3Url &) { return S3RequestQuery(); },
+	                    "",
+	                    "",
+	                    ""};
+	REQUIRE_THROWS(S3RequestExecutor::RunSession(encryption_util, session, spec, [&](S3RequestData &) {
+		request_count++;
+		return make_uniq<HTTPResponse>(HTTPStatusCode::OK_200);
+	}));
 	REQUIRE(request_count == 0);
 }
 
@@ -1710,9 +1769,9 @@ TEST_CASE("S3 HTTP errors preserve metadata and provider-specific context", "[ht
 	                "<AWSAccessKeyId>test-key</AWSAccessKeyId></Error>";
 	response.headers.Insert("x-test-request-id", "request-42");
 
-	S3AuthParams auth_params;
-	auth_params.provider_type = S3ProviderType::S3;
-	auth_params.region = "eu-west-1";
+	auto config = TestAuthConfig();
+	config.credentials.region = "eu-west-1";
+	auto auth_params = ResolveTestAuth(std::move(config));
 	auto display_url = S3Url::GetDisplayUrl("s3://bucket/key?s3_secret_access_key=hidden", auth_params);
 	auto error =
 	    ErrorData(S3RequestUtil::GetError(auth_params, response, RequestType::GET_REQUEST, "reading", display_url));
@@ -1735,9 +1794,9 @@ TEST_CASE("S3 HTTP diagnostics stay within their provider", "[httpfs][s3][provid
 	bad_request.body = "not XML";
 
 	for (const auto provider_type : {S3ProviderType::S3, S3ProviderType::GCS, S3ProviderType::R2}) {
-		S3AuthParams auth_params;
-		auth_params.provider_type = provider_type;
-		auth_params.region = "test-region";
+		auto config = TestAuthConfig(provider_type);
+		config.credentials.region = "test-region";
+		auto auth_params = ResolveTestAuth(std::move(config));
 		auto error = ErrorData(S3RequestUtil::GetError(auth_params, bad_request, RequestType::POST_REQUEST, "listing",
 		                                               "provider://bucket"));
 		CHECK(StringUtil::Contains(error.RawMessage(), "Bad Request - this can be caused by the S3 region") ==
@@ -1750,8 +1809,7 @@ TEST_CASE("S3 HTTP diagnostics stay within their provider", "[httpfs][s3][provid
 	for (const auto &entry : {pair<S3ProviderType, string> {S3ProviderType::S3, "invalid or missing credentials"},
 	                          pair<S3ProviderType, string> {S3ProviderType::GCS, "GCS authentication failed"},
 	                          pair<S3ProviderType, string> {S3ProviderType::R2, "R2 authentication failed"}}) {
-		S3AuthParams auth_params;
-		auth_params.provider_type = entry.first;
+		auto auth_params = ResolveTestAuth(TestAuthConfig(entry.first));
 		auto error = ErrorData(S3RequestUtil::GetError(auth_params, unauthorized, RequestType::HEAD_REQUEST, "checking",
 		                                               "provider://bucket/key"));
 		CHECK(StringUtil::Contains(error.RawMessage(), entry.second));
@@ -1772,36 +1830,36 @@ TEST_CASE("S3 error classification requires valid XML but accepts code-only erro
 TEST_CASE("S3 request error context belongs to the final attempt", "[httpfs][s3][error][request-session]") {
 	HTTPFSUtil http_util;
 	HTTPFSParams http_params(http_util);
-	S3AuthParams auth_params;
-	auth_params.provider_type = S3ProviderType::S3;
-	auth_params.region = "request-region";
-	auth_params.SetEndpoint("s3.request-region.amazonaws.com");
+	auto config = TestAuthConfig();
+	config.credentials.region = "request-region";
+	config.endpoint = "s3.request-region.amazonaws.com";
+	auto auth_params = ResolveTestAuth(std::move(config));
 	auto snapshot = make_shared_ptr<S3RequestSnapshot>(http_params, auth_params, "s3://bucket/key",
 	                                                   weak_ptr<ClientContext>(), false);
 	HTTPRequestSession session(snapshot);
 	::AESStateSSLFactory encryption_util;
-	S3RequestContext request_context;
+	S3RequestSpec spec {"s3://bucket/key?s3_secret_access_key=hidden",
+	                    S3RequestOperation::GET_OBJECT,
+	                    [](const ParsedS3Url &) { return S3RequestQuery(); },
+	                    "",
+	                    "",
+	                    ""};
+	auto result = S3RequestExecutor::RunSession(encryption_util, session, spec, [&](S3RequestData &request_data) {
+		CHECK(request_data.auth_params.GetCredentials().region == "request-region");
+		string previous_region;
+		REQUIRE(S3RequestExecutor::SetSessionRegion(session, "published-region", previous_region));
+		auto result = make_uniq<HTTPResponse>(HTTPStatusCode::BadRequest_400);
+		result->reason = "Bad Request";
+		result->body = "<Error><Code>InvalidRequest</Code></Error>";
+		return result;
+	});
 
-	auto response = S3RequestExecutor::RunSession(
-	    encryption_util, session, "s3://bucket/key?s3_secret_access_key=hidden", RequestType::GET_REQUEST,
-	    S3RequestTarget::OBJECT, [](const ParsedS3Url &) { return S3RequestQuery(); }, "", "", "",
-	    [&](S3RequestData &request_data) {
-		    CHECK(request_data.auth_params.region == "request-region");
-		    string previous_region;
-		    REQUIRE(S3RequestExecutor::SetSessionRegion(session, "published-region", previous_region));
-		    auto result = make_uniq<HTTPResponse>(HTTPStatusCode::BadRequest_400);
-		    result->reason = "Bad Request";
-		    result->body = "<Error><Code>InvalidRequest</Code></Error>";
-		    return result;
-	    },
-	    {}, request_context);
-
-	REQUIRE(response);
-	CHECK(session.Capture().snapshot->Cast<S3RequestSnapshot>().auth_params.region == "published-region");
-	CHECK(request_context.auth_params.region == "request-region");
-	CHECK(request_context.display_url == "s3://bucket/key");
-	auto error = ErrorData(S3RequestUtil::GetError(request_context.auth_params, *response, request_context.request_type,
-	                                               "reading", request_context.display_url));
+	REQUIRE(result.response);
+	CHECK(session.Capture().snapshot->Cast<S3RequestSnapshot>().auth_params.GetCredentials().region ==
+	      "published-region");
+	CHECK(result.context.GetAuthParams().GetCredentials().region == "request-region");
+	CHECK(result.context.display_url == "s3://bucket/key");
+	auto error = ErrorData(S3RequestUtil::GetRequestError(result.context, *result.response));
 	CHECK(StringUtil::Contains(error.RawMessage(), "Provided region is: \"request-region\""));
 	CHECK_FALSE(StringUtil::Contains(error.RawMessage(), "published-region"));
 	CHECK_FALSE(StringUtil::Contains(error.RawMessage(), "hidden"));
@@ -1809,14 +1867,15 @@ TEST_CASE("S3 request error context belongs to the final attempt", "[httpfs][s3]
 
 TEST_CASE("S3 request signing remains deterministic", "[httpfs][s3][signing]") {
 	::AESStateSSLFactory encryption_util;
-	S3AuthParams auth_params;
-	auth_params.region = "us-east-1";
-	auth_params.access_key_id = "AKIAIOSFODNN7EXAMPLE";
-	auth_params.secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+	auto config = TestAuthConfig();
+	config.credentials.region = "us-east-1";
+	config.credentials.access_key_id = "AKIAIOSFODNN7EXAMPLE";
+	config.credentials.secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+	auto auth_params = ResolveTestAuth(std::move(config));
 	auto parsed_url = ParseTestS3Url("s3://examplebucket/test.txt", "s3.amazonaws.com", "virtual");
 
-	auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT, S3RequestQuery(),
-	                                            RequestType::GET_REQUEST, auth_params, "20130524", "20130524T000000Z");
+	auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT,
+	                                            S3RequestQuery(), auth_params, "20130524", "20130524T000000Z");
 
 	REQUIRE(headers.GetHeaderValue("Host") == "examplebucket.s3.amazonaws.com");
 	REQUIRE(headers.GetHeaderValue("x-amz-content-sha256") ==
@@ -1829,18 +1888,19 @@ TEST_CASE("S3 request signing remains deterministic", "[httpfs][s3][signing]") {
 
 TEST_CASE("S3 request signing includes optional headers", "[httpfs][s3][signing]") {
 	::AESStateSSLFactory encryption_util;
-	S3AuthParams auth_params;
-	auth_params.region = "eu-west-1";
-	auth_params.access_key_id = "key";
-	auth_params.secret_access_key = "secret";
-	auth_params.session_token = "token";
-	auth_params.kms_key_id = "kms-key";
-	auth_params.requester_pays = true;
+	auto config = TestAuthConfig();
+	config.credentials.region = "eu-west-1";
+	config.credentials.access_key_id = "key";
+	config.credentials.secret_access_key = "secret";
+	config.credentials.session_token = "token";
+	config.request_options.kms_key_id = "kms-key";
+	config.request_options.requester_pays = true;
+	auto auth_params = ResolveTestAuth(std::move(config));
 	auto parsed_url = ParseTestS3Url("s3://bucket/key", "bucket.example.com", "path");
 
-	auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT, S3RequestQuery(),
-	                                            RequestType::PUT_REQUEST, auth_params, "20260730", "20260730T120000Z",
-	                                            "", "application/octet-stream", "content-md5");
+	auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::PUT_OBJECT,
+	                                            S3RequestQuery(), auth_params, "20260730", "20260730T120000Z", "",
+	                                            "application/octet-stream", "content-md5");
 
 	REQUIRE(headers.GetHeaderValue("x-amz-security-token") == "token");
 	REQUIRE(headers.GetHeaderValue("x-amz-request-payer") == "requester");
@@ -1851,27 +1911,49 @@ TEST_CASE("S3 request signing includes optional headers", "[httpfs][s3][signing]
 	        "SignedHeaders=content-md5;content-type;host;x-amz-content-sha256;x-amz-date;x-amz-request-payer;"
 	        "x-amz-security-token;x-amz-server-side-encryption;x-amz-server-side-encryption-aws-kms-key-id, "
 	        "Signature=303dcf01c2ad19bf52fe539998ff6fa5d6a5d3ee54c6eb8cf6275ed5128e89b0");
+
+	SECTION("KMS headers are limited to operations that create object encryption state") {
+		const array<S3RequestOperation, 8> operations_without_kms {S3RequestOperation::HEAD_OBJECT,
+		                                                           S3RequestOperation::GET_OBJECT,
+		                                                           S3RequestOperation::DELETE_OBJECT,
+		                                                           S3RequestOperation::LIST_OBJECTS,
+		                                                           S3RequestOperation::DELETE_OBJECTS,
+		                                                           S3RequestOperation::UPLOAD_PART,
+		                                                           S3RequestOperation::COMPLETE_MULTIPART_UPLOAD,
+		                                                           S3RequestOperation::ABORT_MULTIPART_UPLOAD};
+		for (const auto operation : operations_without_kms) {
+			auto operation_headers = S3RequestUtil::CreateHeaders(
+			    encryption_util, parsed_url, operation, S3RequestQuery(), auth_params, "20260730", "20260730T120000Z");
+			REQUIRE_FALSE(operation_headers.HasHeader("x-amz-server-side-encryption"));
+			REQUIRE_FALSE(operation_headers.HasHeader("x-amz-server-side-encryption-aws-kms-key-id"));
+		}
+
+		auto create_headers =
+		    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::CREATE_MULTIPART_UPLOAD,
+		                                 S3RequestQuery(), auth_params, "20260730", "20260730T120000Z");
+		REQUIRE(create_headers.GetHeaderValue("x-amz-server-side-encryption") == "aws:kms");
+		REQUIRE(create_headers.GetHeaderValue("x-amz-server-side-encryption-aws-kms-key-id") == "kms-key");
+	}
 }
 
 TEST_CASE("GCS billing projects are applied across authentication modes", "[httpfs][s3][gcs][requester-pays]") {
 	::AESStateSSLFactory encryption_util;
 	auto parsed_url = ParseTestS3Url("s3://bucket/key", "storage.googleapis.com", "path");
-	const array<RequestType, 5> request_types {RequestType::GET_REQUEST, RequestType::HEAD_REQUEST,
-	                                           RequestType::PUT_REQUEST, RequestType::POST_REQUEST,
-	                                           RequestType::DELETE_REQUEST};
+	const array<S3RequestOperation, 5> operations {
+	    S3RequestOperation::GET_OBJECT, S3RequestOperation::HEAD_OBJECT, S3RequestOperation::PUT_OBJECT,
+	    S3RequestOperation::CREATE_MULTIPART_UPLOAD, S3RequestOperation::DELETE_OBJECT};
 
 	SECTION("HMAC signs the billing project for every request verb") {
-		S3AuthParams auth_params;
-		auth_params.provider_type = S3ProviderType::GCS;
-		auth_params.region = "auto";
-		auth_params.access_key_id = "key";
-		auth_params.secret_access_key = "secret";
-		auth_params.requester_pays = true;
-		auth_params.user_project = "billing-project";
-		for (const auto request_type : request_types) {
-			auto headers =
-			    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT, S3RequestQuery(),
-			                                 request_type, auth_params, "20260902", "20260902T120000Z");
+		auto config = TestAuthConfig(S3ProviderType::GCS);
+		config.credentials.region = "auto";
+		config.credentials.access_key_id = "key";
+		config.credentials.secret_access_key = "secret";
+		config.request_options.requester_pays = true;
+		config.request_options.user_project = "billing-project";
+		auto auth_params = ResolveTestAuth(std::move(config));
+		for (const auto operation : operations) {
+			auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, operation, S3RequestQuery(),
+			                                            auth_params, "20260902", "20260902T120000Z");
 			REQUIRE(headers.GetHeaderValue("x-goog-user-project") == "billing-project");
 			REQUIRE_FALSE(headers.HasHeader("x-amz-request-payer"));
 			REQUIRE(StringUtil::Contains(headers.GetHeaderValue("Authorization"), "x-goog-user-project"));
@@ -1879,61 +1961,57 @@ TEST_CASE("GCS billing projects are applied across authentication modes", "[http
 	}
 
 	SECTION("bearer and anonymous requests retain their authentication behavior") {
-		S3AuthParams bearer;
-		bearer.provider_type = S3ProviderType::GCS;
-		bearer.oauth2_bearer_token = "gcs-token";
-		bearer.user_project = "billing-project";
-		for (const auto request_type : request_types) {
-			auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
-			                                            S3RequestQuery(), request_type, bearer);
+		auto bearer_config = TestAuthConfig(S3ProviderType::GCS);
+		bearer_config.credentials.oauth2_bearer_token = "gcs-token";
+		bearer_config.request_options.user_project = "billing-project";
+		auto bearer = ResolveTestAuth(std::move(bearer_config));
+		for (const auto operation : operations) {
+			auto headers =
+			    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, operation, S3RequestQuery(), bearer);
 			REQUIRE(headers.GetHeaderValue("x-goog-user-project") == "billing-project");
 			REQUIRE(headers.GetHeaderValue("Authorization") == "Bearer gcs-token");
 			REQUIRE_FALSE(headers.HasHeader("x-amz-request-payer"));
 		}
 
-		S3AuthParams anonymous;
-		anonymous.provider_type = S3ProviderType::GCS;
-		anonymous.user_project = "billing-project";
-		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
-		                                            S3RequestQuery(), RequestType::GET_REQUEST, anonymous);
+		auto anonymous_config = TestAuthConfig(S3ProviderType::GCS);
+		anonymous_config.request_options.user_project = "billing-project";
+		auto anonymous = ResolveTestAuth(std::move(anonymous_config));
+		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT,
+		                                            S3RequestQuery(), anonymous);
 		REQUIRE(headers.GetHeaderValue("x-goog-user-project") == "billing-project");
 		REQUIRE_FALSE(headers.HasHeader("Authorization"));
 	}
 
 	SECTION("unconfigured GCS requests remain unchanged") {
-		S3AuthParams auth_params;
-		auth_params.provider_type = S3ProviderType::GCS;
-		auth_params.oauth2_bearer_token = "gcs-token";
-		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
-		                                            S3RequestQuery(), RequestType::GET_REQUEST, auth_params);
+		auto config = TestAuthConfig(S3ProviderType::GCS);
+		config.credentials.oauth2_bearer_token = "gcs-token";
+		auto auth_params = ResolveTestAuth(std::move(config));
+		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT,
+		                                            S3RequestQuery(), auth_params);
 		REQUIRE_FALSE(headers.HasHeader("x-goog-user-project"));
 	}
 
 	SECTION("the billing header is owned only for GCS") {
 		unordered_map<string, string> extra_headers {{"X-GoOg-UsEr-PrOjEcT", "configured-project"}};
-		S3AuthParams gcs;
-		gcs.provider_type = S3ProviderType::GCS;
-		REQUIRE_THROWS(S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
-		                                            S3RequestQuery(), RequestType::GET_REQUEST, gcs, "", "", "", "", "",
-		                                            extra_headers));
+		auto gcs = ResolveTestAuth(TestAuthConfig(S3ProviderType::GCS));
+		REQUIRE_THROWS(S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT,
+		                                            S3RequestQuery(), gcs, "", "", "", "", "", extra_headers));
 
-		S3AuthParams s3;
-		auto headers =
-		    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT, S3RequestQuery(),
-		                                 RequestType::GET_REQUEST, s3, "", "", "", "", "", extra_headers);
+		auto s3 = ResolveTestAuth(TestAuthConfig());
+		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT,
+		                                            S3RequestQuery(), s3, "", "", "", "", "", extra_headers);
 		REQUIRE(headers.GetHeaderValue("X-GoOg-UsEr-PrOjEcT") == "configured-project");
 	}
 
 	SECTION("R2 retains the AWS requester-pays header") {
-		S3AuthParams auth_params;
-		auth_params.provider_type = S3ProviderType::R2;
-		auth_params.region = "auto";
-		auth_params.access_key_id = "key";
-		auth_params.secret_access_key = "secret";
-		auth_params.requester_pays = true;
-		auto headers =
-		    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT, S3RequestQuery(),
-		                                 RequestType::GET_REQUEST, auth_params, "20260902", "20260902T120000Z");
+		auto config = TestAuthConfig(S3ProviderType::R2);
+		config.credentials.region = "auto";
+		config.credentials.access_key_id = "key";
+		config.credentials.secret_access_key = "secret";
+		config.request_options.requester_pays = true;
+		auto auth_params = ResolveTestAuth(std::move(config));
+		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT,
+		                                            S3RequestQuery(), auth_params, "20260902", "20260902T120000Z");
 		REQUIRE(headers.GetHeaderValue("x-amz-request-payer") == "requester");
 		REQUIRE_FALSE(headers.HasHeader("x-goog-user-project"));
 	}
@@ -1941,22 +2019,23 @@ TEST_CASE("GCS billing projects are applied across authentication modes", "[http
 
 TEST_CASE("S3 request signing canonicalizes configured extension headers", "[httpfs][s3][signing][headers]") {
 	::AESStateSSLFactory encryption_util;
-	S3AuthParams auth_params;
-	auth_params.region = "us-east-1";
-	auth_params.access_key_id = "key";
-	auth_params.secret_access_key = "secret";
+	auto config = TestAuthConfig();
+	config.credentials.region = "us-east-1";
+	config.credentials.access_key_id = "key";
+	config.credentials.secret_access_key = "secret";
+	auto auth_params = ResolveTestAuth(std::move(config));
 	auto parsed_url = ParseTestS3Url("s3://bucket/key", "bucket.example.com", "path");
 	unordered_map<string, string> raw_headers {
 	    {"X-AmZ-Meta-Color", "\t blue  green \t"}, {"x-GoOg-Meta-Mode", "  fast\tmode  "}, {"X-Ordinary", "value"}};
 	unordered_map<string, string> normalized_headers {
 	    {"x-amz-meta-color", "blue green"}, {"X-GOOG-META-MODE", "fast mode"}, {"X-Ordinary", "value"}};
 
-	auto raw = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT, S3RequestQuery(),
-	                                        RequestType::GET_REQUEST, auth_params, "20260831", "20260831T120000Z", "",
-	                                        "", "", raw_headers, "httpfs-agent");
-	auto normalized = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
-	                                               S3RequestQuery(), RequestType::GET_REQUEST, auth_params, "20260831",
-	                                               "20260831T120000Z", "", "", "", normalized_headers, "httpfs-agent");
+	auto raw = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT,
+	                                        S3RequestQuery(), auth_params, "20260831", "20260831T120000Z", "", "", "",
+	                                        raw_headers, "httpfs-agent");
+	auto normalized = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT,
+	                                               S3RequestQuery(), auth_params, "20260831", "20260831T120000Z", "",
+	                                               "", "", normalized_headers, "httpfs-agent");
 
 	const auto &authorization = raw.GetHeaderValue("Authorization");
 	REQUIRE(authorization == normalized.GetHeaderValue("Authorization"));
@@ -1980,20 +2059,21 @@ TEST_CASE("S3 request signing canonicalizes configured extension headers", "[htt
 
 TEST_CASE("S3 request signing preserves empty configured extension headers", "[httpfs][s3][signing][headers]") {
 	::AESStateSSLFactory encryption_util;
-	S3AuthParams auth_params;
-	auth_params.region = "us-east-1";
-	auth_params.access_key_id = "key";
-	auth_params.secret_access_key = "secret";
+	auto config = TestAuthConfig();
+	config.credentials.region = "us-east-1";
+	config.credentials.access_key_id = "key";
+	config.credentials.secret_access_key = "secret";
+	auto auth_params = ResolveTestAuth(std::move(config));
 	auto parsed_url = ParseTestS3Url("s3://bucket/key", "bucket.example.com", "path");
 	unordered_map<string, string> raw_headers {{"X-AmZ-Meta-Empty", ""}, {"x-GoOg-Meta-Whitespace", "\t  \t"}};
 	unordered_map<string, string> normalized_headers {{"x-amz-meta-empty", ""}, {"X-GOOG-META-WHITESPACE", ""}};
 
-	auto raw = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT, S3RequestQuery(),
-	                                        RequestType::GET_REQUEST, auth_params, "20260831", "20260831T120000Z", "",
-	                                        "", "", raw_headers);
-	auto normalized = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
-	                                               S3RequestQuery(), RequestType::GET_REQUEST, auth_params, "20260831",
-	                                               "20260831T120000Z", "", "", "", normalized_headers);
+	auto raw =
+	    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT, S3RequestQuery(),
+	                                 auth_params, "20260831", "20260831T120000Z", "", "", "", raw_headers);
+	auto normalized =
+	    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT, S3RequestQuery(),
+	                                 auth_params, "20260831", "20260831T120000Z", "", "", "", normalized_headers);
 
 	const auto &authorization = raw.GetHeaderValue("Authorization");
 	REQUIRE(authorization == normalized.GetHeaderValue("Authorization"));
@@ -2007,20 +2087,21 @@ TEST_CASE("S3 request signing preserves empty configured extension headers", "[h
 
 TEST_CASE("S3 request signing changes configured headers after a region redirect", "[httpfs][s3][signing][headers]") {
 	::AESStateSSLFactory encryption_util;
-	S3AuthParams auth_params;
-	auth_params.region = "us-east-1";
-	auth_params.access_key_id = "key";
-	auth_params.secret_access_key = "secret";
+	auto config = TestAuthConfig();
+	config.credentials.region = "us-east-1";
+	config.credentials.access_key_id = "key";
+	config.credentials.secret_access_key = "secret";
+	auto auth_params = ResolveTestAuth(std::move(config));
 	auto parsed_url = ParseTestS3Url("s3://bucket/key", "bucket.example.com", "path");
 	unordered_map<string, string> extra_headers {{"X-AmZ-Meta-Region", "region-value"}};
 
-	auto us_east_1 = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
-	                                              S3RequestQuery(), RequestType::GET_REQUEST, auth_params, "20260831",
-	                                              "20260831T120000Z", "", "", "", extra_headers);
-	auth_params.region = "eu-west-1";
-	auto eu_west_1 = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
-	                                              S3RequestQuery(), RequestType::GET_REQUEST, auth_params, "20260831",
-	                                              "20260831T120000Z", "", "", "", extra_headers);
+	auto us_east_1 =
+	    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT, S3RequestQuery(),
+	                                 auth_params, "20260831", "20260831T120000Z", "", "", "", extra_headers);
+	auth_params = auth_params.WithRegion("eu-west-1");
+	auto eu_west_1 =
+	    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT, S3RequestQuery(),
+	                                 auth_params, "20260831", "20260831T120000Z", "", "", "", extra_headers);
 
 	const auto &us_authorization = us_east_1.GetHeaderValue("Authorization");
 	const auto &eu_authorization = eu_west_1.GetHeaderValue("Authorization");
@@ -2058,27 +2139,25 @@ TEST_CASE("S3 request queries share canonical and wire encoding", "[httpfs][s3][
 
 	SECTION("signing is independent of raw parameter order") {
 		::AESStateSSLFactory encryption_util;
-		S3AuthParams auth_params;
-		auth_params.region = "us-east-1";
-		auth_params.access_key_id = "key";
-		auth_params.secret_access_key = "secret";
+		auto config = TestAuthConfig();
+		config.credentials.region = "us-east-1";
+		config.credentials.access_key_id = "key";
+		config.credentials.secret_access_key = "secret";
+		auto auth_params = ResolveTestAuth(std::move(config));
 		auto parsed_url = ParseTestS3Url("s3://bucket/key", "bucket.example.com", "path");
-		auto first =
-		    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
-		                                 S3RequestQuery({{"uploadId", "opaque&id"}, {"partNumber", "12"}}),
-		                                 RequestType::PUT_REQUEST, auth_params, "20260806", "20260806T120000Z");
-		auto second =
-		    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT,
-		                                 S3RequestQuery({{"partNumber", "12"}, {"uploadId", "opaque&id"}}),
-		                                 RequestType::PUT_REQUEST, auth_params, "20260806", "20260806T120000Z");
+		auto first = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::UPLOAD_PART,
+		                                          S3RequestQuery({{"uploadId", "opaque&id"}, {"partNumber", "12"}}),
+		                                          auth_params, "20260806", "20260806T120000Z");
+		auto second = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::UPLOAD_PART,
+		                                           S3RequestQuery({{"partNumber", "12"}, {"uploadId", "opaque&id"}}),
+		                                           auth_params, "20260806", "20260806T120000Z");
 		REQUIRE(first.GetHeaderValue("Authorization") == second.GetHeaderValue("Authorization"));
 		REQUIRE(first.GetHeaderValue("Authorization") ==
 		        "AWS4-HMAC-SHA256 Credential=key/20260806/us-east-1/s3/aws4_request, "
 		        "SignedHeaders=host;x-amz-content-sha256;x-amz-date, "
 		        "Signature=7d31006078e4c8754eb70f96358af8f4c84a60186bf8e8fe1605b9bb90fcffad");
-		auto empty_query =
-		    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestTarget::OBJECT, S3RequestQuery(),
-		                                 RequestType::PUT_REQUEST, auth_params, "20260806", "20260806T120000Z");
+		auto empty_query = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::UPLOAD_PART,
+		                                                S3RequestQuery(), auth_params, "20260806", "20260806T120000Z");
 		REQUIRE(first.GetHeaderValue("Authorization") != empty_query.GetHeaderValue("Authorization"));
 	}
 }

--- a/test/unittest/s3/s3_request_test.cpp
+++ b/test/unittest/s3/s3_request_test.cpp
@@ -1666,7 +1666,8 @@ TEST_CASE("S3 configured headers are validated before request authentication", "
 	auto create_headers = [&](const S3AuthParams &auth, const unordered_map<string, string> &extra_headers,
 	                          const string &user_agent = "httpfs-agent") {
 		return S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT,
-		                                    S3RequestQuery(), auth, "", "", "", "", "", extra_headers, user_agent);
+		                                    S3RequestQuery(), auth, "", "", "", "", "",
+		                                    HTTPConfiguredHeaders {user_agent, extra_headers});
 	};
 	auto capture_error = [&](const S3AuthParams &auth, const unordered_map<string, string> &extra_headers) {
 		try {
@@ -1995,11 +1996,13 @@ TEST_CASE("GCS billing projects are applied across authentication modes", "[http
 		unordered_map<string, string> extra_headers {{"X-GoOg-UsEr-PrOjEcT", "configured-project"}};
 		auto gcs = ResolveTestAuth(TestAuthConfig(S3ProviderType::GCS));
 		REQUIRE_THROWS(S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT,
-		                                            S3RequestQuery(), gcs, "", "", "", "", "", extra_headers));
+		                                            S3RequestQuery(), gcs, "", "", "", "", "",
+		                                            HTTPConfiguredHeaders {"", extra_headers}));
 
 		auto s3 = ResolveTestAuth(TestAuthConfig());
-		auto headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT,
-		                                            S3RequestQuery(), s3, "", "", "", "", "", extra_headers);
+		auto headers =
+		    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT, S3RequestQuery(),
+		                                 s3, "", "", "", "", "", HTTPConfiguredHeaders {"", extra_headers});
 		REQUIRE(headers.GetHeaderValue("X-GoOg-UsEr-PrOjEcT") == "configured-project");
 	}
 
@@ -2032,10 +2035,10 @@ TEST_CASE("S3 request signing canonicalizes configured extension headers", "[htt
 
 	auto raw = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT,
 	                                        S3RequestQuery(), auth_params, "20260831", "20260831T120000Z", "", "", "",
-	                                        raw_headers, "httpfs-agent");
+	                                        HTTPConfiguredHeaders {"httpfs-agent", raw_headers});
 	auto normalized = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT,
 	                                               S3RequestQuery(), auth_params, "20260831", "20260831T120000Z", "",
-	                                               "", "", normalized_headers, "httpfs-agent");
+	                                               "", "", HTTPConfiguredHeaders {"httpfs-agent", normalized_headers});
 
 	const auto &authorization = raw.GetHeaderValue("Authorization");
 	REQUIRE(authorization == normalized.GetHeaderValue("Authorization"));
@@ -2068,12 +2071,12 @@ TEST_CASE("S3 request signing preserves empty configured extension headers", "[h
 	unordered_map<string, string> raw_headers {{"X-AmZ-Meta-Empty", ""}, {"x-GoOg-Meta-Whitespace", "\t  \t"}};
 	unordered_map<string, string> normalized_headers {{"x-amz-meta-empty", ""}, {"X-GOOG-META-WHITESPACE", ""}};
 
-	auto raw =
-	    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT, S3RequestQuery(),
-	                                 auth_params, "20260831", "20260831T120000Z", "", "", "", raw_headers);
-	auto normalized =
-	    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT, S3RequestQuery(),
-	                                 auth_params, "20260831", "20260831T120000Z", "", "", "", normalized_headers);
+	auto raw = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT,
+	                                        S3RequestQuery(), auth_params, "20260831", "20260831T120000Z", "", "", "",
+	                                        HTTPConfiguredHeaders {"", raw_headers});
+	auto normalized = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT,
+	                                               S3RequestQuery(), auth_params, "20260831", "20260831T120000Z", "",
+	                                               "", "", HTTPConfiguredHeaders {"", normalized_headers});
 
 	const auto &authorization = raw.GetHeaderValue("Authorization");
 	REQUIRE(authorization == normalized.GetHeaderValue("Authorization"));
@@ -2095,13 +2098,13 @@ TEST_CASE("S3 request signing changes configured headers after a region redirect
 	auto parsed_url = ParseTestS3Url("s3://bucket/key", "bucket.example.com", "path");
 	unordered_map<string, string> extra_headers {{"X-AmZ-Meta-Region", "region-value"}};
 
-	auto us_east_1 =
-	    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT, S3RequestQuery(),
-	                                 auth_params, "20260831", "20260831T120000Z", "", "", "", extra_headers);
+	auto us_east_1 = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT,
+	                                              S3RequestQuery(), auth_params, "20260831", "20260831T120000Z", "", "",
+	                                              "", HTTPConfiguredHeaders {"", extra_headers});
 	auth_params = auth_params.WithRegion("eu-west-1");
-	auto eu_west_1 =
-	    S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT, S3RequestQuery(),
-	                                 auth_params, "20260831", "20260831T120000Z", "", "", "", extra_headers);
+	auto eu_west_1 = S3RequestUtil::CreateHeaders(encryption_util, parsed_url, S3RequestOperation::GET_OBJECT,
+	                                              S3RequestQuery(), auth_params, "20260831", "20260831T120000Z", "", "",
+	                                              "", HTTPConfiguredHeaders {"", extra_headers});
 
 	const auto &us_authorization = us_east_1.GetHeaderValue("Authorization");
 	const auto &eu_authorization = eu_west_1.GetHeaderValue("Authorization");

--- a/test/unittest/s3/s3_upload_config_test.cpp
+++ b/test/unittest/s3/s3_upload_config_test.cpp
@@ -15,9 +15,14 @@ static constexpr idx_t MIB = 1024ULL * 1024ULL;
 static constexpr idx_t GIB = 1024ULL * MIB;
 
 static S3MultipartUploadPolicy GetUploadPolicy(S3ProviderType provider_type) {
-	S3AuthParams auth_params;
-	auth_params.provider_type = provider_type;
-	return S3Provider::GetMultipartUploadPolicy(auth_params);
+	const char *scheme = provider_type == S3ProviderType::R2 ? "r2://" : "s3://";
+	S3AuthConfig config;
+	config.route = S3UrlScheme::Match(scheme);
+	if (provider_type == S3ProviderType::R2) {
+		config.endpoint = "account.r2.cloudflarestorage.com";
+	}
+	auto auth_params = S3AuthResolver::Resolve(std::move(config), scheme);
+	return auth_params.GetProvider().GetMultipartUploadPolicy();
 }
 
 } // namespace

--- a/test/unittest/s3/scheme_alias_isolation_test.cpp
+++ b/test/unittest/s3/scheme_alias_isolation_test.cpp
@@ -64,33 +64,28 @@ TEST_CASE("a required endpoint may arrive from any source, but must arrive", "[h
 	// Resolve() runs the real ordering: parse, apply url query parameters, then finalize
 	static constexpr EndpointCase CASES[] = {{"oss://bucket/key", true}, {"r2://bucket/key", false}};
 
-	auto make_params = [](const EndpointCase &test_case) {
-		S3AuthParams params;
-		if (test_case.is_alias) {
-			params.scheme_is_alias = true;
-		} else {
-			params.provider_type = S3ProviderType::R2;
-		}
-		return params;
+	auto make_config = [](const EndpointCase &test_case) {
+		S3AuthConfig config;
+		config.route = test_case.is_alias ? S3ProviderMatch {S3ProviderType::S3, "oss://", S3UrlSchemeOrigin::ALIAS}
+		                                  : S3UrlScheme::Match("r2://");
+		return config;
 	};
 
 	SECTION("no source supplies one") {
 		for (auto &test_case : CASES) {
-			auto params = make_params(test_case);
-			// Reading secrets and settings leaves it unresolved rather than deriving an AWS endpoint
-			S3Provider::InitializeAuthParams(params);
-			REQUIRE(params.GetEndpoint().IsEmpty());
-			REQUIRE_THROWS(S3Url::Resolve(test_case.url, params));
+			auto config = make_config(test_case);
+			REQUIRE(config.endpoint.empty());
+			REQUIRE_THROWS(S3AuthResolver::Resolve(std::move(config), test_case.url));
 		}
 	}
 
 	SECTION("only the url supplies one") {
 		for (auto &test_case : CASES) {
-			auto params = make_params(test_case);
-			S3Provider::InitializeAuthParams(params);
-			auto parsed = S3Url::Resolve(string(test_case.url) + "?s3_endpoint=storage.example.com", params);
-			REQUIRE(params.GetEndpoint().GetHost() == "storage.example.com");
-			REQUIRE(params.endpoint_mode == S3EndpointMode::EXPLICIT);
+			auto params = S3AuthResolver::Resolve(make_config(test_case),
+			                                      string(test_case.url) + "?s3_endpoint=storage.example.com");
+			auto parsed = S3Url::Parse(test_case.url, params);
+			REQUIRE(params.GetURLParams().endpoint.GetHost() == "storage.example.com");
+			REQUIRE(params.GetURLParams().endpoint_mode == S3EndpointMode::EXPLICIT);
 			REQUIRE(parsed.GetHost() == "bucket.storage.example.com");
 		}
 	}
@@ -98,19 +93,20 @@ TEST_CASE("a required endpoint may arrive from any source, but must arrive", "[h
 	SECTION("the url clears one supplied by a secret or setting") {
 		for (auto &test_case : CASES) {
 			for (const auto &cleared : {"", "%20"}) {
-				auto params = make_params(test_case);
-				params.SetEndpoint("storage.example.com");
-				S3Provider::InitializeAuthParams(params);
-				REQUIRE_THROWS(S3Url::Resolve(string(test_case.url) + "?s3_endpoint=" + cleared, params));
+				auto config = make_config(test_case);
+				config.endpoint = "storage.example.com";
+				config.endpoint_mode = S3EndpointMode::EXPLICIT;
+				REQUIRE_THROWS(
+				    S3AuthResolver::Resolve(std::move(config), string(test_case.url) + "?s3_endpoint=" + cleared));
 			}
 		}
 	}
 
 	SECTION("built-in s3 still derives the AWS default") {
-		S3AuthParams params;
-		S3Provider::InitializeAuthParams(params);
-		S3Provider::FinalizeAuthParams(params);
-		REQUIRE(params.GetEndpoint().GetHost() == "s3.amazonaws.com");
+		S3AuthConfig config;
+		config.route = S3UrlScheme::Match("s3://");
+		auto params = S3AuthResolver::Resolve(std::move(config), "s3://bucket/key");
+		REQUIRE(params.GetURLParams().endpoint.GetHost() == "s3.amazonaws.com");
 	}
 }
 


### PR DESCRIPTION
This cleans up the S3 and HTTPFS request path. It gives provider, auth, request, and transport state clearer ownership and hardens header and cache handling.