### PR TITLE
Add opt-in S3 SSE-C encryption support

### DIFF
--- a/src/create_secret_functions.cpp
+++ b/src/create_secret_functions.cpp
@@ -28,6 +28,16 @@ static Value MapToStruct(const Value &map) {
 	return Value::STRUCT(struct_fields);
 }
 
+static bool MapContainsKey(const Value &map, const string &name) {
+	for (const auto &kv_child : MapValue::GetChildren(map)) {
+		auto kv_pair = StructValue::GetChildren(kv_child);
+		if (kv_pair.size() == 2 && StringUtil::CIEquals(kv_pair[0].ToString(), name)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 struct S3SecretBuilder {
 public:
 	explicit S3SecretBuilder(CreateSecretInput &input_p) : input(input_p) {
@@ -88,6 +98,9 @@ private:
 		child_list_t<Value> struct_fields;
 		for (const auto &option : input.options) {
 			struct_fields.emplace_back(StringUtil::Lower(option.first), option.second);
+			if (StringUtil::CIEquals(option.first, "sse_c_key")) {
+				secret->redact_keys.insert("refresh_info");
+			}
 		}
 		secret->secret_map["refresh_info"] = Value::STRUCT(struct_fields);
 	}
@@ -97,6 +110,9 @@ private:
 			throw InvalidInputException("Can not set `refresh` and `refresh_info` at the same time");
 		}
 		refresh = true;
+		if (MapContainsKey(value, "sse_c_key")) {
+			secret->redact_keys.insert("refresh_info");
+		}
 		secret->secret_map["refresh_info"] = MapToStruct(value);
 	}
 

--- a/src/http/httpfs.cpp
+++ b/src/http/httpfs.cpp
@@ -35,6 +35,36 @@ HTTPUtil &HTTPFSUtil::GetHTTPUtil(optional_ptr<FileOpener> opener) {
 	throw InternalException("FileOpener not provided, can't get HTTPUtil");
 }
 
+void HTTPFSUtil::LogRequest(BaseRequest &request, optional_ptr<HTTPResponse> response) {
+	if (!request.params.logger || !request.params.logger->ShouldLog(HTTPLogType::NAME, HTTPLogType::LEVEL)) {
+		return;
+	}
+	if (!request.headers.HasHeader("x-amz-server-side-encryption-customer-key")) {
+		HTTPUtil::LogRequest(request, response);
+		return;
+	}
+	HTTPHeaders sanitized_headers;
+	for (const auto &header : request.headers) {
+		auto value = StringUtil::CIEquals(header.first, "x-amz-server-side-encryption-customer-key")
+		                 ? string("redacted")
+		                 : header.second;
+		sanitized_headers.Insert(header.first, std::move(value));
+	}
+	auto sanitized_params = request.params.Cast<HTTPFSParams>().Clone();
+	sanitized_params->extra_headers.clear();
+	BaseRequest sanitized_request(request.type, request.url, sanitized_headers, *sanitized_params);
+	sanitized_request.try_request = request.try_request;
+	sanitized_request.have_request_timing = request.have_request_timing;
+	sanitized_request.request_system_start = request.request_system_start;
+	sanitized_request.request_monotonic_start = request.request_monotonic_start;
+	sanitized_request.request_monotonic_end = request.request_monotonic_end;
+	sanitized_request.request_body_length = request.request_body_length;
+	sanitized_request.have_time_to_fst_byte = request.have_time_to_fst_byte;
+	sanitized_request.time_to_fst_byte_sec = request.time_to_fst_byte_sec;
+	sanitized_request.bytes_received = request.bytes_received;
+	HTTPUtil::LogRequest(sanitized_request, response);
+}
+
 struct HTTPParametersInitializer {
 private:
 	HTTPParametersInitializer(HTTPFSUtil &httpfs_util_p, optional_ptr<FileOpener> opener_p,

--- a/src/http/httpfs.cpp
+++ b/src/http/httpfs.cpp
@@ -43,25 +43,8 @@ void HTTPFSUtil::LogRequest(BaseRequest &request, optional_ptr<HTTPResponse> res
 		HTTPUtil::LogRequest(request, response);
 		return;
 	}
-	HTTPHeaders sanitized_headers;
-	for (const auto &header : request.headers) {
-		auto value = StringUtil::CIEquals(header.first, "x-amz-server-side-encryption-customer-key")
-		                 ? string("redacted")
-		                 : header.second;
-		sanitized_headers.Insert(header.first, std::move(value));
-	}
-	auto sanitized_params = request.params.Cast<HTTPFSParams>().Clone();
-	sanitized_params->extra_headers.clear();
-	BaseRequest sanitized_request(request.type, request.url, sanitized_headers, *sanitized_params);
-	sanitized_request.try_request = request.try_request;
-	sanitized_request.have_request_timing = request.have_request_timing;
-	sanitized_request.request_system_start = request.request_system_start;
-	sanitized_request.request_monotonic_start = request.request_monotonic_start;
-	sanitized_request.request_monotonic_end = request.request_monotonic_end;
-	sanitized_request.request_body_length = request.request_body_length;
-	sanitized_request.have_time_to_fst_byte = request.have_time_to_fst_byte;
-	sanitized_request.time_to_fst_byte_sec = request.time_to_fst_byte_sec;
-	sanitized_request.bytes_received = request.bytes_received;
+	auto sanitized_request = request;
+	sanitized_request.headers["x-amz-server-side-encryption-customer-key"] = "redacted";
 	HTTPUtil::LogRequest(sanitized_request, response);
 }
 

--- a/src/include/http/httpfs_client.hpp
+++ b/src/include/http/httpfs_client.hpp
@@ -104,6 +104,7 @@ public:
 	unique_ptr<HTTPParams> InitializeParameters(optional_ptr<FileOpener> opener,
 	                                            optional_ptr<FileOpenerInfo> info) override;
 	unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
+	void LogRequest(BaseRequest &request, optional_ptr<HTTPResponse> response) override;
 
 	//! Clear any cached connections
 	virtual void ClearCachedConnections();

--- a/src/include/s3/s3_auth.hpp
+++ b/src/include/s3/s3_auth.hpp
@@ -11,6 +11,27 @@ namespace duckdb {
 
 enum class S3EndpointMode : uint8_t { AUTOMATIC, EXPLICIT };
 
+class S3SSECustomerKey {
+public:
+	static S3SSECustomerKey Create(const string &key);
+
+public:
+	const string &GetKey() const {
+		return key;
+	}
+	const string &GetKeyMD5() const {
+		return key_md5;
+	}
+	bool operator==(const S3SSECustomerKey &other) const;
+
+private:
+	S3SSECustomerKey(string key_p, string key_md5_p);
+
+private:
+	string key;
+	string key_md5;
+};
+
 struct S3AuthCredentials {
 	string region;
 	string access_key_id;
@@ -33,7 +54,11 @@ struct S3AuthURLParams {
 };
 
 struct S3AuthRequestOptions {
+	//! Server-side encryption
 	string kms_key_id;
+	optional<S3SSECustomerKey> sse_customer_key;
+
+	//! Request billing
 	bool requester_pays = false;
 	string user_project;
 

--- a/src/include/s3/s3_provider.hpp
+++ b/src/include/s3/s3_provider.hpp
@@ -67,7 +67,7 @@ struct S3SecretConfig {
 	static constexpr const char *AWS_SECRET_TYPE = "aws";
 
 	static const array<const char *, 4> &SecretTypes();
-	static const array<const char *, 13> &CredentialMaterialKeys();
+	static const array<const char *, 14> &CredentialMaterialKeys();
 
 	static vector<string> DefaultSecretScope(const string &secret_type);
 	static void SetSecretNamedParameters(const string &secret_type, CreateSecretFunction &function);
@@ -93,6 +93,7 @@ public:
 	S3AuthType GetAuthType(const S3AuthParams &auth_params) const;
 	S3MultipartUploadPolicy GetMultipartUploadPolicy() const;
 	idx_t GetBulkDeleteMaxBatchSize() const;
+	bool SupportsSSECustomerKey() const;
 	string GetBadRequestError(const S3AuthParams &auth_params, const string &correct_region = "") const;
 	string GetAuthError(const S3AuthParams &auth_params) const;
 

--- a/src/include/s3/s3_request.hpp
+++ b/src/include/s3/s3_request.hpp
@@ -56,6 +56,7 @@ struct S3RequestOperationInfo {
 	bool retry_timeout;
 	bool retry_received_response;
 	bool uses_kms_headers;
+	bool uses_sse_customer_headers;
 };
 
 struct S3RequestQuery {

--- a/src/s3/s3_auth.cpp
+++ b/src/s3/s3_auth.cpp
@@ -2,11 +2,40 @@
 
 #include "s3/s3_url.hpp"
 
+#include "duckdb/common/crypto/md5.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/blob.hpp"
 
 #include <cstdlib>
 
 namespace duckdb {
+
+S3SSECustomerKey::S3SSECustomerKey(string key_p, string key_md5_p)
+    : key(std::move(key_p)), key_md5(std::move(key_md5_p)) {
+}
+
+S3SSECustomerKey S3SSECustomerKey::Create(const string &key) {
+	string decoded_key;
+	try {
+		decoded_key = Blob::FromBase64(key);
+	} catch (std::exception &) {
+		throw InvalidInputException("SSE_C_KEY must be a valid base64-encoded 256-bit key");
+	}
+	if (decoded_key.size() != 32 || Blob::ToBase64(decoded_key) != key) {
+		throw InvalidInputException("SSE_C_KEY must be a valid base64-encoded 256-bit key");
+	}
+
+	MD5Context md5_context;
+	md5_context.Add(decoded_key);
+	data_t md5_hash[MD5Context::MD5_HASH_LENGTH_BINARY];
+	md5_context.Finish(md5_hash);
+	string_t md5_blob(const_char_ptr_cast(md5_hash), MD5Context::MD5_HASH_LENGTH_BINARY);
+	return S3SSECustomerKey(key, Blob::ToBase64(md5_blob));
+}
+
+bool S3SSECustomerKey::operator==(const S3SSECustomerKey &other) const {
+	return key == other.key && key_md5 == other.key_md5;
+}
 
 void AWSEnvironmentCredentialsProvider::SetExtensionOptionValue(const Identifier &key, const char *env_var_name) {
 	const auto env_value = std::getenv(env_var_name);
@@ -47,8 +76,8 @@ bool S3AuthURLParams::operator==(const S3AuthURLParams &other) const {
 }
 
 bool S3AuthRequestOptions::operator==(const S3AuthRequestOptions &other) const {
-	return kms_key_id == other.kms_key_id && requester_pays == other.requester_pays &&
-	       user_project == other.user_project;
+	return kms_key_id == other.kms_key_id && sse_customer_key == other.sse_customer_key &&
+	       requester_pays == other.requester_pays && user_project == other.user_project;
 }
 
 S3AuthParams S3AuthResolver::Resolve(optional_ptr<FileOpener> opener, FileOpenerInfo &info) {
@@ -86,6 +115,10 @@ S3AuthConfig S3AuthResolver::ReadConfig(S3KeyValueReader &secret_reader, const s
 	secret_reader.TryGetSecretKeyOrSetting("session_token", "s3_session_token", credentials.session_token);
 	secret_reader.TryGetSecretKeyOrSetting("use_ssl", "s3_use_ssl", config.use_ssl);
 	secret_reader.TryGetSecretKeyOrSetting("kms_key_id", "s3_kms_key_id", request_options.kms_key_id);
+	string sse_c_key;
+	if (secret_reader.TryGetSecretKey("sse_c_key", sse_c_key)) {
+		request_options.sse_customer_key = S3SSECustomerKey::Create(sse_c_key);
+	}
 	secret_reader.TryGetSecretKeysOrSetting("url_compatibility_mode", "s3_url_compatibility_mode",
 	                                        "s3_url_compatibility_mode", config.compatibility_mode);
 	secret_reader.TryGetSecretKeyOrSetting("requester_pays", "s3_requester_pays", request_options.requester_pays);
@@ -194,6 +227,20 @@ S3AuthParams S3AuthResolver::Resolve(S3AuthConfig config, const string &file_pat
 	result.url = {std::move(endpoint), config.endpoint_mode, style, config.compatibility_mode};
 	result.request_options = std::move(request_options);
 	result.refresh_identity = {config.use_ssl};
+	if (result.request_options.sse_customer_key) {
+		if (!result.request_options.kms_key_id.empty()) {
+			throw InvalidInputException("SSE_C_KEY and KMS_KEY_ID cannot be configured together");
+		}
+		if (!result.provider.SupportsSSECustomerKey()) {
+			throw InvalidInputException("SSE_C_KEY is only supported for S3-compatible endpoints");
+		}
+		if (!result.url.endpoint.UsesSSL()) {
+			throw InvalidInputException("SSE_C_KEY requires an HTTPS endpoint");
+		}
+		if (result.credentials.access_key_id.empty() || result.credentials.secret_access_key.empty()) {
+			throw InvalidInputException("SSE_C_KEY requires both KEY_ID and SECRET for signed S3 requests");
+		}
+	}
 	return result;
 }
 

--- a/src/s3/s3_delete.cpp
+++ b/src/s3/s3_delete.cpp
@@ -54,6 +54,11 @@ static void AddDeleteAuthHash(hash_t &result, const S3AuthParams &auth_params) {
 
 	auto &request_options = auth_params.GetRequestOptions();
 	AddDeleteHash(result, request_options.kms_key_id);
+	AddDeleteHash(result, static_cast<idx_t>(request_options.sse_customer_key.has_value()));
+	if (request_options.sse_customer_key) {
+		AddDeleteHash(result, request_options.sse_customer_key->GetKey());
+		AddDeleteHash(result, request_options.sse_customer_key->GetKeyMD5());
+	}
 	AddDeleteHash(result, static_cast<idx_t>(request_options.requester_pays));
 	AddDeleteHash(result, request_options.user_project);
 }

--- a/src/s3/s3_provider.cpp
+++ b/src/s3/s3_provider.cpp
@@ -116,11 +116,11 @@ const array<const char *, 4> &S3SecretConfig::SecretTypes() {
 	return SECRET_TYPES;
 }
 
-const array<const char *, 13> &S3SecretConfig::CredentialMaterialKeys() {
-	static constexpr array<const char *, 13> CREDENTIAL_MATERIAL_KEYS = {
-	    "key_id",    "secret",  "session_token",          "region",         "endpoint",     "kms_key_id",
-	    "url_style", "use_ssl", "url_compatibility_mode", "requester_pays", "bearer_token", "user_project",
-	    "account_id"};
+const array<const char *, 14> &S3SecretConfig::CredentialMaterialKeys() {
+	static constexpr array<const char *, 14> CREDENTIAL_MATERIAL_KEYS = {
+	    "key_id",     "secret",   "session_token",          "region",         "endpoint",     "kms_key_id",
+	    "url_style",  "use_ssl",  "url_compatibility_mode", "requester_pays", "bearer_token", "user_project",
+	    "account_id", "sse_c_key"};
 	return CREDENTIAL_MATERIAL_KEYS;
 }
 
@@ -191,7 +191,9 @@ vector<string> S3SecretConfig::DefaultSecretScope(const string &secret_type) {
 }
 
 void S3SecretConfig::SetSecretNamedParameters(const string &secret_type, CreateSecretFunction &function) {
-	if (secret_type == R2_SECRET_TYPE) {
+	if (secret_type == S3_SECRET_TYPE) {
+		function.named_parameters["sse_c_key"] = LogicalType::VARCHAR;
+	} else if (secret_type == R2_SECRET_TYPE) {
 		function.named_parameters["account_id"] = LogicalType::VARCHAR;
 	} else if (secret_type == GCS_SECRET_TYPE) {
 		function.named_parameters["bearer_token"] = LogicalType::VARCHAR;
@@ -213,6 +215,12 @@ void S3SecretConfig::ApplySecretDefaults(const CreateSecretInput &input, KeyValu
 
 bool S3SecretConfig::TryApplySecretOption(const CreateSecretInput &input, const string &name, const Value &value,
                                           KeyValueSecret &secret) {
+	if (name == "sse_c_key" && input.type == S3_SECRET_TYPE) {
+		auto sse_customer_key = S3SSECustomerKey::Create(value.ToString());
+		secret.secret_map["sse_c_key"] = sse_customer_key.GetKey();
+		secret.redact_keys.insert("sse_c_key");
+		return true;
+	}
 	if (name == "account_id" && input.type == R2_SECRET_TYPE) {
 		return true;
 	}
@@ -297,6 +305,10 @@ S3MultipartUploadPolicy S3Provider::GetMultipartUploadPolicy() const {
 
 idx_t S3Provider::GetBulkDeleteMaxBatchSize() const {
 	return profile == S3CompatibilityProfile::R2 ? 700 : 1000;
+}
+
+bool S3Provider::SupportsSSECustomerKey() const {
+	return profile == S3CompatibilityProfile::S3;
 }
 
 string S3Provider::GetBadRequestError(const S3AuthParams &auth_params, const string &correct_region) const {

--- a/src/s3/s3_request.cpp
+++ b/src/s3/s3_request.cpp
@@ -82,20 +82,25 @@ const string &S3RequestQuery::CanonicalQuery() const {
 
 const S3RequestOperationInfo &S3RequestUtil::GetOperationInfo(S3RequestOperation operation) {
 	static const array<S3RequestOperationInfo, 10> OPERATION_INFO = {
-	    S3RequestOperationInfo {RequestType::HEAD_REQUEST, S3RequestTarget::OBJECT, "checking", true, false, false},
-	    S3RequestOperationInfo {RequestType::GET_REQUEST, S3RequestTarget::OBJECT, "reading", true, false, false},
-	    S3RequestOperationInfo {RequestType::PUT_REQUEST, S3RequestTarget::OBJECT, "uploading to", true, false, true},
-	    S3RequestOperationInfo {RequestType::DELETE_REQUEST, S3RequestTarget::OBJECT, "deleting", true, false, false},
-	    S3RequestOperationInfo {RequestType::GET_REQUEST, S3RequestTarget::BUCKET, "listing", true, false, false},
-	    S3RequestOperationInfo {RequestType::POST_REQUEST, S3RequestTarget::BUCKET, "bulk-deleting from", false, false,
+	    S3RequestOperationInfo {RequestType::HEAD_REQUEST, S3RequestTarget::OBJECT, "checking", true, false, false,
+	                            true},
+	    S3RequestOperationInfo {RequestType::GET_REQUEST, S3RequestTarget::OBJECT, "reading", true, false, false, true},
+	    S3RequestOperationInfo {RequestType::PUT_REQUEST, S3RequestTarget::OBJECT, "uploading to", true, false, true,
+	                            true},
+	    S3RequestOperationInfo {RequestType::DELETE_REQUEST, S3RequestTarget::OBJECT, "deleting", true, false, false,
 	                            false},
+	    S3RequestOperationInfo {RequestType::GET_REQUEST, S3RequestTarget::BUCKET, "listing", true, false, false,
+	                            false},
+	    S3RequestOperationInfo {RequestType::POST_REQUEST, S3RequestTarget::BUCKET, "bulk-deleting from", false, false,
+	                            false, false},
 	    S3RequestOperationInfo {RequestType::POST_REQUEST, S3RequestTarget::OBJECT, "initializing multipart upload for",
-	                            false, false, true},
-	    S3RequestOperationInfo {RequestType::PUT_REQUEST, S3RequestTarget::OBJECT, "uploading to", true, false, false},
+	                            false, false, true, true},
+	    S3RequestOperationInfo {RequestType::PUT_REQUEST, S3RequestTarget::OBJECT, "uploading to", true, false, false,
+	                            true},
 	    S3RequestOperationInfo {RequestType::POST_REQUEST, S3RequestTarget::OBJECT, "completing multipart upload for",
-	                            false, true, false},
+	                            false, true, false, true},
 	    S3RequestOperationInfo {RequestType::DELETE_REQUEST, S3RequestTarget::OBJECT, "aborting multipart upload for",
-	                            true, false, false}};
+	                            true, false, false, false}};
 	auto index = static_cast<idx_t>(operation);
 	if (index >= OPERATION_INFO.size()) {
 		throw InternalException("Unknown S3 request operation");
@@ -144,6 +149,9 @@ private:
 		    {"x-amz-request-payer", "x-amz-request-payer"},
 		    {"x-amz-server-side-encryption", "x-amz-server-side-encryption"},
 		    {"x-amz-server-side-encryption-aws-kms-key-id", "x-amz-server-side-encryption-aws-kms-key-id"},
+		    {"x-amz-server-side-encryption-customer-algorithm", "x-amz-server-side-encryption-customer-algorithm"},
+		    {"x-amz-server-side-encryption-customer-key", "x-amz-server-side-encryption-customer-key"},
+		    {"x-amz-server-side-encryption-customer-key-md5", "x-amz-server-side-encryption-customer-key-md5"},
 		};
 		return headers;
 	}
@@ -168,6 +176,8 @@ public:
 	      content_md5(std::move(content_md5_p)),
 	      use_sse_kms(!auth_params.GetRequestOptions().kms_key_id.empty() &&
 	                  S3RequestUtil::GetOperationInfo(operation_p).uses_kms_headers),
+	      use_sse_customer(auth_params.GetRequestOptions().sse_customer_key.has_value() &&
+	                       S3RequestUtil::GetOperationInfo(operation_p).uses_sse_customer_headers),
 	      headers(headers_p) {
 	}
 
@@ -207,6 +217,12 @@ private:
 		if (use_sse_kms) {
 			headers["x-amz-server-side-encryption"] = "aws:kms";
 			headers["x-amz-server-side-encryption-aws-kms-key-id"] = request_options.kms_key_id;
+		}
+		if (use_sse_customer) {
+			auto &sse_customer_key = *request_options.sse_customer_key;
+			headers["x-amz-server-side-encryption-customer-algorithm"] = "AES256";
+			headers["x-amz-server-side-encryption-customer-key"] = sse_customer_key.GetKey();
+			headers["x-amz-server-side-encryption-customer-key-md5"] = sse_customer_key.GetKeyMD5();
 		}
 		if (request_options.requester_pays && auth_params.GetProvider().GetType() != S3ProviderType::GCS) {
 			headers["x-amz-request-payer"] = "requester";
@@ -312,6 +328,7 @@ private:
 	const string content_type;
 	const string content_md5;
 	const bool use_sse_kms;
+	const bool use_sse_customer;
 	HTTPHeaders &headers;
 };
 

--- a/test/unittest/s3/CMakeLists.txt
+++ b/test/unittest/s3/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(
           s3_refresh_test.cpp
           s3_request_test.cpp
           s3_retry_test.cpp
+          s3_sse_test.cpp
           s3_test_helper.cpp
           scheme_alias_isolation_test.cpp
           s3_upload_config_test.cpp

--- a/test/unittest/s3/mock_s3_server.cpp
+++ b/test/unittest/s3/mock_s3_server.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/atomic.hpp"
 #include "duckdb/common/string_util.hpp"
 
+#define CPPHTTPLIB_OPENSSL_SUPPORT
 #include "httplib.hpp"
 
 #include <algorithm>
@@ -15,11 +16,62 @@
 #include <sstream>
 #include <thread>
 
-namespace httplib = duckdb_httplib;
+namespace httplib = duckdb_httplib_openssl;
 
 namespace duckdb {
 
 namespace {
+
+static constexpr const char *MOCK_S3_CERTIFICATE = R"PEM(-----BEGIN CERTIFICATE-----
+MIIDGjCCAgKgAwIBAgIUTWCWMe9mqyP+NK8dRswpg8l39ikwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJMTI3LjAuMC4xMB4XDTI2MDkwNDExNTExNVoXDTM2MDkw
+MTExNTExNVowFDESMBAGA1UEAwwJMTI3LjAuMC4xMIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAsdJ0J+1+qfChJ69UxVidlhNoKcTLIUh5J8NILk/2nV2n
+OFSEFKB1Z2Xsf+6f/1WqRIr+w6Vx+D6/dDJ4fkcSVfjWbSuVM7Jvhw3riBlZMLPW
+LBh0AGiqeQ84oAHdiZzrDDqS3NZH9/GFVPrwCqbhN7jigSeiNVykov/Zd3sHCmWL
+qER+F7aJaSgr2aLiUJKa1dnATS2xLcaW8St6v0i3kuHZQhmpJm+OI9qOUB0JdgRp
+9WT6r7jZJQINDIG13JdKv53XSRFKAMT8uPdIzK0MlXJd/QpnJ5oXqPN2Zgjq4SvP
+H3y9Osk04PyvLwgNsw6scpvEeJSHkgmIO+yZIneUUwIDAQABo2QwYjAdBgNVHQ4E
+FgQU2+5vFidU38L24c5zLZu//7xYTf0wHwYDVR0jBBgwFoAU2+5vFidU38L24c5z
+LZu//7xYTf0wDwYDVR0TAQH/BAUwAwEB/zAPBgNVHREECDAGhwR/AAABMA0GCSqG
+SIb3DQEBCwUAA4IBAQBXIKqqQccLkEuPDfTrJWXRjmk35LY9XxxlMubjeF8rtefJ
+/fvP0PdVslLwtmYMOFD1e+gDs1Gk2rXEYUvL5te2TpfQ1QTPekCAIu7l42scR6Wc
+JwKT0jkQENDXGOv5ERzan9YX3BLT086CX9q0EKQHbrCdiSyMqzEQ1tEc2yQq/Ci2
+td+RzMrYLC8gYCYfLHrqgrMbTYJg9UMxY6co0YbnfvGVjfch4HWps6gu2CoTLP3Y
+lFDLBg7vN8Q+bB/ky1IaUOD2s0NHL6uPuuB/xgHhMEhZqZ386KjtleXQhKzaHSpL
+IQCRTdLYcFvfpO3Vvv+nCD8swRidMXTzwoGBxINq
+-----END CERTIFICATE-----
+)PEM";
+
+static constexpr const char *MOCK_S3_PRIVATE_KEY = R"PEM(-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCx0nQn7X6p8KEn
+r1TFWJ2WE2gpxMshSHknw0guT/adXac4VIQUoHVnZex/7p//VapEiv7DpXH4Pr90
+Mnh+RxJV+NZtK5Uzsm+HDeuIGVkws9YsGHQAaKp5DzigAd2JnOsMOpLc1kf38YVU
++vAKpuE3uOKBJ6I1XKSi/9l3ewcKZYuoRH4XtolpKCvZouJQkprV2cBNLbEtxpbx
+K3q/SLeS4dlCGakmb44j2o5QHQl2BGn1ZPqvuNklAg0MgbXcl0q/nddJEUoAxPy4
+90jMrQyVcl39Cmcnmheo83ZmCOrhK88ffL06yTTg/K8vCA2zDqxym8R4lIeSCYg7
+7Jkid5RTAgMBAAECggEAStb+0SEpCp/+S4QE4wwBQv0G/XFYZrkoWJ5dXjSEYEXe
+z5vufPntf6eLimplh2LIBxIS2Efk+Cx8ioyFXuxNoMZahNbvdDMYslge9Yhpm9BM
+hwGBrPxgJxRLajhuw3C6EksCrZQ39Pf+/D2i0nDa4AdduSrzn47OsdWJcrpiQ7K1
+/I54L8q3L9FpW7NH1co0HUH3Knhed7BwCL8+bWI/8r5rCdlsq2auuzygGmhy7Ztx
+Lnb2K+/9vCdthRAGm1tMGwikkNuHLB7N1FzEHFizsV9PeuAZE7TQdn3FD4ZVCl7e
+G9HpeSBJVS4TAAc1/2aGGg1JU3j/haJ8p5TuApzLjQKBgQDoZDJXmssLkZDZIy2y
+InUPDUebcyvl/fne1L/tX9Nxmtq7DQqPLv7RMCPpMwKIAHvzaRhtZMDYaay/us97
+aV3Zu7U00uy9+Nx0A/98J6+uKk+Q61W60FRFzspDNZzg6X7Md8EgyTBYHS8POasY
+veneZcQj+oh5Ta1LTAZTKNho1QKBgQDD4xKvt9MA0ZzyJkumT6qxBSwKqkcibN3U
+7EVlOcUbhpkpErf9+wdpzCO5bOYJIvHxGAbhh8cp0FldmAihaabTcchPzq4rRvOQ
+s3758ymq+DObKrQ9+Fq7w76b5u8hnT194p4W4bBgdO/KxZrATKWsy3T6STl5O2+x
+iDopOd0chwKBgCQk2VOYxrXA6SdsekH3a/9wUE/UJOK7kq5epo8z1T4ZGKX5DEhi
+xc0hUKSHg4BFmwGrudnhzsCaBv02/+gw5iDkOfXCTIHrf9YnfQgBYCiVehSPFaFd
+n43P8NNtNj4g8tC4W3hO8k7yEwyqKntJpmMprsztvWYod6h7ZYxvkOEVAoGBAJ/9
+W6rHMgBuM4iXfJwWX2x7s+/2CWl1j20zmK5Hk9Sah4fDcSFwoSppABiXd/6oWwE2
+RZB4jFN7hzHpVcs39nimaxu7zAcuyQo7gI73auXoGIY4R8SBjuHiy1CcOl2zBqFF
+sScxKBRwDdYItQ8wyvQprJ4rplR9FgnjINXBG/YLAoGBAI5RE5/d9aE5MWFica+4
+R5PhVuehUuFW1r/Bk4wPNc3/kl3sithuZK4UDyYMB6vtWXrBujP0Ay2Q8uvyiwU2
+/fnxG36kuDL67cFGDSJVTSmt3S9OuD49hzZtX4Kqk/ccPglD5YYQBrupVuy81TUJ
+sQvWtXkxKsNfOUe42TX0hn78
+-----END PRIVATE KEY-----
+)PEM";
 
 static ssize_t WriteMockResponseHeaders(httplib::Stream &stream, httplib::Headers &headers) {
 	ssize_t total_size = 0;
@@ -265,7 +317,26 @@ public:
 	};
 
 public:
-	explicit Impl(MockS3ServerConfig config_p) : config(std::move(config_p)) {
+	static unique_ptr<httplib::Server> CreateServer(bool use_ssl) {
+		if (!use_ssl) {
+			return make_uniq<httplib::Server>();
+		}
+		httplib::SSLServer::PemMemory pem {MOCK_S3_CERTIFICATE,
+		                                   strlen(MOCK_S3_CERTIFICATE),
+		                                   MOCK_S3_PRIVATE_KEY,
+		                                   strlen(MOCK_S3_PRIVATE_KEY),
+		                                   nullptr,
+		                                   0,
+		                                   nullptr};
+		auto result = make_uniq<httplib::SSLServer>(pem);
+		if (!result->is_valid()) {
+			throw IOException("Failed to initialize mock S3 TLS server");
+		}
+		return result;
+	}
+
+	explicit Impl(MockS3ServerConfig config_p)
+	    : config(std::move(config_p)), server_owner(CreateServer(config.use_ssl)), server(*server_owner) {
 		uploaded_object = config.upload.initial_published_object;
 		remaining_put_failures = config.failures.transient_put_failures;
 		remaining_get_failures = config.failures.transient_get_failures;
@@ -310,8 +381,8 @@ public:
 	}
 
 	string HTTPPath() const {
-		return StringUtil::Format("http://%s%s/%s/%s", Endpoint(), config.endpoint_base_path, config.object.bucket,
-		                          config.object.key);
+		return StringUtil::Format("%s://%s%s/%s/%s", config.use_ssl ? "https" : "http", Endpoint(),
+		                          config.endpoint_base_path, config.object.bucket, config.object.key);
 	}
 
 	vector<MockS3RequestObservation> Observations() const DUCKDB_EXCLUDES(observation_lock) {
@@ -429,7 +500,10 @@ public:
 	void Record(const httplib::Request &request, int status) const DUCKDB_EXCLUDES(observation_lock, upload_lock) {
 		MockS3RequestObservation observation;
 		for (const auto &header : request.headers) {
-			observation.headers.emplace_back(header.first, header.second);
+			auto value = StringUtil::CIEquals(header.first, "x-amz-server-side-encryption-customer-key")
+			                 ? string("redacted")
+			                 : header.second;
+			observation.headers.emplace_back(header.first, std::move(value));
 		}
 		observation.method = request.method;
 		observation.path = request.path;
@@ -445,6 +519,15 @@ public:
 		observation.upload_id = GetParameter(request, "uploadId");
 		observation.server_side_encryption = GetHeader(request, "x-amz-server-side-encryption");
 		observation.kms_key_id = GetHeader(request, "x-amz-server-side-encryption-aws-kms-key-id");
+		observation.sse_customer_algorithm = GetHeader(request, "x-amz-server-side-encryption-customer-algorithm");
+		observation.sse_customer_key_md5 = GetHeader(request, "x-amz-server-side-encryption-customer-key-md5");
+		observation.has_sse_customer_key = request.has_header("x-amz-server-side-encryption-customer-key");
+		if (observation.has_sse_customer_key) {
+			auto raw_key = GetHeader(request, "x-amz-server-side-encryption-customer-key");
+			observation.sse_customer_key_matches =
+			    std::find(config.sse_customer.accepted_keys.begin(), config.sse_customer.accepted_keys.end(),
+			              raw_key) != config.sse_customer.accepted_keys.end();
+		}
 		observation.part_number = GetPartNumber(request);
 		observation.body_size = request.body.size();
 		observation.body_digest = MockS3BodyDigest::Compute(request.body);
@@ -1214,7 +1297,8 @@ public:
 public:
 	//! Server configuration and lifetime
 	MockS3ServerConfig config;
-	httplib::Server server;
+	unique_ptr<httplib::Server> server_owner;
+	httplib::Server &server;
 	std::thread server_thread;
 	int port = 0;
 
@@ -1395,14 +1479,18 @@ string MockS3DescribeObservations(const vector<MockS3RequestObservation> &observ
 		result += StringUtil::Format(
 		    "%s %s status=%d key=%s region=%s range=%s if_match=%s version_id=%s target=%s upload_id=%s "
 		    "part_number=%s body_size=%llu delete_key_count=%llu body_digest=%s published=%s sse=%s "
-		    "kms_key_id=%s user_agent=%s "
+		    "kms_key_id=%s sse_customer_algorithm=%s sse_customer_key_md5=%s sse_customer_key=%s "
+		    "sse_customer_key_matches=%s user_agent=%s "
 		    "session_header=%s",
 		    observation.method, observation.path, observation.status, observation.key_id, observation.region,
 		    observation.range, observation.if_match, observation.version_id, observation.target, observation.upload_id,
 		    observation.part_number.IsValid() ? std::to_string(observation.part_number.GetIndex()) : string(),
 		    observation.body_size, observation.delete_key_count, observation.body_digest,
 		    observation.multipart_upload_published ? "true" : "false", observation.server_side_encryption,
-		    observation.kms_key_id, observation.user_agent, observation.session_header);
+		    observation.kms_key_id, observation.sse_customer_algorithm, observation.sse_customer_key_md5,
+		    observation.has_sse_customer_key ? "redacted" : "absent",
+		    observation.sse_customer_key_matches ? "true" : "false", observation.user_agent,
+		    observation.session_header);
 	}
 	return result;
 }

--- a/test/unittest/s3/mock_s3_server.hpp
+++ b/test/unittest/s3/mock_s3_server.hpp
@@ -187,9 +187,15 @@ struct MockS3UploadConfig {
 	MockS3MultipartGeometry geometry = MockS3MultipartGeometry::FLEXIBLE;
 };
 
+struct MockS3SSECustomerConfig {
+	//! Raw keys accepted by the mock; request observations never retain them
+	vector<string> accepted_keys;
+};
+
 struct MockS3ServerConfig {
 	//! Path prefix configured as part of the endpoint, without a trailing slash
 	string endpoint_base_path;
+	bool use_ssl = false;
 	MockS3ObjectConfig object;
 	MockS3AuthConfig auth;
 	MockS3MetadataConfig metadata;
@@ -199,6 +205,7 @@ struct MockS3ServerConfig {
 	MockS3RangeConfig range;
 	MockS3FullGetConfig full_get;
 	MockS3UploadConfig upload;
+	MockS3SSECustomerConfig sse_customer;
 	MockS3HTTPResponseConfig http_response;
 };
 
@@ -218,6 +225,8 @@ struct MockS3RequestObservation {
 	string upload_id;
 	string server_side_encryption;
 	string kms_key_id;
+	string sse_customer_algorithm;
+	string sse_customer_key_md5;
 	string body_digest;
 	optional_idx part_number;
 	idx_t body_size = 0;
@@ -226,6 +235,8 @@ struct MockS3RequestObservation {
 	idx_t session_header_count = 0;
 	int status = 0;
 	bool multipart_upload_published = false;
+	bool has_sse_customer_key = false;
+	bool sse_customer_key_matches = false;
 	//! Client's ephemeral source port; a new connection shows a new port
 	int remote_port = 0;
 };

--- a/test/unittest/s3/s3_request_test.cpp
+++ b/test/unittest/s3/s3_request_test.cpp
@@ -312,6 +312,9 @@ CREATE SECRET s3_rejected_headers (
 	    {"X-AMZ-REQUEST-PAYER", "x-amz-request-payer"},
 	    {"X-AMZ-SERVER-SIDE-ENCRYPTION", "x-amz-server-side-encryption"},
 	    {"X-AMZ-SERVER-SIDE-ENCRYPTION-AWS-KMS-KEY-ID", "x-amz-server-side-encryption-aws-kms-key-id"},
+	    {"X-AMZ-SERVER-SIDE-ENCRYPTION-CUSTOMER-ALGORITHM", "x-amz-server-side-encryption-customer-algorithm"},
+	    {"X-AMZ-SERVER-SIDE-ENCRYPTION-CUSTOMER-KEY", "x-amz-server-side-encryption-customer-key"},
+	    {"X-AMZ-SERVER-SIDE-ENCRYPTION-CUSTOMER-KEY-MD5", "x-amz-server-side-encryption-customer-key-md5"},
 	};
 	for (const auto &protected_header : protected_headers) {
 		S3TestHelper::RequireQueryOk(
@@ -1666,21 +1669,25 @@ TEST_CASE("S3 request operations define transport and retry policy", "[httpfs][s
 		bool retry_timeout;
 		bool retry_received_response;
 		bool uses_kms_headers;
+		bool uses_sse_customer_headers;
 	};
 	const array<ExpectedOperationInfo, 10> expected {{
-	    {S3RequestOperation::HEAD_OBJECT, RequestType::HEAD_REQUEST, S3RequestTarget::OBJECT, true, false, false},
-	    {S3RequestOperation::GET_OBJECT, RequestType::GET_REQUEST, S3RequestTarget::OBJECT, true, false, false},
-	    {S3RequestOperation::PUT_OBJECT, RequestType::PUT_REQUEST, S3RequestTarget::OBJECT, true, false, true},
-	    {S3RequestOperation::DELETE_OBJECT, RequestType::DELETE_REQUEST, S3RequestTarget::OBJECT, true, false, false},
-	    {S3RequestOperation::LIST_OBJECTS, RequestType::GET_REQUEST, S3RequestTarget::BUCKET, true, false, false},
-	    {S3RequestOperation::DELETE_OBJECTS, RequestType::POST_REQUEST, S3RequestTarget::BUCKET, false, false, false},
+	    {S3RequestOperation::HEAD_OBJECT, RequestType::HEAD_REQUEST, S3RequestTarget::OBJECT, true, false, false, true},
+	    {S3RequestOperation::GET_OBJECT, RequestType::GET_REQUEST, S3RequestTarget::OBJECT, true, false, false, true},
+	    {S3RequestOperation::PUT_OBJECT, RequestType::PUT_REQUEST, S3RequestTarget::OBJECT, true, false, true, true},
+	    {S3RequestOperation::DELETE_OBJECT, RequestType::DELETE_REQUEST, S3RequestTarget::OBJECT, true, false, false,
+	     false},
+	    {S3RequestOperation::LIST_OBJECTS, RequestType::GET_REQUEST, S3RequestTarget::BUCKET, true, false, false,
+	     false},
+	    {S3RequestOperation::DELETE_OBJECTS, RequestType::POST_REQUEST, S3RequestTarget::BUCKET, false, false, false,
+	     false},
 	    {S3RequestOperation::CREATE_MULTIPART_UPLOAD, RequestType::POST_REQUEST, S3RequestTarget::OBJECT, false, false,
-	     true},
-	    {S3RequestOperation::UPLOAD_PART, RequestType::PUT_REQUEST, S3RequestTarget::OBJECT, true, false, false},
+	     true, true},
+	    {S3RequestOperation::UPLOAD_PART, RequestType::PUT_REQUEST, S3RequestTarget::OBJECT, true, false, false, true},
 	    {S3RequestOperation::COMPLETE_MULTIPART_UPLOAD, RequestType::POST_REQUEST, S3RequestTarget::OBJECT, false, true,
-	     false},
+	     false, true},
 	    {S3RequestOperation::ABORT_MULTIPART_UPLOAD, RequestType::DELETE_REQUEST, S3RequestTarget::OBJECT, true, false,
-	     false},
+	     false, false},
 	}};
 
 	for (const auto &entry : expected) {
@@ -1690,6 +1697,7 @@ TEST_CASE("S3 request operations define transport and retry policy", "[httpfs][s
 		REQUIRE(info.retry_timeout == entry.retry_timeout);
 		REQUIRE(info.retry_received_response == entry.retry_received_response);
 		REQUIRE(info.uses_kms_headers == entry.uses_kms_headers);
+		REQUIRE(info.uses_sse_customer_headers == entry.uses_sse_customer_headers);
 	}
 }
 

--- a/test/unittest/s3/s3_sse_test.cpp
+++ b/test/unittest/s3/s3_sse_test.cpp
@@ -1,0 +1,592 @@
+#include "catch.hpp"
+
+#include "s3/mock_s3_server.hpp"
+#include "s3/s3_test_helper.hpp"
+
+#include "s3/s3_auth.hpp"
+#include "s3/s3_provider.hpp"
+
+#include "duckdb.hpp"
+#include "duckdb/catalog/catalog_transaction.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/multi_file/multi_file_list.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/main/client_context_file_opener.hpp"
+#include "duckdb/main/secret/secret.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
+#include "test_helpers.hpp"
+
+#include <algorithm>
+#include <cstring>
+
+namespace duckdb {
+
+namespace {
+
+static constexpr const char *SSE_C_KEY = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=";
+static constexpr const char *SSE_C_KEY_MD5 = "hRasmdxgYDKV3nvbahU1MA==";
+static constexpr const char *REFRESHED_SSE_C_KEY = "ZmVkY2JhOTg3NjU0MzIxMGZlZGNiYTk4NzY1NDMyMTA=";
+static constexpr const char *REFRESHED_SSE_C_KEY_MD5 = "dT1y7SEiqn6YCJ3QeqwoIw==";
+static constexpr const char *SSE_C_ALGORITHM_HEADER = "x-amz-server-side-encryption-customer-algorithm";
+static constexpr const char *SSE_C_KEY_HEADER = "x-amz-server-side-encryption-customer-key";
+static constexpr const char *SSE_C_KEY_MD5_HEADER = "x-amz-server-side-encryption-customer-key-md5";
+
+static string RequireQueryError(Connection &con, const string &query) {
+	auto result = con.Query(query);
+	REQUIRE(result);
+	REQUIRE(result->HasError());
+	return result->GetError();
+}
+
+template <class CALLBACK>
+static void RequireExceptionContains(CALLBACK callback, const string &expected) {
+	string error;
+	try {
+		callback();
+	} catch (std::exception &ex) {
+		error = ex.what();
+	}
+	REQUIRE(StringUtil::Contains(error, expected));
+}
+
+static int64_t QueryCount(Connection &con, const string &query) {
+	auto result = con.Query(query);
+	REQUIRE(result);
+	INFO((result->HasError() ? result->GetError() : string()));
+	REQUIRE_FALSE(result->HasError());
+	REQUIRE(result->RowCount() == 1);
+	return result->GetValue(0, 0).GetValue<int64_t>();
+}
+
+static void ConfigureClient(Connection &con, const string &client_implementation) {
+	S3TestHelper::RequireQueryOk(con,
+	                             StringUtil::Format("SET httpfs_client_implementation='%s'", client_implementation));
+	S3TestHelper::RequireQueryOk(con, "SET httpfs_connection_caching=false");
+	S3TestHelper::RequireQueryOk(con, "SET enable_global_s3_configuration=false");
+	S3TestHelper::RequireQueryOk(con, "SET enable_curl_server_cert_verification=false");
+	S3TestHelper::RequireQueryOk(con, "SET enable_server_cert_verification=false");
+}
+
+static void CreateSSESecret(Connection &con, const string &name, const string &scope, const string &endpoint,
+                            const string &key = SSE_C_KEY, const string &extra_options = string()) {
+	S3TestHelper::RequireQueryOk(con, StringUtil::Format(R"(
+CREATE OR REPLACE SECRET %s (
+	TYPE S3,
+	SCOPE '%s',
+	KEY_ID 'SSE_TEST_KEY',
+	SECRET 'SSE_TEST_SECRET',
+	REGION 'us-east-1',
+	ENDPOINT '%s',
+	USE_SSL false,
+	VERIFY_SSL false,
+	URL_STYLE 'path',
+	SSE_C_KEY '%s'%s
+))",
+	                                                     name, scope, endpoint, key, extra_options));
+}
+
+static string ReadOneByte(Connection &con, const string &path, bool force_download) {
+	S3TestHelper::RequireQueryOk(con, StringUtil::Format("SET force_download=%s", force_download ? "true" : "false"));
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto flags = FileFlags::FILE_FLAGS_READ;
+	if (!force_download) {
+		flags |= FileFlags::FILE_FLAGS_DIRECT_IO;
+	}
+	auto handle = fs.OpenFile(path, flags);
+	string result(1, '\0');
+	handle->Read(QueryContext(*con.context), &result[0], result.size(), 0);
+	return result;
+}
+
+static void WriteObject(Connection &con, const string &path, idx_t size) {
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	string payload(size, 'x');
+	handle->Write(QueryContext(*con.context), &payload[0], payload.size());
+	handle->Close();
+}
+
+static vector<string> SignedHeaders(const MockS3RequestObservation &observation) {
+	static constexpr const char *PREFIX = "SignedHeaders=";
+	auto position = observation.authorization.find(PREFIX);
+	if (position == string::npos) {
+		return {};
+	}
+	position += strlen(PREFIX);
+	auto end = observation.authorization.find(',', position);
+	return StringUtil::Split(observation.authorization.substr(position, end - position), ";");
+}
+
+static idx_t CountValue(const vector<string> &values, const string &value) {
+	return NumericCast<idx_t>(std::count(values.begin(), values.end(), value));
+}
+
+static bool KeyMatches(const S3SSECustomerKey &key, const string &expected_key, const string &expected_md5) {
+	return key.GetKey() == expected_key && key.GetKeyMD5() == expected_md5;
+}
+
+static bool UsesSSECustomerHeaders(const MockS3RequestObservation &observation) {
+	if (observation.method == "HEAD" || observation.method == "PUT") {
+		return true;
+	}
+	if (observation.method == "GET") {
+		return !StringUtil::Contains(observation.target, "list-type=2");
+	}
+	if (observation.method == "POST") {
+		return StringUtil::Contains(observation.target, "uploads") ||
+		       StringUtil::Contains(observation.target, "uploadId");
+	}
+	return false;
+}
+
+static void RequireSSECustomerHeaders(const MockS3RequestObservation &observation, const string &expected_md5) {
+	auto signed_headers = SignedHeaders(observation);
+	if (UsesSSECustomerHeaders(observation)) {
+		REQUIRE(observation.sse_customer_algorithm == "AES256");
+		REQUIRE(observation.sse_customer_key_md5 == expected_md5);
+		REQUIRE(observation.has_sse_customer_key);
+		REQUIRE(observation.sse_customer_key_matches);
+		REQUIRE(MockS3HeaderValues(observation, SSE_C_KEY_HEADER) == vector<string> {"redacted"});
+		REQUIRE(CountValue(signed_headers, SSE_C_ALGORITHM_HEADER) == 1);
+		REQUIRE(CountValue(signed_headers, SSE_C_KEY_HEADER) == 1);
+		REQUIRE(CountValue(signed_headers, SSE_C_KEY_MD5_HEADER) == 1);
+	} else {
+		REQUIRE(observation.sse_customer_algorithm.empty());
+		REQUIRE(observation.sse_customer_key_md5.empty());
+		REQUIRE_FALSE(observation.has_sse_customer_key);
+		REQUIRE_FALSE(observation.sse_customer_key_matches);
+		REQUIRE(MockS3HeaderValues(observation, SSE_C_KEY_HEADER).empty());
+		REQUIRE(CountValue(signed_headers, SSE_C_ALGORITHM_HEADER) == 0);
+		REQUIRE(CountValue(signed_headers, SSE_C_KEY_HEADER) == 0);
+		REQUIRE(CountValue(signed_headers, SSE_C_KEY_MD5_HEADER) == 0);
+	}
+}
+
+static S3AuthConfig SSEAuthConfig(S3ProviderType provider_type, const string &endpoint) {
+	S3AuthConfig config;
+	const char *prefix = provider_type == S3ProviderType::GCS  ? "gcs://"
+	                     : provider_type == S3ProviderType::R2 ? "r2://"
+	                                                           : "s3://";
+	config.route = {provider_type, prefix, S3UrlSchemeOrigin::BUILTIN};
+	config.endpoint = endpoint;
+	config.endpoint_mode = S3EndpointMode::EXPLICIT;
+	config.credentials.access_key_id = "key";
+	config.credentials.secret_access_key = "secret";
+	config.request_options.sse_customer_key = S3SSECustomerKey::Create(SSE_C_KEY);
+	return config;
+}
+
+static string RequireOpenError(Connection &con, const string &path) {
+	string error;
+	try {
+		auto &fs = FileSystem::GetFileSystem(*con.context);
+		fs.OpenFile(path, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	} catch (std::exception &ex) {
+		error = ex.what();
+	}
+	REQUIRE_FALSE(error.empty());
+	return error;
+}
+
+static void RunSSECustomerMatrix(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.use_ssl = true;
+	config.auth.stale_key_id = "NEVER_STALE";
+	config.sse_customer.accepted_keys = {SSE_C_KEY};
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	S3TestHelper::LoadExtension(db);
+	ConfigureClient(con, client_implementation);
+	CreateSSESecret(con, "sse_customer", "s3://refresh-bucket/", "https://" + server.Endpoint());
+	S3TestHelper::RequireQueryOk(con, "CALL enable_logging('HTTP')");
+
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+	REQUIRE(ReadOneByte(con, S3TestHelper::S3_PATH, false) == server.ObjectData().substr(0, 1));
+	REQUIRE(ReadOneByte(con, S3TestHelper::S3_PATH, true) == server.ObjectData().substr(0, 1));
+	WriteObject(con, S3TestHelper::S3_PATH, 32);
+	S3TestHelper::RequireQueryOk(con, "SET s3_uploader_max_filesize='50GB'");
+	WriteObject(con, S3TestHelper::S3_PATH, 10ULL * 1024ULL * 1024ULL + 1);
+	auto glob_result = fs.Glob("s3://refresh-bucket/*.bin", FileGlobOptions::ALLOW_EMPTY, nullptr);
+	REQUIRE(glob_result->GetAllFiles().size() == 1);
+	fs.RemoveFile(S3TestHelper::S3_PATH);
+	fs.RemoveFiles({S3TestHelper::S3_PATH, "s3://refresh-bucket/another.bin"});
+	{
+		auto handle =
+		    fs.OpenFile(S3TestHelper::S3_PATH, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+		string payload(10ULL * 1024ULL * 1024ULL + 1, 'a');
+		handle->Write(QueryContext(*con.context), &payload[0], payload.size());
+		handle->AbortWrite();
+	}
+	S3TestHelper::RequireQueryOk(con, "COMMIT");
+
+	auto observations = server.Observations();
+	auto description = MockS3DescribeObservations(observations);
+	INFO(description);
+	REQUIRE_FALSE(observations.empty());
+	REQUIRE_FALSE(StringUtil::Contains(description, SSE_C_KEY));
+	bool saw_head = false;
+	bool saw_range_get = false;
+	bool saw_full_get = false;
+	bool saw_single_put = false;
+	bool saw_multipart_init = false;
+	bool saw_upload_part = false;
+	bool saw_multipart_complete = false;
+	bool saw_list = false;
+	bool saw_object_delete = false;
+	bool saw_bulk_delete = false;
+	bool saw_multipart_abort = false;
+	for (const auto &observation : observations) {
+		RequireSSECustomerHeaders(observation, SSE_C_KEY_MD5);
+		saw_head |= observation.method == "HEAD";
+		saw_range_get |= observation.method == "GET" && !observation.range.empty();
+		saw_full_get |= observation.method == "GET" && observation.range.empty() &&
+		                !StringUtil::Contains(observation.target, "list-type=2");
+		saw_single_put |= observation.method == "PUT" && !observation.part_number.IsValid();
+		saw_multipart_init |= observation.method == "POST" && StringUtil::Contains(observation.target, "uploads");
+		saw_upload_part |= observation.method == "PUT" && observation.part_number.IsValid();
+		saw_multipart_complete |= observation.method == "POST" && StringUtil::Contains(observation.target, "uploadId");
+		saw_list |= observation.method == "GET" && StringUtil::Contains(observation.target, "list-type=2");
+		saw_object_delete |= observation.method == "DELETE" && observation.upload_id.empty();
+		saw_bulk_delete |= observation.method == "POST" && StringUtil::Contains(observation.target, "delete");
+		saw_multipart_abort |= observation.method == "DELETE" && !observation.upload_id.empty();
+	}
+	REQUIRE(saw_head);
+	REQUIRE(saw_range_get);
+	REQUIRE(saw_full_get);
+	REQUIRE(saw_single_put);
+	REQUIRE(saw_multipart_init);
+	REQUIRE(saw_upload_part);
+	REQUIRE(saw_multipart_complete);
+	REQUIRE(saw_list);
+	REQUIRE(saw_object_delete);
+	REQUIRE(saw_bulk_delete);
+	REQUIRE(saw_multipart_abort);
+
+	REQUIRE(QueryCount(con, StringUtil::Format("SELECT count(*) FROM duckdb_logs WHERE contains(message, '%s')",
+	                                           SSE_C_KEY)) == 0);
+	REQUIRE(QueryCount(con, StringUtil::Format(R"(
+SELECT count(*) FROM duckdb_logs_parsed('HTTP')
+WHERE request.headers['%s'] = 'redacted'
+)",
+	                                           SSE_C_KEY_HEADER)) > 0);
+}
+
+static void RunSSECustomerAlias(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.use_ssl = true;
+	config.auth.stale_key_id = "NEVER_STALE";
+	config.sse_customer.accepted_keys = {SSE_C_KEY};
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	S3TestHelper::LoadExtension(db);
+	ConfigureClient(con, client_implementation);
+	S3TestHelper::RequireQueryOk(con, "SET s3_url_scheme_aliases=['oss']");
+	CreateSSESecret(con, "sse_alias", "oss://refresh-bucket/", "https://" + server.Endpoint());
+	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+	REQUIRE(ReadOneByte(con, "oss://refresh-bucket/object.bin", false) == server.ObjectData().substr(0, 1));
+	S3TestHelper::RequireQueryOk(con, "COMMIT");
+	for (const auto &observation : server.Observations()) {
+		RequireSSECustomerHeaders(observation, SSE_C_KEY_MD5);
+	}
+}
+
+static void RunSSECustomerValidation(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.use_ssl = true;
+	config.auth.stale_key_id = "NEVER_STALE";
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	S3TestHelper::LoadExtension(db);
+	ConfigureClient(con, client_implementation);
+	auto https_endpoint = "https://" + server.Endpoint();
+	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+
+	CreateSSESecret(con, "invalid_sse", "s3://refresh-bucket/", https_endpoint, SSE_C_KEY, ",\n\tKMS_KEY_ID 'kms-key'");
+	REQUIRE(StringUtil::Contains(RequireOpenError(con, S3TestHelper::S3_PATH),
+	                             "SSE_C_KEY and KMS_KEY_ID cannot be configured together"));
+	REQUIRE(server.Observations().empty());
+
+	S3TestHelper::RequireQueryOk(con, StringUtil::Format(R"(
+CREATE OR REPLACE SECRET invalid_sse (
+	TYPE S3, SCOPE 's3://refresh-bucket/', KEY_ID '', SECRET '', REGION 'us-east-1', ENDPOINT '%s',
+	USE_SSL false, VERIFY_SSL false, URL_STYLE 'path', SSE_C_KEY '%s'
+))",
+	                                                     https_endpoint, SSE_C_KEY));
+	REQUIRE(StringUtil::Contains(RequireOpenError(con, S3TestHelper::S3_PATH),
+	                             "SSE_C_KEY requires both KEY_ID and SECRET"));
+	REQUIRE(server.Observations().empty());
+
+	S3TestHelper::RequireQueryOk(con, StringUtil::Format(R"(
+CREATE OR REPLACE SECRET invalid_sse (
+	TYPE S3, SCOPE 's3://refresh-bucket/', KEY_ID '', SECRET 'secret', REGION 'us-east-1', ENDPOINT '%s',
+	USE_SSL false, VERIFY_SSL false, URL_STYLE 'path', SSE_C_KEY '%s'
+))",
+	                                                     https_endpoint, SSE_C_KEY));
+	REQUIRE(StringUtil::Contains(RequireOpenError(con, S3TestHelper::S3_PATH),
+	                             "SSE_C_KEY requires both KEY_ID and SECRET"));
+	REQUIRE(server.Observations().empty());
+
+	S3TestHelper::RequireQueryOk(con, StringUtil::Format(R"(
+CREATE OR REPLACE SECRET invalid_sse (
+	TYPE S3, SCOPE 's3://refresh-bucket/', KEY_ID 'key', SECRET '', REGION 'us-east-1', ENDPOINT '%s',
+	USE_SSL false, VERIFY_SSL false, URL_STYLE 'path', SSE_C_KEY '%s'
+))",
+	                                                     https_endpoint, SSE_C_KEY));
+	REQUIRE(StringUtil::Contains(RequireOpenError(con, S3TestHelper::S3_PATH),
+	                             "SSE_C_KEY requires both KEY_ID and SECRET"));
+	REQUIRE(server.Observations().empty());
+
+	S3TestHelper::RequireQueryOk(con, StringUtil::Format(R"(
+CREATE OR REPLACE SECRET invalid_sse (
+	TYPE S3, SCOPE 's3://refresh-bucket/', KEY_ID 'key', SECRET 'secret', REGION 'us-east-1',
+	ENDPOINT 'http://%s', USE_SSL true, URL_STYLE 'path', SSE_C_KEY '%s'
+))",
+	                                                     server.Endpoint(), SSE_C_KEY));
+	REQUIRE(StringUtil::Contains(RequireOpenError(con, S3TestHelper::S3_PATH), "SSE_C_KEY requires an HTTPS endpoint"));
+	REQUIRE(server.Observations().empty());
+
+	CreateSSESecret(con, "invalid_sse", "s3://refresh-bucket/", "account.r2.cloudflarestorage.com");
+	REQUIRE(StringUtil::Contains(RequireOpenError(con, S3TestHelper::S3_PATH),
+	                             "SSE_C_KEY is only supported for S3-compatible endpoints"));
+	REQUIRE(server.Observations().empty());
+	S3TestHelper::RequireQueryOk(con, "ROLLBACK");
+}
+
+static void RunSSECustomerRefresh(const string &client_implementation) {
+	MockS3ServerConfig config;
+	config.use_ssl = true;
+	config.auth.stale_key_id = S3TestHelper::STALE_KEY_ID;
+	config.auth.refresh_target = MockS3RefreshTarget::HEAD;
+	config.sse_customer.accepted_keys = {SSE_C_KEY, REFRESHED_SSE_C_KEY};
+	MockS3Server server(std::move(config));
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	S3TestHelper::LoadExtension(db);
+	S3TestHelper::RegisterRefreshProvider(db);
+	ConfigureClient(con, client_implementation);
+	S3TestHelper::RequireQueryOk(con, "SET httpfs_enable_credential_refresh=true");
+	auto test_id = S3TestHelper::NextTestId();
+	auto endpoint = "https://" + server.Endpoint();
+	S3TestHelper::RequireQueryOk(con, StringUtil::Format(R"(
+CREATE SECRET refresh_sse (
+	TYPE S3,
+	PROVIDER %s,
+	SCOPE 's3://refresh-bucket/',
+	KEY_ID '%s',
+	SECRET '%s',
+	REGION 'us-east-1',
+	ENDPOINT '%s',
+	USE_SSL false,
+	VERIFY_SSL false,
+	URL_STYLE 'path',
+	SSE_C_KEY '%s',
+	TEST_ID '%s',
+	REFRESH_INFO MAP {
+		'KEY_ID': '%s',
+		'SECRET': '%s',
+		'REGION': 'us-east-1',
+		'ENDPOINT': '%s',
+		'URL_STYLE': 'path',
+		'SSE_C_KEY': '%s',
+		'TEST_ID': '%s'
+	}
+))",
+	                                                     S3TestHelper::TEST_PROVIDER, S3TestHelper::STALE_KEY_ID,
+	                                                     S3TestHelper::STALE_SECRET, endpoint, SSE_C_KEY, test_id,
+	                                                     S3TestHelper::FRESH_KEY_ID, S3TestHelper::FRESH_SECRET,
+	                                                     endpoint, REFRESHED_SSE_C_KEY, test_id));
+
+	S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+	REQUIRE(ReadOneByte(con, S3TestHelper::S3_PATH, false) == server.ObjectData().substr(0, 1));
+	S3TestHelper::RequireQueryOk(con, "COMMIT");
+	auto observations = server.Observations();
+	INFO(MockS3DescribeObservations(observations));
+	REQUIRE(observations.size() >= 2);
+	REQUIRE(observations[0].key_id == S3TestHelper::STALE_KEY_ID);
+	REQUIRE(observations[0].sse_customer_key_md5 == SSE_C_KEY_MD5);
+	REQUIRE(observations[1].key_id == S3TestHelper::FRESH_KEY_ID);
+	REQUIRE(observations[1].sse_customer_key_md5 == REFRESHED_SSE_C_KEY_MD5);
+	for (idx_t i = 0; i < observations.size(); i++) {
+		auto &observation = observations[i];
+		REQUIRE(observation.sse_customer_key_matches);
+		REQUIRE_FALSE(StringUtil::Contains(MockS3DescribeObservations({observation}), SSE_C_KEY));
+		REQUIRE_FALSE(StringUtil::Contains(MockS3DescribeObservations({observation}), REFRESHED_SSE_C_KEY));
+		if (i > 0) {
+			REQUIRE(observation.key_id == S3TestHelper::FRESH_KEY_ID);
+			REQUIRE(observation.sse_customer_key_md5 == REFRESHED_SSE_C_KEY_MD5);
+		}
+	}
+	S3TestHelper::AssertSingleRefresh(test_id);
+}
+
+} // namespace
+
+TEST_CASE("S3 SSE-C key validation derives the required digest", "[httpfs][s3][sse-c][secret]") {
+	auto key = S3SSECustomerKey::Create(SSE_C_KEY);
+	REQUIRE(KeyMatches(key, SSE_C_KEY, SSE_C_KEY_MD5));
+	REQUIRE(key == S3SSECustomerKey::Create(SSE_C_KEY));
+	REQUIRE_FALSE(key == S3SSECustomerKey::Create(REFRESHED_SSE_C_KEY));
+
+	const string invalid_sentinel = "SSE_C_KEY_SENTINEL_NOT_BASE64!";
+	try {
+		S3SSECustomerKey::Create(invalid_sentinel);
+		FAIL("Expected invalid base64 to throw");
+	} catch (std::exception &ex) {
+		REQUIRE_FALSE(StringUtil::Contains(ex.what(), invalid_sentinel));
+	}
+	RequireExceptionContains([&]() { S3SSECustomerKey::Create("MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZQ=="); },
+	                         "SSE_C_KEY must be a valid base64-encoded 256-bit key");
+}
+
+TEST_CASE("S3 SSE-C is limited to S3 secrets and plain S3 profiles", "[httpfs][s3][sse-c][secret]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	S3TestHelper::LoadExtension(db);
+	for (const auto secret_type : {"AWS", "R2", "GCS"}) {
+		auto error = RequireQueryError(con, StringUtil::Format("CREATE SECRET invalid_%s (TYPE %s, SSE_C_KEY '%s')",
+		                                                       StringUtil::Lower(secret_type), secret_type, SSE_C_KEY));
+		REQUIRE(StringUtil::Contains(StringUtil::Lower(error), "sse_c_key"));
+	}
+	REQUIRE(QueryCount(con, "SELECT count(*) FROM duckdb_settings() WHERE name = 's3_sse_c_key'") == 0);
+
+	auto gcs = SSEAuthConfig(S3ProviderType::GCS, "https://storage.googleapis.com");
+	RequireExceptionContains([&]() { S3AuthResolver::Resolve(std::move(gcs), "gcs://bucket/key"); },
+	                         "SSE_C_KEY is only supported for S3-compatible endpoints");
+	auto r2 = SSEAuthConfig(S3ProviderType::R2, "https://account.r2.cloudflarestorage.com");
+	RequireExceptionContains([&]() { S3AuthResolver::Resolve(std::move(r2), "r2://bucket/key"); },
+	                         "SSE_C_KEY is only supported for S3-compatible endpoints");
+}
+
+TEST_CASE("S3 SSE-C secret display redacts direct and refresh material", "[httpfs][s3][sse-c][secret]") {
+	DBConfig config;
+	config.SetOptionByName("allow_unredacted_secrets", Value(true));
+	DuckDB db(nullptr, &config);
+	Connection con(db);
+	S3TestHelper::LoadExtension(db);
+	CreateSSESecret(con, "direct_sse", "s3://direct/", "https://storage.example.com");
+	CreateSSESecret(con, "automatic_sse", "s3://automatic/", "https://storage.example.com", SSE_C_KEY,
+	                ",\n\tREFRESH AUTO");
+	CreateSSESecret(con, "explicit_sse", "s3://explicit/", "https://storage.example.com", SSE_C_KEY,
+	                StringUtil::Format(",\n\tREFRESH_INFO MAP {'SSE_C_KEY': '%s'}", REFRESHED_SSE_C_KEY));
+
+	for (const auto name : {"direct_sse", "automatic_sse", "explicit_sse"}) {
+		REQUIRE(QueryCount(con, StringUtil::Format(R"(
+SELECT count(*) FROM duckdb_secrets()
+WHERE name = '%s' AND NOT contains(secret_string, '%s') AND NOT contains(secret_string, '%s')
+)",
+		                                           name, SSE_C_KEY, REFRESHED_SSE_C_KEY)) == 1);
+		REQUIRE(QueryCount(con, StringUtil::Format(R"(
+SELECT count(*) FROM duckdb_secrets(redact=false)
+WHERE name = '%s' AND contains(secret_string, '%s')
+)",
+		                                           name, SSE_C_KEY)) == 1);
+	}
+	REQUIRE(QueryCount(con, R"(
+SELECT count(*) FROM duckdb_secrets()
+WHERE name = 'automatic_sse' AND contains(secret_string, 'refresh_info=redacted')
+)") == 1);
+	REQUIRE(QueryCount(con, R"(
+SELECT count(*) FROM duckdb_secrets()
+WHERE name = 'explicit_sse' AND contains(secret_string, 'refresh_info=redacted')
+)") == 1);
+	REQUIRE(QueryCount(con, StringUtil::Format(R"(
+SELECT count(*) FROM duckdb_secrets(redact=false)
+WHERE name = 'explicit_sse' AND contains(secret_string, '%s')
+)",
+	                                           REFRESHED_SSE_C_KEY)) == 1);
+}
+
+TEST_CASE("Persistent S3 SSE-C secrets preserve validated key material", "[httpfs][s3][sse-c][secret]") {
+	auto secret_directory = TestCreatePath("httpfs_sse_c_persistent_" + S3TestHelper::NextTestId());
+	TestDeleteDirectory(secret_directory);
+	{
+		DBConfig config;
+		config.SetOptionByName("secret_directory", Value(secret_directory));
+		config.SetOptionByName("allow_unredacted_secrets", Value(true));
+		DuckDB db(nullptr, &config);
+		Connection con(db);
+		S3TestHelper::LoadExtension(db);
+		S3TestHelper::RequireQueryOk(con, StringUtil::Format(R"(
+CREATE PERSISTENT SECRET persistent_sse (
+	TYPE S3, SCOPE 's3://persistent/', KEY_ID 'key', SECRET 'secret', REGION 'us-east-1',
+	ENDPOINT 'https://storage.example.com', URL_STYLE 'path', SSE_C_KEY '%s',
+	REFRESH_INFO MAP {'SSE_C_KEY': '%s'}
+))",
+		                                                     SSE_C_KEY, REFRESHED_SSE_C_KEY));
+	}
+	{
+		DBConfig config;
+		config.SetOptionByName("secret_directory", Value(secret_directory));
+		config.SetOptionByName("allow_unredacted_secrets", Value(true));
+		DuckDB db(nullptr, &config);
+		Connection con(db);
+		S3TestHelper::LoadExtension(db);
+		REQUIRE(QueryCount(con, StringUtil::Format(R"(
+SELECT count(*) FROM duckdb_secrets()
+WHERE name = 'persistent_sse' AND NOT contains(secret_string, '%s') AND NOT contains(secret_string, '%s')
+	AND contains(secret_string, 'sse_c_key=redacted') AND contains(secret_string, 'refresh_info=redacted')
+)",
+		                                           SSE_C_KEY, REFRESHED_SSE_C_KEY)) == 1);
+		REQUIRE(QueryCount(con, StringUtil::Format(R"(
+SELECT count(*) FROM duckdb_secrets(redact=false)
+WHERE name = 'persistent_sse' AND contains(secret_string, '%s') AND contains(secret_string, '%s')
+)",
+		                                           SSE_C_KEY, REFRESHED_SSE_C_KEY)) == 1);
+
+		auto &secret_manager = db.instance->GetSecretManager();
+		S3TestHelper::RequireQueryOk(con, "BEGIN TRANSACTION");
+		auto transaction = CatalogTransaction::GetSystemCatalogTransaction(*con.context);
+		auto secret_entry = secret_manager.GetSecretByName(transaction, "persistent_sse");
+		REQUIRE(secret_entry);
+		auto &secret = secret_entry->secret->Cast<KeyValueSecret>();
+		ClientContextFileOpener opener(*con.context);
+		S3KeyValueReader reader {KeyValueSecretReader(secret, opener)};
+		auto auth_params = S3AuthResolver::Resolve(reader, "s3://persistent/object.bin");
+		REQUIRE(auth_params.GetRequestOptions().sse_customer_key);
+		REQUIRE(KeyMatches(*auth_params.GetRequestOptions().sse_customer_key, SSE_C_KEY, SSE_C_KEY_MD5));
+		S3TestHelper::RequireQueryOk(con, "ROLLBACK");
+	}
+	TestDeleteDirectory(secret_directory);
+}
+
+TEST_CASE("S3 SSE-C validates effective transport and credentials before dispatch", "[httpfs][s3][sse-c][request]") {
+	for (const auto client_implementation : {"curl", "httplib"}) {
+		DYNAMIC_SECTION(client_implementation) {
+			RunSSECustomerValidation(client_implementation);
+		}
+	}
+}
+
+TEST_CASE("S3 SSE-C headers follow the object operation matrix", "[httpfs][s3][sse-c][request]") {
+	for (const auto client_implementation : {"curl", "httplib"}) {
+		DYNAMIC_SECTION(client_implementation) {
+			RunSSECustomerMatrix(client_implementation);
+		}
+	}
+}
+
+TEST_CASE("S3 SSE-C supports configured URL scheme aliases", "[httpfs][s3][sse-c][alias]") {
+	for (const auto client_implementation : {"curl", "httplib"}) {
+		DYNAMIC_SECTION(client_implementation) {
+			RunSSECustomerAlias(client_implementation);
+		}
+	}
+}
+
+TEST_CASE("S3 SSE-C credential refresh rebuilds the encrypted request headers", "[httpfs][s3][sse-c][refresh]") {
+	for (const auto client_implementation : {"curl", "httplib"}) {
+		DYNAMIC_SECTION(client_implementation) {
+			RunSSECustomerRefresh(client_implementation);
+		}
+	}
+}
+
+} // namespace duckdb


### PR DESCRIPTION
Adds opt-in SSE-C support through the `SSE_C_KEY` option on S3 secrets, so httpfs can read and write objects encrypted with a customer-provided key. The key is validated, sent only over HTTPS on the relevant object requests, and redacted from secret display and HTTP logs. Existing encryption behavior stays unchanged; the bucket must allow SSE-C.