### PR TITLE
Remove S3 delete existence probe

### DIFF
--- a/src/s3/s3_delete.cpp
+++ b/src/s3/s3_delete.cpp
@@ -78,24 +78,17 @@ static void AddDeleteHTTPHash(hash_t &result, const S3RefreshableHTTPParams &htt
 }
 
 void S3FileSystem::RemoveFile(const string &path, optional_ptr<FileOpener> opener) {
-	auto handle = OpenFile(path, FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS, opener);
-	if (!handle) {
-		FileOpenerInfo info = {path};
-		auto auth_params = S3AuthResolver::Resolve(opener, info);
-		throw IOException({{"errno", "404"}}, "Could not remove file \"%s\": %s",
-		                  S3Url::GetDisplayUrl(path, auth_params), string("No such file or directory"));
-	}
-
-	auto &s3fh = handle->Cast<S3FileHandle>();
-	auto res = DeleteRequest(*handle, s3fh.path, {});
+	FileOpenerInfo info = {path};
+	auto auth_params = S3AuthResolver::Resolve(opener, info);
+	auto session = S3RequestExecutor::CreateSession(opener, path, auth_params);
+	auto request_result = DeleteRequest(*session, S3RequestOperation::DELETE_OBJECT, path, {});
+	auto &res = request_result.response;
 	if (res->HasRequestError()) {
-		auto captured = s3fh.request_session->Capture();
-		auto &snapshot = captured.snapshot->Cast<S3RequestSnapshot>();
-		throw IOException("S3 delete request for \"%s\" could not be completed: %s",
-		                  S3Url::GetDisplayUrl(path, snapshot.auth_params), res->GetRequestError());
+		throw IOException("S3 delete request for \"%s\" could not be completed: %s", request_result.context.display_url,
+		                  res->GetRequestError());
 	}
 	if (res->status != HTTPStatusCode::OK_200 && res->status != HTTPStatusCode::NoContent_204) {
-		throw GetHTTPError(*handle, *res, RequestType::DELETE_REQUEST, path);
+		throw S3RequestUtil::GetRequestError(request_result.context, *res);
 	}
 }
 

--- a/test/unittest/s3/mock_s3_server.cpp
+++ b/test/unittest/s3/mock_s3_server.cpp
@@ -273,6 +273,7 @@ public:
 		remaining_head_failures = config.failures.transient_head_failures;
 		remaining_head_not_found = config.failures.head_not_found_requests;
 		remaining_delete_failures = config.failures.transient_delete_failures;
+		remaining_delete_disconnects = config.failures.transient_delete_disconnects;
 		remaining_post_failures = config.failures.transient_post_failures;
 		remaining_completion_faults = config.failures.completion_fault.count;
 		if (config.range.behavior == MockS3RangeBehavior::SHORT_SUCCESS && config.range.behavior_requests > 0) {
@@ -887,7 +888,17 @@ public:
 			SendS3Error400(request, response, config.failures.failure_is_request_timeout);
 			return;
 		}
