### PR TITLE
Two fixes for HTTP cache control

### DIFF
--- a/src/http/httpfs.cpp
+++ b/src/http/httpfs.cpp
@@ -903,7 +903,7 @@ optional<timestamp_t> HTTPFileHandle::GetCacheValidUntil() const {
 
 bool HTTPFileHandle::CanReuseCachedData() const {
 	annotated_lock_guard<annotated_mutex> guard(cache_policy_lock);
-	return !cache_valid_until || Timestamp::GetCurrentTimestamp() <= *cache_valid_until;
+	return !cache_valid_until || Timestamp::GetCurrentTimestamp() < *cache_valid_until;
 }
 
 struct HTTPFileInfoParser {

--- a/src/http/httpfs.cpp
+++ b/src/http/httpfs.cpp
@@ -880,9 +880,13 @@ void HTTPFileHandle::ApplyCachePolicy(const HTTPResponse &response, timestamp_t 
 		return;
 	}
 	auto response_valid_until = HTTPFileSystem::ComputeCacheValidUntil(response.headers, request_time, response_time);
-	// TODO(hjiang): Prevent shared reuse of private responses and authenticated requests without explicit permission.
+	// TODO(hjiang): Prevent shared reuse of authenticated requests without explicit permission.
 	if (HasCacheControlDirective(response.headers, "no-store")) {
 		// no-store applies to this response, so only blocks populated by this read are retired.
+		response_valid_until = timestamp_t::ninfinity();
+	}
+	if (HasCacheControlDirective(response.headers, "private")) {
+		// Private responses cannot be stored in caches shared across connections.
 		response_valid_until = timestamp_t::ninfinity();
 	}
 	if (VaryProhibitsReuse(response.headers, request_snapshot->Params().extra_headers)) {

--- a/src/include/http/http_metadata_cache.hpp
+++ b/src/include/http/http_metadata_cache.hpp
@@ -20,7 +20,7 @@ struct HTTPMetadataCacheEntry {
 	idx_t length;
 	timestamp_t last_modified;
 	string etag;
-	//! Freshness deadline (inclusive); unset means the server provides no freshness information.
+	//! Freshness deadline (exclusive); unset means the server provides no freshness information.
 	optional<timestamp_t> cache_valid_until;
 	string version_id;
 	unordered_map<string, string> properties;
@@ -56,7 +56,7 @@ public:
 			return false;
 		}
 		if (!OverridesResponseCachePolicy() && lookup->second.cache_valid_until &&
-		    Timestamp::GetCurrentTimestamp() > *lookup->second.cache_valid_until) {
+		    Timestamp::GetCurrentTimestamp() >= *lookup->second.cache_valid_until) {
 			map.erase(lookup);
 			return false;
 		}

--- a/src/include/http/httpfs.hpp
+++ b/src/include/http/httpfs.hpp
@@ -99,7 +99,7 @@ private:
 	                        bool should_write_cache);
 
 	mutable annotated_mutex cache_policy_lock;
-	//! Freshness deadline (inclusive) derived from HTTP caching headers (Cache-Control/Expires).
+	//! Freshness deadline (exclusive) derived from HTTP caching headers (Cache-Control/Expires).
 	//! Unset means no freshness information; positive/negative infinity mean always valid/invalid.
 	//! Used to bound how long cached file data may be served.
 	optional<timestamp_t> cache_valid_until DUCKDB_GUARDED_BY(cache_policy_lock);
@@ -141,7 +141,7 @@ private:
 class HTTPFileSystem : public FileSystem {
 public:
 	static bool TryParseLastModifiedTime(const string &timestamp, timestamp_t &result);
-	//! Compute the freshness deadline (inclusive) from HTTP caching headers (RFC 9111): Cache-Control max-age,
+	//! Compute the freshness deadline (exclusive) from HTTP caching headers (RFC 9111): Cache-Control max-age,
 	//! falling back to Expires relative to Date (or receipt time when Date is absent), adjusted by the response's age.
 	//! Unset if no freshness lifetime is provided.
 	static optional<timestamp_t> ComputeCacheValidUntil(const HTTPHeaders &headers, timestamp_t request_time,


### PR DESCRIPTION
Redo https://github.com/duckdb/duckdb/pull/25196 and https://github.com/duckdb/duckdb/pull/25195 to extension repo