-		if (config.http_response.object_delete_body.empty()) {
+		if (remaining_delete_disconnects.load() > 0) {
+			remaining_delete_disconnects--;
+			SendDisconnectedResponse(request, response);
+			return;
+		}
+		if (config.http_response.object_delete_status != 0) {
+			response.status = config.http_response.object_delete_status;
+			if (!config.http_response.object_delete_body.empty()) {
+				response.set_content(config.http_response.object_delete_body, "application/xml");
+			}
+		} else if (config.http_response.object_delete_body.empty()) {
 			response.status = 204;
 		} else {
 			response.status = 200;
@@ -1217,6 +1228,7 @@ public:
 	mutable atomic<idx_t> remaining_head_failures {0};
 	mutable atomic<idx_t> remaining_head_not_found {0};
 	mutable atomic<idx_t> remaining_delete_failures {0};
+	mutable atomic<idx_t> remaining_delete_disconnects {0};
 	mutable atomic<idx_t> remaining_post_failures {0};
 	mutable atomic<idx_t> remaining_completion_faults {0};
 

--- a/test/unittest/s3/mock_s3_server.hpp
+++ b/test/unittest/s3/mock_s3_server.hpp
@@ -105,6 +105,8 @@ struct MockS3FailureConfig {
 	idx_t head_not_found_requests = 0;
 	//! Number of object DELETEs to fail with a 400 before succeeding
 	idx_t transient_delete_failures = 0;
+	//! Number of object DELETE responses to disconnect before succeeding
+	idx_t transient_delete_disconnects = 0;
 	//! Number of multipart-init POSTs (uploads=) to fail before succeeding
 	idx_t transient_post_failures = 0;
 	//! HTTP status used for injected multipart-init failures
@@ -157,6 +159,8 @@ struct MockS3PutResponseConfig {
 struct MockS3HTTPResponseConfig {
 	string object_put_body;
 	string object_delete_body;
+	//! Zero retains the default 204/200 selection based on whether a body is configured
+	int object_delete_status = 0;
 	string options_body;
 };
 

--- a/test/unittest/s3/s3_refresh_test.cpp
+++ b/test/unittest/s3/s3_refresh_test.cpp
@@ -242,8 +242,11 @@ static void RunDeleteRefreshScenario(const string &client_implementation, bool c
 		                                       auto &fs = FileSystem::GetFileSystem(*con.context);
 		                                       fs.RemoveFile(S3TestHelper::S3_PATH);
 	                                       });
-	REQUIRE(MockS3HasObservation(observations, "DELETE", S3TestHelper::STALE_KEY_ID, 403));
-	REQUIRE(MockS3HasObservation(observations, "DELETE", S3TestHelper::FRESH_KEY_ID, 204));
+	REQUIRE(S3TestHelper::CountObservations(observations, "DELETE", S3TestHelper::STALE_KEY_ID, 403) == 1);
+	REQUIRE(S3TestHelper::CountObservations(observations, "DELETE", S3TestHelper::FRESH_KEY_ID, 204) == 1);
+	for (const auto &observation : observations) {
+		REQUIRE(observation.method == "DELETE");
+	}
 }
 
 static void RunListGlobRefreshScenario(const string &client_implementation, bool connection_caching) {

--- a/test/unittest/s3/s3_request_test.cpp
+++ b/test/unittest/s3/s3_request_test.cpp
@@ -841,6 +841,90 @@ static void RunGCSListAuthErrorScenario(const string &client_implementation) {
 	REQUIRE(result->GetError().find("Authentication Failure - GCS authentication failed") != string::npos);
 }
 
+static void ConfigureDirectDelete(Connection &con, MockS3Server &server, const string &client_implementation) {
+	S3TestHelper::RequireQueryOk(con,
+	                             StringUtil::Format("SET httpfs_client_implementation='%s'", client_implementation));
+	S3TestHelper::RequireQueryOk(con, "SET httpfs_connection_caching=false");
+	S3TestHelper::RequireQueryOk(con, "SET enable_global_s3_configuration=false");
+	S3TestHelper::RequireQueryOk(con, StringUtil::Format(R"(
+CREATE SECRET direct_delete (
+	TYPE S3,
+	SCOPE 's3://refresh-bucket/',
+	KEY_ID 'DELETE_ONLY_KEY',
+	SECRET 'DELETE_ONLY_SECRET',
+	REGION 'us-east-1',
+	ENDPOINT '%s',
+	USE_SSL false,
+	URL_STYLE 'path'
+))",
+	                                                     server.Endpoint()));
+}
+
+static void RunDirectDeleteSuccessScenario(const string &client_implementation, int status) {
+	MockS3ServerConfig config;
+	config.auth.stale_key_id = "DELETE_ONLY_KEY";
+	// A preliminary HEAD would fail, while the DELETE itself is authorized.
+	config.auth.refresh_target = MockS3RefreshTarget::HEAD;
+	config.http_response.object_delete_status = status;
+	if (status == 200) {
+		config.http_response.object_delete_body = "deleted";
+	}
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	S3TestHelper::LoadExtension(db);
+	ConfigureDirectDelete(con, server, client_implementation);
+
+	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	fs.RemoveFile(S3TestHelper::S3_PATH);
+	S3TestHelper::RequireQueryOk(con, "COMMIT");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(observations.size() == 1);
+	REQUIRE(observations[0].method == "DELETE");
+	REQUIRE(observations[0].status == status);
+}
+
+static void RunDirectDeleteErrorScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.auth.stale_key_id = "DELETE_ONLY_KEY";
+	config.auth.refresh_target = MockS3RefreshTarget::HEAD;
+	config.http_response.object_delete_status = 404;
+	config.http_response.object_delete_body =
+	    "<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message></Error>";
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	S3TestHelper::LoadExtension(db);
+	ConfigureDirectDelete(con, server, client_implementation);
+
+	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+	ErrorData error;
+	bool threw = false;
+	try {
+		auto &fs = FileSystem::GetFileSystem(*con.context);
+		fs.RemoveFile(S3TestHelper::S3_PATH);
+	} catch (std::exception &ex) {
+		error = ErrorData(ex);
+		threw = true;
+	}
+	REQUIRE(threw);
+	REQUIRE(error.Type() == ExceptionType::HTTP);
+	REQUIRE(error.ExtraInfo().at("status_code") == "404");
+	REQUIRE(StringUtil::Contains(error.ExtraInfo().at("response_body"), "NoSuchKey"));
+	S3TestHelper::RequireQueryOk(con, "ROLLBACK");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(observations.size() == 1);
+	REQUIRE(observations[0].method == "DELETE");
+	REQUIRE(observations[0].status == 404);
+}
+
 static S3AuthParams ReadSecretAuthParams(Connection &con, KeyValueSecret &secret,
                                          const string &path = "s3://bucket/key") {
 	ClientContextFileOpener opener(*con.context);
@@ -2229,6 +2313,20 @@ TEST_CASE("GCS bearer authentication is shared by object, list and bulk-delete r
 	}
 	SECTION("curl") {
 		RunGCSBearerRequestScenario("curl");
+	}
+}
+
+TEST_CASE("S3 single-object delete does not probe object metadata", "[httpfs][s3][delete]") {
+	for (const string client_implementation : {"httplib", "curl"}) {
+		DYNAMIC_SECTION(client_implementation << " accepts an existing-object 200 response") {
+			RunDirectDeleteSuccessScenario(client_implementation, 200);
+		}
+		DYNAMIC_SECTION(client_implementation << " accepts an idempotent missing-object 204 response") {
+			RunDirectDeleteSuccessScenario(client_implementation, 204);
+		}
+		DYNAMIC_SECTION(client_implementation << " preserves an actual DELETE 404") {
+			RunDirectDeleteErrorScenario(client_implementation);
+		}
 	}
 }
 

--- a/test/unittest/s3/s3_retry_test.cpp
+++ b/test/unittest/s3/s3_retry_test.cpp
@@ -376,6 +376,34 @@ static void RunTransientDeleteRetryScenario(const string &client_implementation)
 	INFO(MockS3DescribeObservations(observations));
 	REQUIRE(S3TestHelper::CountObservations(observations, "DELETE", S3TestHelper::STALE_KEY_ID, 400) == 2);
 	REQUIRE(S3TestHelper::CountObservations(observations, "DELETE", S3TestHelper::STALE_KEY_ID, 204) == 1);
+	REQUIRE(observations.size() == 3);
+}
+
+static void RunDisconnectedDeleteRetryScenario(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.object.bucket = S3TestHelper::BUCKET;
+	config.object.key = S3TestHelper::OBJECT_KEY;
+	config.auth.stale_key_id = S3TestHelper::STALE_KEY_ID;
+	config.auth.refresh_target = MockS3RefreshTarget::PUT;
+	config.failures.transient_delete_disconnects = 2;
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	S3TestHelper::ConfigureRefresh(db, con, server, client_implementation, false);
+
+	S3TestHelper::RequireQueryOk(con, "SET http_retries=2");
+	S3TestHelper::RequireQueryOk(con, "SET http_retry_wait_ms=1");
+	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	fs.RemoveFile(S3TestHelper::S3_PATH);
+	S3TestHelper::RequireQueryOk(con, "COMMIT");
+
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(observations.size() == 3);
+	REQUIRE(S3TestHelper::CountObservations(observations, "DELETE", S3TestHelper::STALE_KEY_ID, 200) == 2);
+	REQUIRE(S3TestHelper::CountObservations(observations, "DELETE", S3TestHelper::STALE_KEY_ID, 204) == 1);
 }
 
 // HEAD responses carry no body, so a RequestTimeout 400 cannot be classified as transient:
@@ -841,6 +869,15 @@ TEST_CASE("HTTPFS retries transient S3 RequestTimeout across request types", "[h
 	}
 	SECTION("shared curl retries RequestTimeout on a fresh connection") {
 		RunFreshConnectionRetryScenario("curl", true);
+	}
+}
+
+TEST_CASE("HTTPFS retries disconnected S3 DELETE responses", "[httpfs][s3][delete][retry]") {
+	SECTION("httplib") {
+		RunDisconnectedDeleteRetryScenario("httplib");
+	}
+	SECTION("curl") {
+		RunDisconnectedDeleteRetryScenario("curl");
 	}
 }
 


### PR DESCRIPTION
S3 single-object deletes now send DELETE directly instead of issuing a HEAD request first. This allows deletion without read permission and keeps retry and credential-refresh handling on the DELETE request itself.