### PR TITLE
Automatic generation checks for GCS reads

### DIFF
--- a/src/http/http_request.cpp
+++ b/src/http/http_request.cpp
@@ -98,14 +98,14 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRequest(HTTPFileHandle &hfh, cons
 	    url, request_headers, http_params,
 	    [&](const HTTPResponse &response) {
 		    if (response.status == HTTPStatusCode::PreconditionFailed_412 &&
-		        read_config.condition.type == HTTPReadConditionType::ETAG) {
+		        read_config.condition.type != HTTPReadConditionType::NONE) {
 			    return false;
 		    }
 		    if (static_cast<int>(response.status) >= 400) {
 			    throw get_error(response);
 		    }
 		    if (static_cast<int>(response.status) < 300) {
-			    ValidateResponseETag(hfh, read_config, response);
+			    ValidateResponseVersion(hfh, read_config, response);
 			    hfh.ApplyCachePolicy(response, request_time, Timestamp::GetCurrentTimestamp());
 		    }
 		    download.Reset();
@@ -155,7 +155,7 @@ public:
 public:
 	bool HandleResponse(const HTTPResponse &response) {
 		if (response.status == HTTPStatusCode::PreconditionFailed_412 &&
-		    read_config.condition.type == HTTPReadConditionType::ETAG) {
+		    read_config.condition.type != HTTPReadConditionType::NONE) {
 			return false;
 		}
 		if (static_cast<int>(response.status) >= 400) {
@@ -281,7 +281,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::RunGetRangeRequest(HTTPFileHandle &hfh,
 	const auto request_time = Timestamp::GetCurrentTimestamp();
 	HTTPRangeRequestContext context(hfh, read_config, url, range_expr, buffer_out, buffer_out_len,
 	                                std::move(range_request), get_error, [&](const HTTPResponse &response) {
-		                                ValidateResponseETag(hfh, read_config, response);
+		                                ValidateResponseVersion(hfh, read_config, response);
 		                                hfh.ApplyCachePolicy(response, request_time, Timestamp::GetCurrentTimestamp());
 	                                });
 	GetRequestInfo get_request(
@@ -346,8 +346,8 @@ HTTPException HTTPFileSystem::GetHTTPError(FileHandle &, const HTTPResponse &res
 	return HTTPFSUtil::GetHTTPStatusError(response, request_type, "on", url, details);
 }
 
-void HTTPFileSystem::ValidateResponseETag(HTTPFileHandle &hfh, const HTTPReadConfig &read_config,
-                                          const HTTPResponse &response) {
+void HTTPFileSystem::ValidateResponseVersion(HTTPFileHandle &hfh, const HTTPReadConfig &read_config,
+                                             const HTTPResponse &response) {
 	if (!read_config.validate_etag || read_config.etag.empty() || !response.HasHeader("ETag")) {
 		return;
 	}
@@ -365,14 +365,37 @@ void HTTPFileSystem::ValidateResponseETag(HTTPFileHandle &hfh, const HTTPReadCon
 	    hfh.path, read_config.etag, response_etag);
 }
 
+void HTTPFileSystem::ValidateCachedFile(HTTPFileHandle &hfh, const HTTPReadConfig &read_config,
+                                        const CachedFileHandle &cached) {
+	const auto &metadata = cached.GetMetadata();
+	const auto &actual = metadata.object_version;
+	const auto &selected = read_config.object_version;
+	bool version_matches = true;
+	if (selected.GetType() == HTTPObjectVersionType::GCS_GENERATION && actual.IsSet()) {
+		version_matches = actual.GetType() == selected.GetType() && selected.GetValue() == actual.GetValue();
+	} else if (read_config.condition.type == HTTPReadConditionType::GCS_GENERATION_MATCH) {
+		version_matches = actual.GetType() == HTTPObjectVersionType::GCS_GENERATION &&
+		                  actual.GetValue() == read_config.condition.value;
+	}
+	const auto etag_matches = !read_config.validate_etag || read_config.etag.empty() || metadata.etag.empty() ||
+	                          metadata.etag == read_config.etag ||
+	                          StripETagQuotes(metadata.etag) == StripETagQuotes(read_config.etag);
+	if (!version_matches || !etag_matches) {
+		EraseGlobalCacheEntry(hfh.path);
+		throw HTTPException(Exception::ConstructMessage(
+		    "Cached contents of file \"%s\" do not match the version captured when it was opened", hfh.path));
+	}
+}
+
 void HTTPFileSystem::ThrowIfReadConditionFailed(HTTPFileHandle &hfh, const HTTPReadConfig &read_config,
                                                 const HTTPResponse &response) {
 	if (response.status != HTTPStatusCode::PreconditionFailed_412 ||
-	    read_config.condition.type != HTTPReadConditionType::ETAG) {
+	    read_config.condition.type == HTTPReadConditionType::NONE) {
 		return;
 	}
 	EraseGlobalCacheEntry(hfh.path);
-	throw HTTPException(response, "ETag on reading file \"%s\" changed after it was opened: the server rejected %s",
+	auto kind = read_config.condition.type == HTTPReadConditionType::ETAG ? "ETag" : "Object version";
+	throw HTTPException(response, "%s on reading file \"%s\" changed after it was opened: the server rejected %s", kind,
 	                    hfh.path, read_config.condition.value);
 }
 

--- a/src/http/http_state.cpp
+++ b/src/http/http_state.cpp
@@ -43,7 +43,11 @@ const char *CachedFileHandle::GetData() const {
 }
 
 idx_t CachedFileHandle::GetSize() const {
-	return file->size;
+	return file->metadata.length;
+}
+
+const HTTPMetadataCacheEntry &CachedFileHandle::GetMetadata() const {
+	return file->metadata;
 }
 
 CachedFileDownload::CachedFileDownload(shared_ptr<CachedFile> file_p, Allocator &allocator_p)
@@ -99,11 +103,12 @@ void CachedFileDownload::Reset() {
 	size = 0;
 }
 
-unique_ptr<CachedFileHandle> CachedFileDownload::Finalize() {
+unique_ptr<CachedFileHandle> CachedFileDownload::Finalize(HTTPMetadataCacheEntry metadata) {
+	metadata.length = size;
+	auto cached_data = make_shared_ptr<CachedFileData>(std::move(data), std::move(metadata));
 	annotated_lock_guard<annotated_mutex> guard(file->lock);
 	D_ASSERT(file->downloading);
 	D_ASSERT(!file->cached_data);
-	auto cached_data = make_shared_ptr<CachedFileData>(std::move(data), size);
 	file->cached_data = cached_data;
 	file->downloading = false;
 	active = false;

--- a/src/http/httpfs.cpp
+++ b/src/http/httpfs.cpp
@@ -230,10 +230,11 @@ static bool IsStrongETag(string etag) {
 }
 
 HTTPFileHandle::HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags,
-                               unique_ptr<HTTPParams> params_p)
+                               unique_ptr<HTTPParams> params_p, HTTPObjectVersion object_version_p)
     : FileHandle(fs, file.path, flags), request_session(make_shared_ptr<HTTPRequestSession>(
                                             make_shared_ptr<HTTPRequestSnapshot>(params_p->Cast<HTTPFSParams>()))),
-      flags(flags), length(0), last_modified(0), force_full_download(false), file_offset(0) {
+      flags(flags), length(0), last_modified(0), force_full_download(false), file_offset(0),
+      object_version(std::move(object_version_p)) {
 	// check if the handle has extended properties that can be set directly in the handle
 	// if we have these properties we don't need to do a head request to obtain them later
 	if (file.extended_info) {
@@ -441,6 +442,7 @@ bool HTTPFileSystem::ReadAt(FileHandle &handle, data_ptr_t buffer, idx_t read_si
 	D_ASSERT(hfh.file_state);
 	auto cached_file = hfh.file_state->TryGetCachedFileHandle();
 	if (cached_file) {
+		ValidateCachedFile(hfh, read_config, *cached_file);
 		if (cached_file->GetSize() < read_end) {
 			throw IOException("Cached file length can't satisfy the requested Read. You can try to resolve this by "
 			                  "enabling `SET force_download=true`");
@@ -567,7 +569,7 @@ FileMetadata HTTPFileSystem::Stats(FileHandle &handle) {
 	metadata.last_modification_time = sfh.last_modified;
 	metadata.file_type = FileType::FILE_TYPE_REGULAR;
 	metadata.cache_valid_until = sfh.GetCacheValidUntil();
-	metadata.version_tag = sfh.etag;
+	metadata.version_tag = GetVersionTag(handle);
 	return metadata;
 }
 
@@ -680,6 +682,10 @@ unique_ptr<CachedFileHandle> HTTPFileSystem::FullDownload(HTTPFileHandle &hfh, c
 
 	while (true) {
 		if (auto cached_file = hfh.file_state->TryGetCachedFileHandle()) {
+			ValidateCachedFile(hfh, read_config, *cached_file);
+			if (!hfh.initialized) {
+				hfh.InitializeFromCacheEntry(cached_file->GetMetadata());
+			}
 			return cached_file;
 		}
 
@@ -687,14 +693,34 @@ unique_ptr<CachedFileHandle> HTTPFileSystem::FullDownload(HTTPFileHandle &hfh, c
 		if (!download) {
 			continue;
 		}
+		const auto request_time = Timestamp::GetCurrentTimestamp();
 		auto full_download_result = GetRequest(hfh, hfh.path, {}, read_config, *download);
 		ThrowIfReadConditionFailed(hfh, read_config, *full_download_result);
+		if (full_download_result->HasRequestError()) {
+			ErrorData(full_download_result->GetRequestError()).Throw();
+		}
 		if (full_download_result->status != HTTPStatusCode::OK_200) {
 			throw GetHTTPError(hfh, *full_download_result, RequestType::GET_REQUEST, hfh.path);
 		}
+		auto metadata = hfh.ReadFileInfo(*full_download_result, request_time, Timestamp::GetCurrentTimestamp());
+		// A successful conditional or version-selected GET also identifies bytes when a response header is absent.
+		if (!metadata.object_version.IsSet()) {
+			if (read_config.object_version.IsSet()) {
+				metadata.object_version = read_config.object_version;
+			} else if (read_config.condition.type == HTTPReadConditionType::GCS_GENERATION_MATCH) {
+				metadata.object_version =
+				    HTTPObjectVersion(HTTPObjectVersionType::GCS_GENERATION, read_config.condition.value);
+			}
+		}
+		if (metadata.etag.empty() && read_config.condition.type == HTTPReadConditionType::ETAG) {
+			metadata.etag = read_config.condition.value;
+		}
+		if (!hfh.initialized) {
+			hfh.InitializeFromCacheEntry(metadata);
+		}
 		// Publish unconditionally: this buffer is query-scoped and shared only among identical requests,
 		// so HTTP cache policy (no-store/Vary/freshness) does not restrict it.
-		return download->Finalize();
+		return download->Finalize(std::move(metadata));
 	}
 }
 
@@ -944,8 +970,9 @@ private:
 bool HTTPFileHandle::TryLoadFileInfoWithoutRequest() {
 	D_ASSERT(file_state);
 	if (auto cached_file = file_state->TryGetCachedFileHandle()) {
-		length = cached_file->GetSize();
-		initialized = true;
+		if (!initialized) {
+			InitializeFromCacheEntry(cached_file->GetMetadata());
+		}
 		return true;
 	}
 	if (initialized || force_full_download) {
@@ -999,23 +1026,29 @@ unique_ptr<HTTPResponse> HTTPFileHandle::RetryFileInfoWithRange(HTTPFileSystem &
 	throw hfs.GetHTTPError(*this, *response, RequestType::GET_REQUEST, path);
 }
 
-void HTTPFileHandle::ApplyFileInfo(const HTTPResponse &response, timestamp_t request_time, timestamp_t response_time) {
-	length = 0;
+HTTPMetadataCacheEntry HTTPFileHandle::ReadFileInfo(const HTTPResponse &response, timestamp_t request_time,
+                                                    timestamp_t response_time) {
+	auto result = GetCacheEntry();
+	result.length = 0;
+	result.last_modified = timestamp_t(0);
+	result.etag.clear();
 	auto content_size = HTTPFileInfoParser::TryParseContentRange(response.headers);
 	if (!content_size.IsValid()) {
 		content_size = HTTPFileInfoParser::TryParseContentLength(response.headers);
 	}
 	if (content_size.IsValid()) {
-		length = content_size.GetIndex();
+		result.length = content_size.GetIndex();
 	}
 	if (response.headers.HasHeader("Last-Modified")) {
-		HTTPFileSystem::TryParseLastModifiedTime(response.headers.GetHeaderValue("Last-Modified"), last_modified);
+		HTTPFileSystem::TryParseLastModifiedTime(response.headers.GetHeaderValue("Last-Modified"),
+		                                         result.last_modified);
 	}
 	if (response.headers.HasHeader("ETag")) {
-		etag = response.headers.GetHeaderValue("ETag");
+		result.etag = response.headers.GetHeaderValue("ETag");
 	}
 	ApplyCachePolicy(response, request_time, response_time);
-	object_version = ReadObjectVersion(response.headers);
+	result.cache_valid_until = GetCacheValidUntil();
+	result.object_version = ReadObjectVersion(response.headers);
 	if (response.headers.HasHeader("Accept-Ranges")) {
 		auto accept_ranges = response.headers.GetHeaderValue("Accept-Ranges");
 		StringUtil::Trim(accept_ranges);
@@ -1023,7 +1056,7 @@ void HTTPFileHandle::ApplyFileInfo(const HTTPResponse &response, timestamp_t req
 			file_state->MarkRangeRequestsSupported();
 		}
 	}
-	initialized = true;
+	return result;
 }
 
 void HTTPFileHandle::LoadFileInfo() {
@@ -1035,7 +1068,7 @@ void HTTPFileHandle::LoadFileInfo() {
 	timestamp_t response_time;
 	auto response = RequestFileInfo(hfs, request_time, response_time);
 	if (response) {
-		ApplyFileInfo(*response, request_time, response_time);
+		InitializeFromCacheEntry(ReadFileInfo(*response, request_time, response_time));
 	}
 }
 
@@ -1062,6 +1095,7 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
 		                        : cache_entry.cache_valid_until;
 	}
 	object_version = cache_entry.object_version;
+	initialized = true;
 
 	// TODO: handle properties
 }

--- a/src/include/http/http_state.hpp
+++ b/src/include/http/http_state.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "http/http_metadata_cache.hpp"
+
 #include "duckdb/common/allocator.hpp"
 #include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/mutex.hpp"
@@ -128,17 +130,18 @@ private:
 	bool downloading DUCKDB_GUARDED_BY(lock) = false;
 };
 
-//! Immutable data published after a full download completes
+//! Immutable bytes and metadata published after a full download completes
 class CachedFileData {
 	friend class CachedFileHandle;
 
 public:
-	CachedFileData(AllocatedData data_p, idx_t size_p) : data(std::move(data_p)), size(size_p) {
+	CachedFileData(AllocatedData data_p, HTTPMetadataCacheEntry metadata_p)
+	    : data(std::move(data_p)), metadata(std::move(metadata_p)) {
 	}
 
 private:
 	AllocatedData data;
-	idx_t size;
+	HTTPMetadataCacheEntry metadata;
 };
 
 //! Handle to a CachedFile
@@ -150,6 +153,7 @@ public:
 	const char *GetData() const;
 	//! Return the size of the initialized file
 	idx_t GetSize() const;
+	const HTTPMetadataCacheEntry &GetMetadata() const;
 
 private:
 	shared_ptr<CachedFileData> file;
@@ -173,7 +177,7 @@ public:
 	//! Reset bytes written by a prior request attempt
 	void Reset();
 	//! Indicate the file is fully downloaded and safe for parallel reading
-	unique_ptr<CachedFileHandle> Finalize();
+	unique_ptr<CachedFileHandle> Finalize(HTTPMetadataCacheEntry metadata);
 
 private:
 	void ReserveInternal(idx_t capacity);

--- a/src/include/http/httpfs.hpp
+++ b/src/include/http/httpfs.hpp
@@ -16,7 +16,7 @@
 
 namespace duckdb {
 
-enum class HTTPReadConditionType : uint8_t { NONE, ETAG };
+enum class HTTPReadConditionType : uint8_t { NONE, ETAG, GCS_GENERATION_MATCH };
 
 struct HTTPReadCondition {
 	HTTPReadConditionType type = HTTPReadConditionType::NONE;
@@ -55,7 +55,8 @@ class HTTPFileHandle : public FileHandle {
 	friend class S3FileSystem;
 
 public:
-	HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags, unique_ptr<HTTPParams> params);
+	HTTPFileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags, unique_ptr<HTTPParams> params,
+	               HTTPObjectVersion object_version = {});
 	~HTTPFileHandle() override;
 
 public:
@@ -93,7 +94,8 @@ private:
 	                                         timestamp_t &response_time);
 	unique_ptr<HTTPResponse> RetryFileInfoWithRange(HTTPFileSystem &file_system, timestamp_t &request_time,
 	                                                timestamp_t &response_time);
-	void ApplyFileInfo(const HTTPResponse &response, timestamp_t request_time, timestamp_t response_time);
+	HTTPMetadataCacheEntry ReadFileInfo(const HTTPResponse &response, timestamp_t request_time,
+	                                    timestamp_t response_time);
 	void InitializeRequestState(optional_ptr<FileOpener> opener);
 	bool TryInitializeRead(HTTPFileSystem &file_system, optional_ptr<HTTPMetadataCache> cache,
 	                       bool &should_write_cache);
@@ -236,11 +238,15 @@ protected:
 	                                            const HTTPErrorCallback &get_error,
 	                                            const HTTPSendCallback &send_request);
 
+	//! Read consistency validation and stale metadata invalidation
+	virtual void ValidateResponseVersion(HTTPFileHandle &handle, const HTTPReadConfig &read_config,
+	                                     const HTTPResponse &response);
+	void EraseGlobalCacheEntry(const string &path) DUCKDB_EXCLUDES(global_cache_lock);
+
 private:
-	void ValidateResponseETag(HTTPFileHandle &handle, const HTTPReadConfig &read_config, const HTTPResponse &response);
+	void ValidateCachedFile(HTTPFileHandle &handle, const HTTPReadConfig &read_config, const CachedFileHandle &cached);
 	void ThrowIfReadConditionFailed(HTTPFileHandle &handle, const HTTPReadConfig &read_config,
 	                                const HTTPResponse &response);
-	void EraseGlobalCacheEntry(const string &path) DUCKDB_EXCLUDES(global_cache_lock);
 
 private:
 	//! Global metadata cache

--- a/src/include/s3/s3_provider.hpp
+++ b/src/include/s3/s3_provider.hpp
@@ -18,6 +18,8 @@ struct CreateSecretInput;
 class S3AuthParams;
 class S3KeyValueReader;
 struct HTTPHeaders;
+struct ExtendedOpenFileInfo;
+struct HTTPReadCondition;
 
 enum class S3ProviderType : uint8_t { S3, GCS, R2 };
 
@@ -106,6 +108,9 @@ public:
 	static const char *GetVersionParameterName(HTTPObjectVersionType type);
 	const char *GetVersionQueryParameter(const HTTPObjectVersion &version) const;
 	HTTPObjectVersion ReadObjectVersion(const HTTPHeaders &headers) const;
+	HTTPObjectVersion ReadObjectVersion(const ExtendedOpenFileInfo &info) const;
+	void ApplyReadCondition(const HTTPReadCondition &condition, HTTPHeaders &headers) const;
+	string GetVersionTag(const HTTPObjectVersion &version, const string &etag) const;
 
 	bool operator==(const S3Provider &other) const;
 

--- a/src/include/s3/s3_request.hpp
+++ b/src/include/s3/s3_request.hpp
@@ -119,6 +119,7 @@ struct S3RequestSpec {
 	string content_type;
 	string content_md5;
 	HTTPObjectVersion object_version;
+	HTTPReadCondition read_condition;
 };
 
 struct S3RequestData {
@@ -137,7 +138,8 @@ struct S3RequestUtil {
 	                                 S3RequestOperation operation, const S3RequestQuery &query,
 	                                 const S3AuthParams &auth_params, string date_now = "", string datetime_now = "",
 	                                 string payload_hash = "", string content_type = "", string content_md5 = "",
-	                                 const HTTPConfiguredHeaders &configured_headers = {});
+	                                 const HTTPConfiguredHeaders &configured_headers = {},
+	                                 const HTTPReadCondition &read_condition = {});
 	static string GetPayloadHash(EncryptionUtil &encryption_util, const_data_ptr_t buffer, idx_t buffer_len);
 	static bool IsRequestTimeout(const HTTPResponse &response);
 	static bool IsRetryableReceivedResponse(const HTTPResponse &response);

--- a/src/include/s3/s3fs.hpp
+++ b/src/include/s3/s3fs.hpp
@@ -100,6 +100,7 @@ public:
 public:
 	//! FileSystem overrides.
 	string GetName() const override;
+	string GetVersionTag(FileHandle &handle) override;
 	bool CanHandleFile(const string &fpath) override;
 	bool OnDiskFile(FileHandle &handle) override;
 	void RemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr) override;
@@ -137,7 +138,9 @@ public:
 	BufferManager &GetBufferManager();
 
 protected:
-	//! FileSystem extension points for S3 open/list/glob.
+	//! FileSystem extension points for S3 reads, open/list/glob.
+	void ValidateResponseVersion(HTTPFileHandle &handle, const HTTPReadConfig &read_config,
+	                             const HTTPResponse &response) override;
 	bool ListFilesExtended(const string &directory, const std::function<void(OpenFileInfo &info)> &callback,
 	                       optional_ptr<FileOpener> opener) override;
 	bool SupportsListFilesExtended() const override;

--- a/src/s3/s3_provider.cpp
+++ b/src/s3/s3_provider.cpp
@@ -1,6 +1,7 @@
 #include "s3/s3_provider.hpp"
 
 #include "s3/s3_auth.hpp"
+#include "http/httpfs.hpp"
 
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/http_util.hpp"
@@ -68,6 +69,17 @@ HTTPObjectVersion S3Provider::ParseObjectVersion(S3ProviderType provider, unorde
 }
 
 HTTPObjectVersion S3Provider::ReadObjectVersion(const HTTPHeaders &headers) const {
+	if (GetType() == S3ProviderType::GCS && headers.HasHeader("x-goog-generation")) {
+		HTTPObjectVersion result;
+		for (const auto &value : headers.GetHeaderValues("x-goog-generation")) {
+			auto version = ParseVersionValue(HTTPObjectVersionType::GCS_GENERATION, value);
+			if (result.IsSet() && result.GetValue() != version.GetValue()) {
+				throw IOException("Conflicting x-goog-generation response headers");
+			}
+			result = std::move(version);
+		}
+		return result;
+	}
 	if (!headers.HasHeader("x-amz-version-id")) {
 		return {};
 	}
@@ -87,6 +99,35 @@ const char *S3Provider::GetVersionQueryParameter(const HTTPObjectVersion &versio
 	default:
 		throw InternalException("Object version is not set");
 	}
+}
+
+HTTPObjectVersion S3Provider::ReadObjectVersion(const ExtendedOpenFileInfo &info) const {
+	unordered_map<string, string> versions;
+	for (auto type : {HTTPObjectVersionType::S3_VERSION_ID, HTTPObjectVersionType::GCS_GENERATION}) {
+		auto name = GetVersionParameterName(type);
+		auto entry = info.options.find(name);
+		if (entry != info.options.end()) {
+			versions.emplace(name, entry->second.ToString());
+		}
+	}
+	return ParseObjectVersion(GetType(), versions);
+}
+
+void S3Provider::ApplyReadCondition(const HTTPReadCondition &condition, HTTPHeaders &headers) const {
+	if (condition.type != HTTPReadConditionType::GCS_GENERATION_MATCH) {
+		return;
+	}
+	if (GetType() != S3ProviderType::GCS) {
+		throw InvalidInputException("GCS generation checks require a GCS provider");
+	}
+	headers["x-goog-if-generation-match"] = condition.value;
+}
+
+string S3Provider::GetVersionTag(const HTTPObjectVersion &version, const string &etag) const {
+	if (version.GetType() == HTTPObjectVersionType::GCS_GENERATION) {
+		return "gcs-generation:" + version.GetValue();
+	}
+	return etag;
 }
 
 bool S3MultipartUploadPolicy::operator==(const S3MultipartUploadPolicy &other) const {

--- a/src/s3/s3_request.cpp
+++ b/src/s3/s3_request.cpp
@@ -121,7 +121,8 @@ struct HTTPFSOwnedS3Headers {
 public:
 	static bool Contains(const string &name, S3ProviderType provider_type) {
 		return Headers().find(name) != Headers().end() ||
-		       (provider_type == S3ProviderType::GCS && StringUtil::CIEquals(name, "x-goog-user-project"));
+		       (provider_type == S3ProviderType::GCS && (StringUtil::CIEquals(name, "x-goog-user-project") ||
+		                                                 StringUtil::CIEquals(name, "x-goog-if-generation-match")));
 	}
 
 	static string CanonicalName(const string &name, S3ProviderType provider_type) {
@@ -129,8 +130,8 @@ public:
 		if (entry != Headers().end()) {
 			return entry->second;
 		}
-		D_ASSERT(provider_type == S3ProviderType::GCS && StringUtil::CIEquals(name, "x-goog-user-project"));
-		return "x-goog-user-project";
+		D_ASSERT(Contains(name, provider_type));
+		return StringUtil::Lower(name);
 	}
 
 private:
@@ -371,7 +372,8 @@ HTTPHeaders S3RequestUtil::CreateHeaders(EncryptionUtil &encryption_util, const 
                                          S3RequestOperation operation, const S3RequestQuery &query,
                                          const S3AuthParams &auth_params, string date_now, string datetime_now,
                                          string payload_hash, string content_type, string content_md5,
-                                         const HTTPConfiguredHeaders &configured_headers) {
+                                         const HTTPConfiguredHeaders &configured_headers,
+                                         const HTTPReadCondition &read_condition) {
 	const auto &host = parsed_url.GetHost();
 	auto &operation_info = GetOperationInfo(operation);
 	const auto &encoded_path = operation_info.target == S3RequestTarget::BUCKET ? parsed_url.GetEncodedBucketPath()
@@ -380,6 +382,7 @@ HTTPHeaders S3RequestUtil::CreateHeaders(EncryptionUtil &encryption_util, const 
 	auto &credentials = auth_params.GetCredentials();
 	auto &request_options = auth_params.GetRequestOptions();
 	auto headers = CreateConfiguredS3Headers(configured_headers, provider.GetType());
+	provider.ApplyReadCondition(read_condition, headers);
 	if (provider.GetType() == S3ProviderType::GCS && !request_options.user_project.empty()) {
 		headers["x-goog-user-project"] = request_options.user_project;
 	}
@@ -548,9 +551,9 @@ S3RequestData S3RequestExecutor::CreateRequestData(EncryptionUtil &encryption_ut
 	result.http_url = operation_info.target == S3RequestTarget::BUCKET
 	                      ? parsed_s3_url.GetBucketHTTPUrl(query.WireQuery())
 	                      : parsed_s3_url.GetHTTPUrl(query.WireQuery());
-	result.headers = S3RequestUtil::CreateHeaders(encryption_util, parsed_s3_url, spec.operation, query,
-	                                              result.auth_params, "", "", spec.payload_hash, spec.content_type,
-	                                              spec.content_md5, session_request.configured_headers);
+	result.headers = S3RequestUtil::CreateHeaders(
+	    encryption_util, parsed_s3_url, spec.operation, query, result.auth_params, "", "", spec.payload_hash,
+	    spec.content_type, spec.content_md5, session_request.configured_headers, spec.read_condition);
 	return result;
 }
 
@@ -953,6 +956,35 @@ S3RequestResult S3FileSystem::PutRequest(HTTPRequestSession &session, S3RequestO
 	    });
 }
 
+void S3FileSystem::ValidateResponseVersion(HTTPFileHandle &handle, const HTTPReadConfig &read_config,
+                                           const HTTPResponse &response) {
+	optional_ptr<const string> expected;
+	if (read_config.object_version.GetType() == HTTPObjectVersionType::GCS_GENERATION) {
+		expected = &read_config.object_version.GetValue();
+	} else if (read_config.condition.type == HTTPReadConditionType::GCS_GENERATION_MATCH) {
+		expected = &read_config.condition.value;
+	}
+	if (!expected) {
+		HTTPFileSystem::ValidateResponseVersion(handle, read_config, response);
+		return;
+	}
+	HTTPObjectVersion actual;
+	try {
+		auto captured = handle.request_session->Capture();
+		actual =
+		    captured.snapshot->Cast<S3RequestSnapshot>().auth_params.GetProvider().ReadObjectVersion(response.headers);
+	} catch (...) {
+		EraseGlobalCacheEntry(handle.path);
+		throw;
+	}
+	if (actual.IsSet() &&
+	    (actual.GetType() != HTTPObjectVersionType::GCS_GENERATION || actual.GetValue() != *expected)) {
+		EraseGlobalCacheEntry(handle.path);
+		throw HTTPException(response, "GCS generation on reading file \"%s\" was initially %s and now it returned %s",
+		                    handle.path, *expected, actual.GetValue());
+	}
+}
+
 unique_ptr<HTTPResponse> S3FileSystem::HeadRequest(FileHandle &handle, const string &s3_url, HTTPHeaders header_map) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
 	return S3RequestExecutor::RunHandle(
@@ -972,21 +1004,22 @@ unique_ptr<HTTPResponse> S3FileSystem::HeadRequest(FileHandle &handle, const str
 unique_ptr<HTTPResponse> S3FileSystem::GetRequest(FileHandle &handle, string s3_url, HTTPHeaders header_map,
                                                   const HTTPReadConfig &read_config, CachedFileDownload &download) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
-	return S3RequestExecutor::RunHandle(
-	           GetEncryptionUtil(), s3_handle,
-	           S3RequestSpec {s3_url, S3RequestOperation::GET_OBJECT, {}, "", "", "", read_config.object_version},
-	           [&](S3RequestData &request_data) {
-		           auto &params = request_data.http_params->Cast<HTTPFSParams>();
-		           return RunGetRequest(
-		               s3_handle, request_data.http_url, request_data.headers, params, read_config, download,
-		               [&](const HTTPResponse &response) {
-			               return S3RequestUtil::GetRequestError(request_data, response);
-		               },
-		               [&](BaseRequest &request) {
-			               return S3RequestExecutor::SendHandleRequest(s3_handle, request_data.captured, params,
-			                                                           request);
-		               });
-	           })
+	const S3RequestSpec spec {
+	    s3_url, S3RequestOperation::GET_OBJECT, {}, "", "", "", read_config.object_version, read_config.condition};
+	return S3RequestExecutor::RunHandle(GetEncryptionUtil(), s3_handle, spec,
+	                                    [&](S3RequestData &request_data) {
+		                                    auto &params = request_data.http_params->Cast<HTTPFSParams>();
+		                                    return RunGetRequest(
+		                                        s3_handle, request_data.http_url, request_data.headers, params,
+		                                        read_config, download,
+		                                        [&](const HTTPResponse &response) {
+			                                        return S3RequestUtil::GetRequestError(request_data, response);
+		                                        },
+		                                        [&](BaseRequest &request) {
+			                                        return S3RequestExecutor::SendHandleRequest(
+			                                            s3_handle, request_data.captured, params, request);
+		                                        });
+	                                    })
 	    .response;
 }
 
@@ -994,22 +1027,22 @@ unique_ptr<HTTPResponse> S3FileSystem::GetRangeRequest(FileHandle &handle, strin
                                                        const HTTPReadConfig &read_config, idx_t file_offset,
                                                        data_ptr_t buffer_out, idx_t buffer_out_len) {
 	auto &s3_handle = handle.Cast<S3FileHandle>();
-	return S3RequestExecutor::RunHandle(
-	           GetEncryptionUtil(), s3_handle,
-	           S3RequestSpec {s3_url, S3RequestOperation::GET_OBJECT, {}, "", "", "", read_config.object_version},
-	           [&](S3RequestData &request_data) {
-		           auto &params = request_data.http_params->Cast<HTTPFSParams>();
-		           return RunGetRangeRequest(
-		               s3_handle, request_data.http_url, request_data.headers, params, read_config, file_offset,
-		               buffer_out, buffer_out_len,
-		               [&](const HTTPResponse &response) {
-			               return S3RequestUtil::GetRequestError(request_data, response);
-		               },
-		               [&](BaseRequest &request) {
-			               return S3RequestExecutor::SendHandleRequest(s3_handle, request_data.captured, params,
-			                                                           request);
-		               });
-	           })
+	const S3RequestSpec spec {
+	    s3_url, S3RequestOperation::GET_OBJECT, {}, "", "", "", read_config.object_version, read_config.condition};
+	return S3RequestExecutor::RunHandle(GetEncryptionUtil(), s3_handle, spec,
+	                                    [&](S3RequestData &request_data) {
+		                                    auto &params = request_data.http_params->Cast<HTTPFSParams>();
+		                                    return RunGetRangeRequest(
+		                                        s3_handle, request_data.http_url, request_data.headers, params,
+		                                        read_config, file_offset, buffer_out, buffer_out_len,
+		                                        [&](const HTTPResponse &response) {
+			                                        return S3RequestUtil::GetRequestError(request_data, response);
+		                                        },
+		                                        [&](BaseRequest &request) {
+			                                        return S3RequestExecutor::SendHandleRequest(
+			                                            s3_handle, request_data.captured, params, request);
+		                                        });
+	                                    })
 	    .response;
 }
 

--- a/src/s3/s3fs.cpp
+++ b/src/s3/s3fs.cpp
@@ -33,7 +33,9 @@ S3FileHandle::S3FileHandle(FileSystem &fs, const OpenFileInfo &file, FileOpenFla
                            unique_ptr<HTTPParams> http_params_p, const S3AuthParams &auth_params_p,
                            const S3UploadConfig &upload_config,
                            optional<S3MultipartUploadPolicy> multipart_upload_policy)
-    : HTTPFileHandle(fs, file, flags, std::move(http_params_p)),
+    : HTTPFileHandle(fs, file, flags, std::move(http_params_p),
+                     file.extended_info ? auth_params_p.GetProvider().ReadObjectVersion(*file.extended_info)
+                                        : HTTPObjectVersion()),
       requested_version(S3Url::Parse(file.path, auth_params_p).GetObjectVersion()) {
 	if (flags.OpenForWriting() && requested_version.IsSet()) {
 		throw NotImplementedException("%s is only supported for reading",
@@ -65,21 +67,39 @@ HTTPReadConfig S3FileHandle::BuildReadConfig() const {
 	auto result = HTTPFileHandle::BuildReadConfig();
 	if (requested_version.IsSet()) {
 		result.object_version = requested_version;
+	} else if (GetObjectVersion().GetType() == HTTPObjectVersionType::GCS_GENERATION) {
+		if (result.validate_etag) {
+			result.condition.type = HTTPReadConditionType::GCS_GENERATION_MATCH;
+			result.condition.value = GetObjectVersion().GetValue();
+			result.validate_etag = false;
+		}
 	} else if (request_session->Capture().snapshot->Params().s3_version_id_pinning) {
 		result.object_version = GetObjectVersion();
 	}
 	if (result.object_version.IsSet()) {
 		result.condition = {};
+		if (result.object_version.GetType() == HTTPObjectVersionType::GCS_GENERATION) {
+			result.validate_etag = false;
+		}
 	}
 	return result;
 }
 
 HTTPObjectVersion S3FileHandle::ReadObjectVersion(const HTTPHeaders &headers) const {
 	auto captured = request_session->Capture();
-	if (!captured.snapshot->Params().s3_version_id_pinning) {
+	auto version = captured.snapshot->Cast<S3RequestSnapshot>().auth_params.GetProvider().ReadObjectVersion(headers);
+	if (version.GetType() == HTTPObjectVersionType::S3_VERSION_ID &&
+	    !captured.snapshot->Params().s3_version_id_pinning) {
 		return {};
 	}
-	return captured.snapshot->Cast<S3RequestSnapshot>().auth_params.GetProvider().ReadObjectVersion(headers);
+	return version;
+}
+
+string S3FileSystem::GetVersionTag(FileHandle &handle) {
+	auto &s3_handle = handle.Cast<S3FileHandle>();
+	auto captured = s3_handle.request_session->Capture();
+	return captured.snapshot->Cast<S3RequestSnapshot>().auth_params.GetProvider().GetVersionTag(
+	    s3_handle.GetObjectVersion(), s3_handle.etag);
 }
 
 shared_ptr<const HTTPRequestSnapshot> S3FileHandle::CreateRequestSnapshot(const HTTPFSParams &params) const {

--- a/test/unittest/http/range_read_test.cpp
+++ b/test/unittest/http/range_read_test.cpp
@@ -236,6 +236,74 @@ TEST_CASE("HTTP full-download fallback is single-flight", "[httpfs][full-downloa
 	}
 }
 
+TEST_CASE("HTTP cached downloads retain an existing handle's ETag condition", "[httpfs][full-download][etag]") {
+	for (const string client : {"curl", "httplib"}) {
+		MockS3ServerConfig config;
+		config.metadata.response_headers = {{"Cache-Control", "no-store"}};
+		MockS3Server server(std::move(config));
+		DuckDB db(nullptr);
+		Connection con(db);
+		HTTPTestHelper::Configure(db, con, 0, client);
+		HTTPTestHelper::RequireQueryOk(con, "BEGIN");
+		auto &fs = FileSystem::GetFileSystem(*con.context);
+		const auto flags = FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO;
+		auto new_handle = fs.OpenFile(server.HTTPPath(), flags);
+		OpenFileInfo info(server.HTTPPath());
+		info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+		info.extended_info->options["last_modified"] = Value::TIMESTAMP(timestamp_t(0));
+		info.extended_info->options["file_size"] = Value::UBIGINT(server.ObjectData().size());
+		info.extended_info->options["etag"] = "\"older-etag\"";
+		auto old_handle = fs.OpenFile(info, flags);
+		auto &new_http = new_handle->Cast<HTTPFileHandle>();
+		bool write_cache = false;
+		new_handle->file_system.Cast<HTTPFileSystem>().FullDownload(new_http, new_http.GetReadConfig(), write_cache);
+		string data(5, '?');
+		REQUIRE_THROWS_WITH(old_handle->Read(QueryContext(*con.context), &data[0], data.size(), 0),
+		                    Catch::Contains("do not match the version"));
+		REQUIRE(data == "?????");
+		REQUIRE(old_handle->Cast<HTTPFileHandle>().etag == "\"older-etag\"");
+		new_handle->Read(QueryContext(*con.context), &data[0], data.size(), 0);
+		REQUIRE(data == server.ObjectData().substr(0, data.size()));
+		HTTPTestHelper::RequireQueryOk(con, "COMMIT");
+	}
+}
+
+TEST_CASE("HTTP cached downloads accept absent GET ETags", "[httpfs][full-download][etag]") {
+	for (const string client : {"curl", "httplib"}) {
+		for (const auto behavior : {MockS3ETagBehavior::OMIT, MockS3ETagBehavior::EMPTY}) {
+			CAPTURE(client, behavior);
+			MockS3ServerConfig config;
+			config.object.data = "old bytes";
+			config.metadata.etag = "W/\"same\"";
+			config.metadata.get_etag_behavior = behavior;
+			MockS3Server server(std::move(config));
+			DuckDB db(nullptr);
+			Connection con(db);
+			HTTPTestHelper::Configure(db, con, 0, client);
+			HTTPTestHelper::RequireQueryOk(con, "SET force_download_threshold=1024");
+			HTTPTestHelper::RequireQueryOk(con, "BEGIN");
+			auto &fs = FileSystem::GetFileSystem(*con.context);
+			auto handle = fs.OpenFile(server.HTTPPath(), FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+			auto &hfh = handle->Cast<HTTPFileHandle>();
+			REQUIRE(hfh.etag == "W/\"same\"");
+			REQUIRE(hfh.GetReadConfig().condition.type == HTTPReadConditionType::NONE);
+			auto outcome = HTTPTestHelper::TryReadHandle(con, *handle, 0, server.ObjectData().size());
+			INFO(outcome.error);
+			REQUIRE_FALSE(outcome.failed);
+			REQUIRE(outcome.data == server.ObjectData());
+			bool write_cache = false;
+			auto cached =
+			    handle->file_system.Cast<HTTPFileSystem>().FullDownload(hfh, hfh.GetReadConfig(), write_cache);
+			REQUIRE(cached->GetMetadata().etag.empty());
+			REQUIRE(hfh.etag == "W/\"same\"");
+			auto observations = server.Observations();
+			REQUIRE(HTTPTestHelper::CountRequests(observations, "HEAD", 200) == 1);
+			REQUIRE(HTTPTestHelper::CountRequests(observations, "GET", 200) == 1);
+			HTTPTestHelper::RequireQueryOk(con, "COMMIT");
+		}
+	}
+}
+
 TEST_CASE("HTTP full-download fallback rejects HEAD and GET length mismatches", "[httpfs][full-download][issue-354]") {
 	MockS3ServerConfig config;
 	config.object.data = "AB";

--- a/test/unittest/s3/gcs_generation_test.cpp
+++ b/test/unittest/s3/gcs_generation_test.cpp
@@ -3,6 +3,10 @@
 #include "s3/s3_test_helper.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "http/httpfs.hpp"
+#include "duckdb/storage/external_file_cache/caching_file_system.hpp"
+
+#include <thread>
 
 namespace duckdb {
 namespace {
@@ -32,6 +36,216 @@ static string ReadObject(Connection &con, const string &path) {
 }
 
 } // namespace
+
+TEST_CASE("GCS generation checks reject replacement between reads", "[httpfs][s3][gcs-generation]") {
+	for (const string client : {"curl", "httplib"}) {
+		for (const bool bearer : {false, true}) {
+			for (const bool full_download : {false, true}) {
+				for (const bool enforce : {false, true}) {
+					CAPTURE(client, bearer, full_download, enforce);
+					MockS3ServerConfig config;
+					config.object.generation = "123";
+					config.object.generations = {{"123", "aaaaaaaaaa"}, {"456", "bbbbbbbbbb"}};
+					config.metadata.enforce_generation_match = enforce;
+					config.failures.transient_get_failures = 1;
+					MockS3Server server(std::move(config));
+					DuckDB db(nullptr);
+					Connection con(db);
+					ConfigureGenerationTest(db, con, server, client, bearer);
+					S3TestHelper::RequireQueryOk(con, "BEGIN");
+					auto &fs = FileSystem::GetFileSystem(*con.context);
+					auto handle = fs.OpenFile("gcs://refresh-bucket/object.bin",
+					                          FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+					auto &http_handle = handle->Cast<HTTPFileHandle>();
+					REQUIRE(http_handle.GetReadConfig().condition.type == HTTPReadConditionType::GCS_GENERATION_MATCH);
+					REQUIRE(fs.GetVersionTag(*handle) == "gcs-generation:123");
+					REQUIRE(handle->Stats().version_tag == fs.GetVersionTag(*handle));
+					auto cached = fs.OpenFile("gcs://refresh-bucket/object.bin",
+					                          FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+					REQUIRE(cached->Cast<HTTPFileHandle>().GetReadConfig().condition.value == "123");
+					REQUIRE(server.Observations().size() == 1);
+					string data(5, '?');
+					handle->Read(QueryContext(*con.context), &data[0], 5, 0);
+					REQUIRE(data == "aaaaa");
+					server.SetObjectGeneration("456");
+					if (full_download) {
+						bool write_cache = false;
+						REQUIRE_THROWS(handle->file_system.Cast<HTTPFileSystem>().FullDownload(
+						    http_handle, http_handle.GetReadConfig(), write_cache));
+					} else {
+						data = "?????";
+						REQUIRE_THROWS(handle->Read(QueryContext(*con.context), &data[0], 5, 5));
+						REQUIRE(data == "?????");
+					}
+					REQUIRE(http_handle.GetReadConfig().condition.value == "123");
+					for (auto &observation : server.Observations()) {
+						REQUIRE(observation.target == "/refresh-bucket/object.bin");
+						if (observation.method == "GET") {
+							REQUIRE(MockS3HeaderValues(observation, "x-goog-if-generation-match") ==
+							        vector<string> {"123"});
+							REQUIRE(observation.if_match.empty());
+							if (!bearer) {
+								REQUIRE(StringUtil::Contains(observation.authorization, "x-goog-if-generation-match"));
+							}
+						}
+					}
+					// A failed read invalidates global metadata; reopening observes the replacement.
+					auto reopened = fs.OpenFile("gcs://refresh-bucket/object.bin",
+					                            FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+					REQUIRE(fs.GetVersionTag(*reopened) == "gcs-generation:456");
+					S3TestHelper::RequireQueryOk(con, "COMMIT");
+				}
+			}
+		}
+	}
+}
+
+TEST_CASE("GCS automatic checks can be disabled without disabling explicit selection", "[httpfs][s3][gcs-generation]") {
+	for (const string client : {"curl", "httplib"}) {
+		MockS3ServerConfig config;
+		config.object.generation = "123";
+		config.object.generations = {{"123", "old bytes"}, {"456", "new bytes"}};
+		MockS3Server server(std::move(config));
+		DuckDB db(nullptr);
+		Connection con(db);
+		ConfigureGenerationTest(db, con, server, client, true);
+		S3TestHelper::RequireQueryOk(con, "SET unsafe_disable_etag_checks=true");
+		S3TestHelper::RequireQueryOk(con, "BEGIN");
+		auto &fs = FileSystem::GetFileSystem(*con.context);
+		auto handle =
+		    fs.OpenFile("gs://refresh-bucket/object.bin", FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+		server.SetObjectGeneration("456");
+		string data(9, '?');
+		handle->Read(QueryContext(*con.context), &data[0], data.size(), 0);
+		REQUIRE(data == "new bytes");
+		REQUIRE(ReadObject(con, "gs://refresh-bucket/object.bin?gcs_generation=123") == "old bytes");
+		for (auto &observation : server.Observations()) {
+			REQUIRE(MockS3HeaderValues(observation, "x-goog-if-generation-match").empty());
+		}
+		S3TestHelper::RequireQueryOk(con, "COMMIT");
+	}
+}
+
+TEST_CASE("GCS missing generation metadata falls back to ETags", "[httpfs][s3][gcs-generation]") {
+	for (const string client : {"curl", "httplib"}) {
+		MockS3ServerConfig config;
+		config.metadata.enforce_if_match = true;
+		MockS3Server server(std::move(config));
+		DuckDB db(nullptr);
+		Connection con(db);
+		ConfigureGenerationTest(db, con, server, client, false);
+		REQUIRE(ReadObject(con, "gcs://refresh-bucket/object.bin") == server.ObjectData());
+		for (auto &observation : server.Observations()) {
+			REQUIRE(MockS3HeaderValues(observation, "x-goog-if-generation-match").empty());
+			if (observation.method == "GET") {
+				REQUIRE(observation.if_match == "\"httpfs-refresh-test-etag\"");
+			}
+		}
+	}
+}
+
+TEST_CASE("GCS full downloads preserve metadata when reopened without extra HEADs", "[httpfs][s3][gcs-generation]") {
+	for (const string client : {"curl", "httplib"}) {
+		for (const bool chunked : {false, true}) {
+			for (const bool force_download : {false, true}) {
+				CAPTURE(client, chunked, force_download);
+				MockS3ServerConfig config;
+				config.object.generation = "123";
+				config.object.generations = {{"123", "old bytes"}};
+				config.full_get.chunked = chunked;
+				MockS3Server server(std::move(config));
+				DuckDB db(nullptr);
+				Connection con(db);
+				ConfigureGenerationTest(db, con, server, client, false);
+				S3TestHelper::RequireQueryOk(con, string("SET force_download=") + (force_download ? "true" : "false"));
+				S3TestHelper::RequireQueryOk(con, "SET force_download_threshold=1024");
+				S3TestHelper::RequireQueryOk(con, "BEGIN");
+				auto &fs = FileSystem::GetFileSystem(*con.context);
+				auto handle = fs.OpenFile("gs://refresh-bucket/object.bin", FileFlags::FILE_FLAGS_READ);
+				REQUIRE(fs.GetVersionTag(*handle) == "gcs-generation:123");
+				REQUIRE(handle->Stats().version_tag == fs.GetVersionTag(*handle));
+				const auto request_count = force_download ? 1 : 2;
+				REQUIRE(server.Observations().size() == request_count);
+				REQUIRE(server.Observations().back().method == "GET");
+				auto reopened = fs.OpenFile("gs://refresh-bucket/object.bin", FileFlags::FILE_FLAGS_READ);
+				REQUIRE(reopened->Stats().version_tag == handle->Stats().version_tag);
+				REQUIRE(reopened->GetFileSize() == handle->GetFileSize());
+				string data(9, '?');
+				reopened->Read(QueryContext(*con.context), &data[0], data.size(), 0);
+				REQUIRE(data == "old bytes");
+				REQUIRE(server.Observations().size() == request_count);
+				S3TestHelper::RequireQueryOk(con, "COMMIT");
+			}
+		}
+	}
+}
+
+TEST_CASE("GCS concurrent forced downloads publish bytes and metadata together",
+          "[httpfs][s3][gcs-generation][full-download]") {
+	for (const string client : {"curl", "httplib"}) {
+		MockS3ServerConfig config;
+		config.object.generation = "123";
+		config.object.generations = {{"123", "old bytes"}};
+		config.metadata.get_response_headers = {{"Cache-Control", "no-store"},
+		                                        {"Last-Modified", "Tue, 08 Sep 2026 10:00:00 GMT"}};
+		config.full_get.block_until_released = true;
+		config.failures.transient_get_failures = 1;
+		MockS3Server server(std::move(config));
+		DuckDB db(nullptr);
+		Connection con(db);
+		ConfigureGenerationTest(db, con, server, client, false);
+		S3TestHelper::RequireQueryOk(con, "SET enable_external_file_cache=false");
+		S3TestHelper::RequireQueryOk(con, "SET force_download=true");
+		S3TestHelper::RequireQueryOk(con, "BEGIN");
+		auto &fs = FileSystem::GetFileSystem(*con.context);
+		vector<unique_ptr<FileHandle>> handles(2);
+		vector<string> errors(2);
+		vector<std::thread> readers;
+		atomic<bool> start {false};
+		for (idx_t i = 0; i < handles.size(); i++) {
+			readers.emplace_back([&, i]() {
+				while (!start.load()) {
+					std::this_thread::yield();
+				}
+				try {
+					handles[i] = fs.OpenFile("gcs://refresh-bucket/object.bin", FileFlags::FILE_FLAGS_READ);
+				} catch (const std::exception &ex) {
+					errors[i] = ex.what();
+				}
+			});
+		}
+		start = true;
+		auto full_get_started = server.WaitForFullGet();
+		server.ReleaseFullGet();
+		for (auto &reader : readers) {
+			reader.join();
+		}
+		REQUIRE(full_get_started);
+		for (idx_t i = 0; i < handles.size(); i++) {
+			INFO(errors[i]);
+			REQUIRE(errors[i].empty());
+			REQUIRE(handles[i]);
+			auto &http = handles[i]->Cast<HTTPFileHandle>();
+			REQUIRE(fs.GetVersionTag(http) == "gcs-generation:123");
+			REQUIRE(http.length == 9);
+			REQUIRE(http.etag == "\"httpfs-refresh-test-etag\"");
+			REQUIRE(http.last_modified == handles[0]->Cast<HTTPFileHandle>().last_modified);
+			REQUIRE(http.GetCacheValidUntil());
+			REQUIRE(*http.GetCacheValidUntil() == timestamp_t::ninfinity());
+			string data(9, '?');
+			http.Read(QueryContext(*con.context), &data[0], data.size(), 0);
+			REQUIRE(data == "old bytes");
+		}
+		const auto observations = server.Observations();
+		REQUIRE(observations.size() == 2);
+		REQUIRE(observations[0].status == 400);
+		REQUIRE(observations[1].status == 200);
+		for (auto &observation : observations) {
+			REQUIRE(observation.method == "GET");
+		}
+		S3TestHelper::RequireQueryOk(con, "COMMIT");
+	}
+}
 
 TEST_CASE("GCS explicit generations select historical objects on every read", "[httpfs][s3][gcs-generation]") {
 	for (const string client : {"curl", "httplib"}) {
@@ -97,44 +311,53 @@ TEST_CASE("GCS explicit generations select historical objects on every read", "[
 	}
 }
 
-TEST_CASE("GCS generation selection survives credential refresh", "[httpfs][s3][gcs-generation]") {
+TEST_CASE("GCS generation selection and checks survive credential refresh", "[httpfs][s3][gcs-generation]") {
 	for (const string client : {"curl", "httplib"}) {
-		for (const auto target :
-		     {MockS3RefreshTarget::HEAD, MockS3RefreshTarget::RANGE_GET, MockS3RefreshTarget::FULL_GET}) {
-			CAPTURE(client, target);
-			MockS3ServerConfig config;
-			config.auth.refresh_target = target;
-			config.object.generations = {{"123", "historical object"}};
-			MockS3Server server(std::move(config));
-			DuckDB db(nullptr);
-			Connection con(db);
-			ConfigureGenerationTest(db, con, server, client, false);
-			S3TestHelper::RegisterRefreshProvider(db);
-			S3TestHelper::RequireQueryOk(con, "SET s3_use_ssl=false");
-			const auto test_id = S3TestHelper::NextTestId();
-			S3TestHelper::RequireQueryOk(con,
-			                             StringUtil::Format(R"(
+		for (const bool explicit_selection : {false, true}) {
+			for (const auto target :
+			     {MockS3RefreshTarget::HEAD, MockS3RefreshTarget::RANGE_GET, MockS3RefreshTarget::FULL_GET}) {
+				CAPTURE(client, target, explicit_selection);
+				MockS3ServerConfig config;
+				config.auth.refresh_target = target;
+				config.object.generation = "123";
+				config.object.generations = {{"123", "historical object"}};
+				MockS3Server server(std::move(config));
+				DuckDB db(nullptr);
+				Connection con(db);
+				ConfigureGenerationTest(db, con, server, client, false);
+				S3TestHelper::RegisterRefreshProvider(db);
+				S3TestHelper::RequireQueryOk(con, "SET s3_use_ssl=false");
+				const auto test_id = S3TestHelper::NextTestId();
+				S3TestHelper::RequireQueryOk(con, StringUtil::Format(R"(
 CREATE OR REPLACE SECRET generation_test (
     TYPE GCS, PROVIDER httpfs_refresh_test, KEY_ID 'STALE_KEY', SECRET 'STALE_SECRET', TEST_ID '%s',
     ENDPOINT '%s', URL_STYLE 'path', USE_SSL false,
     REFRESH_INFO MAP {'KEY_ID': 'FRESH_KEY', 'SECRET': 'FRESH_SECRET', 'TEST_ID': '%s',
                       'ENDPOINT': '%s', 'URL_STYLE': 'path'}
 ))",
-			                                                test_id, server.Endpoint(), test_id, server.Endpoint()));
-			S3TestHelper::RequireQueryOk(con, string("SET force_download=") +
-			                                      (target == MockS3RefreshTarget::FULL_GET ? "true" : "false"));
-			S3TestHelper::RequireQueryOk(con, "BEGIN");
-			auto &fs = FileSystem::GetFileSystem(*con.context);
-			auto handle = fs.OpenFile("gcs://refresh-bucket/object.bin?gcs_generation=123",
-			                          FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
-			string data(10, '?');
-			handle->Read(QueryContext(*con.context), &data[0], data.size(), 0);
-			REQUIRE(data == "historical");
-			S3TestHelper::AssertSingleRefresh(test_id);
-			for (auto &observation : server.Observations()) {
-				REQUIRE(observation.target == "/refresh-bucket/object.bin?generation=123");
+				                                                     test_id, server.Endpoint(), test_id,
+				                                                     server.Endpoint()));
+				S3TestHelper::RequireQueryOk(con, string("SET force_download=") +
+				                                      (target == MockS3RefreshTarget::FULL_GET ? "true" : "false"));
+				S3TestHelper::RequireQueryOk(con, "BEGIN");
+				auto &fs = FileSystem::GetFileSystem(*con.context);
+				const string selector = explicit_selection ? "?gcs_generation=123" : "";
+				auto handle = fs.OpenFile("gcs://refresh-bucket/object.bin" + selector,
+				                          FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+				string data(10, '?');
+				handle->Read(QueryContext(*con.context), &data[0], data.size(), 0);
+				REQUIRE(data == "historical");
+				S3TestHelper::AssertSingleRefresh(test_id);
+				for (auto &observation : server.Observations()) {
+					REQUIRE(observation.target ==
+					        string("/refresh-bucket/object.bin") + (explicit_selection ? "?generation=123" : ""));
+					const bool conditional =
+					    !explicit_selection && target != MockS3RefreshTarget::FULL_GET && observation.method == "GET";
+					REQUIRE(MockS3HeaderValues(observation, "x-goog-if-generation-match") ==
+					        (conditional ? vector<string> {"123"} : vector<string>()));
+				}
+				S3TestHelper::RequireQueryOk(con, "COMMIT");
 			}
-			S3TestHelper::RequireQueryOk(con, "COMMIT");
 		}
 	}
 }
@@ -152,6 +375,267 @@ TEST_CASE("GCS generation deletes are rejected before dispatch", "[httpfs][s3][g
 	                    Catch::Contains("gcs_generation is only supported for reading"));
 	REQUIRE(server.Observations().empty());
 	S3TestHelper::RequireQueryOk(con, "COMMIT");
+}
+
+TEST_CASE("GCS generation metadata rejects malformed and conflicting responses", "[httpfs][s3][gcs-generation]") {
+	for (const string client : {"curl", "httplib"}) {
+		for (const string invalid : {"", "0", "-1", "1.0", "abc", "18446744073709551616", "123,456"}) {
+			CAPTURE(client, invalid);
+			MockS3ServerConfig config;
+			config.metadata.response_headers = {{"x-goog-generation", invalid}};
+			MockS3Server server(std::move(config));
+			DuckDB db(nullptr);
+			Connection con(db);
+			ConfigureGenerationTest(db, con, server, client, false);
+			auto result = con.Query("SELECT * FROM read_blob('gcs://refresh-bucket/object.bin')");
+			REQUIRE(result->HasError());
+			REQUIRE(StringUtil::Contains(result->GetError(), "positive uint64 decimal"));
+		}
+		for (const bool conflicting : {false, true}) {
+			MockS3ServerConfig config;
+			config.metadata.response_headers = {{"x-goog-generation", "123"},
+			                                    {"x-goog-generation", conflicting ? "456" : "123"}};
+			config.metadata.get_response_headers = {{"x-goog-generation", "123"}};
+			config.metadata.enforce_generation_match = false;
+			MockS3Server server(std::move(config));
+			DuckDB db(nullptr);
+			Connection con(db);
+			ConfigureGenerationTest(db, con, server, client, false);
+			auto result = con.Query("SELECT * FROM read_blob('gcs://refresh-bucket/object.bin')");
+			INFO((result->HasError() ? result->GetError() : ""));
+			REQUIRE(result->HasError() == conflicting);
+		}
+	}
+}
+
+TEST_CASE("GCS invalid GET generation metadata fails before publishing data", "[httpfs][s3][gcs-generation]") {
+	for (const string client : {"curl", "httplib"}) {
+		for (const string value : {"invalid", "456"}) {
+			for (const bool full_download : {false, true}) {
+				CAPTURE(client, value, full_download);
+				MockS3ServerConfig config;
+				config.object.generation = "123";
+				config.object.generations = {{"123", "old bytes"}, {"456", "new bytes"}};
+				config.metadata.get_response_headers = {{"x-goog-generation", value}};
+				MockS3Server server(std::move(config));
+				DuckDB db(nullptr);
+				Connection con(db);
+				ConfigureGenerationTest(db, con, server, client, false);
+				S3TestHelper::RequireQueryOk(con, "BEGIN");
+				auto &fs = FileSystem::GetFileSystem(*con.context);
+				auto handle = fs.OpenFile("gcs://refresh-bucket/object.bin",
+				                          FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+				if (full_download) {
+					bool write_cache = false;
+					auto &http = handle->Cast<HTTPFileHandle>();
+					REQUIRE_THROWS(handle->file_system.Cast<HTTPFileSystem>().FullDownload(http, http.GetReadConfig(),
+					                                                                       write_cache));
+				} else {
+					string data(9, '?');
+					REQUIRE_THROWS(handle->Read(QueryContext(*con.context), &data[0], data.size(), 0));
+					REQUIRE(data == string(9, '?'));
+				}
+				server.SetObjectGeneration("456");
+				auto reopened = fs.OpenFile("gcs://refresh-bucket/object.bin",
+				                            FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+				REQUIRE(fs.GetVersionTag(*reopened) == "gcs-generation:456");
+				S3TestHelper::RequireQueryOk(con, "COMMIT");
+			}
+		}
+	}
+}
+
+TEST_CASE("GCS generation metadata roundtrips through extended file information", "[httpfs][s3][gcs-generation]") {
+	MockS3ServerConfig config;
+	config.object.generation = "123";
+	config.object.generations = {{"123", "old bytes"}};
+	MockS3Server server(std::move(config));
+	DuckDB db(nullptr);
+	Connection con(db);
+	ConfigureGenerationTest(db, con, server, "curl", true);
+	S3TestHelper::RequireQueryOk(con, "BEGIN");
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	auto initial =
+	    fs.OpenFile("gcs://refresh-bucket/object.bin", FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	auto &http = initial->Cast<HTTPFileHandle>();
+	OpenFileInfo info("gcs://refresh-bucket/object.bin?s3_region=auto");
+	info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+	info.extended_info->options["last_modified"] = Value::TIMESTAMP(http.last_modified);
+	info.extended_info->options["file_size"] = Value::UBIGINT(http.length);
+	info.extended_info->options["etag"] = http.etag;
+	info.extended_info->options["gcs_generation"] = http.GetObjectVersion().GetValue();
+	auto restored = fs.OpenFile(info, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+	REQUIRE(restored->Cast<HTTPFileHandle>().GetReadConfig().condition.value == "123");
+	REQUIRE(restored->Stats().version_tag == initial->Stats().version_tag);
+	REQUIRE(server.Observations().size() == 1);
+	string data(9, '?');
+	restored->Read(QueryContext(*con.context), &data[0], data.size(), 0);
+	REQUIRE(data == "old bytes");
+	S3TestHelper::RequireQueryOk(con, "COMMIT");
+}
+
+TEST_CASE("GCS cached metadata remains stable during full downloads", "[httpfs][s3][gcs-generation]") {
+	for (const string client : {"curl", "httplib"}) {
+		MockS3ServerConfig config;
+		config.metadata.response_headers = {{"x-goog-generation", "123"}};
+		config.metadata.enforce_generation_match = false;
+		MockS3Server server(std::move(config));
+		DuckDB db(nullptr);
+		Connection con(db);
+		ConfigureGenerationTest(db, con, server, client, false);
+		S3TestHelper::RequireQueryOk(con, "BEGIN");
+		auto &fs = FileSystem::GetFileSystem(*con.context);
+		auto initial = fs.OpenFile("gcs://refresh-bucket/object.bin",
+		                           FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+		auto cached = fs.OpenFile("gcs://refresh-bucket/object.bin",
+		                          FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+		REQUIRE(server.Observations().size() == 1);
+		REQUIRE(fs.GetVersionTag(*cached) == "gcs-generation:123");
+		auto &http = cached->Cast<HTTPFileHandle>();
+		bool write_cache = false;
+		cached->file_system.Cast<HTTPFileSystem>().FullDownload(http, http.GetReadConfig(), write_cache);
+		string data(5, '?');
+		cached->Read(QueryContext(*con.context), &data[0], data.size(), 0);
+		REQUIRE(data == server.ObjectData().substr(0, data.size()));
+		REQUIRE(fs.GetVersionTag(*cached) == "gcs-generation:123");
+		REQUIRE(cached->Stats().version_tag == fs.GetVersionTag(*cached));
+		REQUIRE(cached->Cast<HTTPFileHandle>().GetReadConfig().condition.value == "123");
+		bool saw_full_get = false;
+		for (auto &observation : server.Observations()) {
+			if (observation.method == "GET") {
+				saw_full_get |= observation.range.empty();
+				REQUIRE(MockS3HeaderValues(observation, "x-goog-if-generation-match") == vector<string> {"123"});
+			}
+		}
+		REQUIRE(saw_full_get);
+		S3TestHelper::RequireQueryOk(con, "COMMIT");
+	}
+}
+
+TEST_CASE("GCS cached full downloads cannot bypass another handle's generation check",
+          "[httpfs][s3][gcs-generation][full-download]") {
+	for (const string client : {"curl", "httplib"}) {
+		for (const bool unsafe : {false, true}) {
+			CAPTURE(client, unsafe);
+			MockS3ServerConfig config;
+			config.object.generation = "123";
+			config.object.generations = {{"123", "aaaaaaaaaa"}, {"456", "bbbbbbbbbb"}};
+			config.metadata.response_headers = {{"Cache-Control", "no-store"}};
+			MockS3Server server(std::move(config));
+			DuckDB db(nullptr);
+			Connection con(db);
+			ConfigureGenerationTest(db, con, server, client, false);
+			S3TestHelper::RequireQueryOk(con, "SET enable_http_metadata_cache=false");
+			S3TestHelper::RequireQueryOk(con, "SET enable_external_file_cache=false");
+			S3TestHelper::RequireQueryOk(con, "SET force_download_threshold=0");
+			S3TestHelper::RequireQueryOk(con, string("SET unsafe_disable_etag_checks=") + (unsafe ? "true" : "false"));
+			S3TestHelper::RequireQueryOk(con, "BEGIN");
+			auto &fs = FileSystem::GetFileSystem(*con.context);
+			const auto flags = FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO;
+			auto old_handle = fs.OpenFile("gcs://refresh-bucket/object.bin", flags);
+			string data(5, '?');
+			old_handle->Read(QueryContext(*con.context), &data[0], data.size(), 0);
+			REQUIRE(data == "aaaaa");
+			server.SetObjectGeneration("456");
+			auto new_handle = fs.OpenFile("gcs://refresh-bucket/object.bin", flags);
+			REQUIRE(fs.GetVersionTag(*new_handle) == "gcs-generation:456");
+			auto &new_http = new_handle->Cast<HTTPFileHandle>();
+			bool write_cache = false;
+			new_handle->file_system.Cast<HTTPFileSystem>().FullDownload(new_http, new_http.GetReadConfig(),
+			                                                            write_cache);
+			const auto request_count = server.Observations().size();
+			auto &old_http = old_handle->Cast<HTTPFileHandle>();
+			auto reuse_download = [&]() {
+				return old_handle->file_system.Cast<HTTPFileSystem>().FullDownload(old_http, old_http.GetReadConfig(),
+				                                                                   write_cache);
+			};
+			data.assign(5, '?');
+			if (unsafe) {
+				old_handle->Read(QueryContext(*con.context), &data[0], data.size(), 5);
+				REQUIRE(data == "bbbbb");
+				REQUIRE(reuse_download()->GetMetadata().object_version.GetValue() == "456");
+			} else {
+				REQUIRE_THROWS_WITH(old_handle->Read(QueryContext(*con.context), &data[0], data.size(), 5),
+				                    Catch::Contains("do not match the version"));
+				REQUIRE(data == "?????");
+				REQUIRE_THROWS_WITH(reuse_download(), Catch::Contains("do not match the version"));
+			}
+			REQUIRE(fs.GetVersionTag(*old_handle) == "gcs-generation:123");
+			new_handle->Read(QueryContext(*con.context), &data[0], data.size(), 5);
+			REQUIRE(data == "bbbbb");
+			REQUIRE(server.Observations().size() == request_count);
+			S3TestHelper::RequireQueryOk(con, "COMMIT");
+		}
+	}
+}
+
+TEST_CASE("GCS unsafe full downloads publish response metadata without changing the handle",
+          "[httpfs][s3][gcs-generation][full-download]") {
+	for (const string client : {"curl", "httplib"}) {
+		MockS3ServerConfig config;
+		config.object.generation = "123";
+		config.object.generations = {{"123", "old bytes"}, {"456", "new bytes"}};
+		config.metadata.response_headers = {{"Cache-Control", "no-store"}};
+		MockS3Server server(std::move(config));
+		DuckDB db(nullptr);
+		Connection con(db);
+		ConfigureGenerationTest(db, con, server, client, false);
+		S3TestHelper::RequireQueryOk(con, "SET enable_http_metadata_cache=false");
+		S3TestHelper::RequireQueryOk(con, "SET enable_external_file_cache=false");
+		S3TestHelper::RequireQueryOk(con, "SET unsafe_disable_etag_checks=true");
+		S3TestHelper::RequireQueryOk(con, "BEGIN");
+		auto &fs = FileSystem::GetFileSystem(*con.context);
+		auto handle = fs.OpenFile("gcs://refresh-bucket/object.bin",
+		                          FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO);
+		REQUIRE(fs.GetVersionTag(*handle) == "gcs-generation:123");
+		server.SetObjectGeneration("456");
+		auto &http = handle->Cast<HTTPFileHandle>();
+		bool write_cache = false;
+		auto cached = handle->file_system.Cast<HTTPFileSystem>().FullDownload(http, http.GetReadConfig(), write_cache);
+		REQUIRE(string(cached->GetData(), cached->GetSize()) == "new bytes");
+		REQUIRE(cached->GetMetadata().object_version.GetValue() == "456");
+		REQUIRE(fs.GetVersionTag(*handle) == "gcs-generation:123");
+		auto reopened = fs.OpenFile("gcs://refresh-bucket/object.bin", FileFlags::FILE_FLAGS_READ);
+		REQUIRE(fs.GetVersionTag(*reopened) == "gcs-generation:456");
+		REQUIRE(server.Observations().size() == 2);
+		S3TestHelper::RequireQueryOk(con, "COMMIT");
+	}
+}
+
+TEST_CASE("GCS external data cache distinguishes generations with the same ETag and size",
+          "[httpfs][s3][gcs-generation]") {
+	for (const string client : {"curl", "httplib"}) {
+		MockS3ServerConfig config;
+		config.object.generation = "123";
+		config.object.generations = {{"123", string(4 * 1024 * 1024, 'a')}, {"456", string(4 * 1024 * 1024, 'b')}};
+		MockS3Server server(std::move(config));
+		DuckDB db(nullptr);
+		Connection con(db);
+		ConfigureGenerationTest(db, con, server, client, false);
+		S3TestHelper::RequireQueryOk(con, "SET enable_http_metadata_cache=false");
+		for (const string generation : {"123", "123", "456"}) {
+			server.SetObjectGeneration(generation);
+			S3TestHelper::RequireQueryOk(con, "BEGIN");
+			{
+				auto fs = CachingFileSystem::Get(*con.context);
+				auto handle = fs.OpenFile(OpenFileInfo("gcs://refresh-bucket/object.bin"), FileFlags::FILE_FLAGS_READ);
+				string data(16, '?');
+				auto buffer = handle->Read(16, 0);
+				buffer.CopyTo(data_ptr_cast(&data[0]), data.size());
+				REQUIRE(data == string(16, generation == "123" ? 'a' : 'b'));
+				REQUIRE(handle->GetVersionTag() == "gcs-generation:" + generation);
+			}
+			S3TestHelper::RequireQueryOk(con, "COMMIT");
+		}
+		idx_t get_count = 0;
+		for (auto &observation : server.Observations()) {
+			if (observation.method == "GET") {
+				get_count++;
+				REQUIRE(observation.range != "bytes=0-4194303");
+			}
+		}
+		REQUIRE(get_count == 2);
+	}
 }
 
 } // namespace duckdb

--- a/test/unittest/s3/mock_s3_server.cpp
+++ b/test/unittest/s3/mock_s3_server.cpp
@@ -336,7 +336,8 @@ public:
 	}
 
 	explicit Impl(MockS3ServerConfig config_p)
-	    : config(std::move(config_p)), server_owner(CreateServer(config.use_ssl)), server(*server_owner) {
+	    : config(std::move(config_p)), live_generation(config.object.generation),
+	      server_owner(CreateServer(config.use_ssl)), server(*server_owner) {
 		uploaded_object = config.upload.initial_published_object;
 		remaining_put_failures = config.failures.transient_put_failures;
 		remaining_get_failures = config.failures.transient_get_failures;
@@ -545,15 +546,26 @@ public:
 		observations.push_back(std::move(observation));
 	}
 
-	optional_ptr<const string> GetObjectData(const httplib::Request &request) const {
-		if (!request.has_param("generation")) {
+	string GetGeneration(const httplib::Request &request) const {
+		if (request.has_param("generation")) {
+			return GetParameter(request, "generation");
+		}
+		annotated_lock_guard<annotated_mutex> guard(generation_lock);
+		return live_generation;
+	}
+
+	optional_ptr<const string> GetObjectData(const string &generation) const {
+		if (generation.empty()) {
 			return config.object.data;
 		}
-		auto entry = config.object.generations.find(GetParameter(request, "generation"));
+		auto entry = config.object.generations.find(generation);
 		return entry == config.object.generations.end() ? nullptr : &entry->second;
 	}
 
-	void SetObjectHeaders(httplib::Response &response, const string &data) const {
+	void SetObjectHeaders(httplib::Response &response, const string &data, const string &generation) const {
+		if (!generation.empty()) {
+			response.set_header("x-goog-generation", generation);
+		}
 		if (config.range.advertise) {
 			response.set_header("Accept-Ranges", "bytes");
 		} else {
@@ -576,8 +588,14 @@ public:
 		return config.metadata.get_etag.empty() ? config.metadata.etag : config.metadata.get_etag;
 	}
 
-	void SetGetHeaders(httplib::Response &response) const {
-		response.set_header("ETag", GetResponseETag());
+	void SetGetHeaders(httplib::Response &response, const string &generation) const {
+		if (!generation.empty()) {
+			response.set_header("x-goog-generation", generation);
+		}
+		for (auto &header : config.metadata.get_response_headers) {
+			response.set_header(header.first, header.second);
+		}
+		SetETagHeader(response, config.metadata.get_etag_behavior, GetResponseETag());
 		if (config.metadata.version_on_get && !config.metadata.version_id.empty()) {
 			response.set_header("x-amz-version-id", config.metadata.version_id);
 		}
@@ -1051,20 +1069,22 @@ public:
 				SendS3Error400(request, response, config.failures.failure_is_request_timeout);
 				return httplib::Server::HandlerResponse::Handled;
 			}
-			auto data = GetObjectData(request);
+			auto generation = GetGeneration(request);
+			auto data = GetObjectData(generation);
 			if (!data) {
 				response.status = 404;
 				Record(request, response.status);
 				return httplib::Server::HandlerResponse::Handled;
 			}
 			response.status = 200;
-			SetObjectHeaders(response, *data);
+			SetObjectHeaders(response, *data, generation);
 			Record(request, response.status);
 			return httplib::Server::HandlerResponse::Handled;
 		});
 
 		server.Get(path, [this](const httplib::Request &request, httplib::Response &response) {
-			auto object_data = GetObjectData(request);
+			auto generation = GetGeneration(request);
+			auto object_data = GetObjectData(generation);
 			if (!object_data) {
 				response.status = 404;
 				Record(request, response.status);
@@ -1086,10 +1106,17 @@ public:
 				return;
 			}
 
+			if (config.metadata.enforce_generation_match && request.has_header("x-goog-if-generation-match") &&
+			    GetHeader(request, "x-goog-if-generation-match") != generation) {
+				response.status = 412;
+				Record(request, response.status);
+				return;
+			}
+
 			auto range = GetHeader(request, "Range");
 			if (range.empty()) {
 				response.status = 200;
-				SetGetHeaders(response);
+				SetGetHeaders(response, generation);
 				if (config.full_get.block_until_released) {
 					response.set_content_provider(
 					    data.size(), "application/octet-stream",
@@ -1134,7 +1161,7 @@ public:
 			}
 			if (config.range.behavior == MockS3RangeBehavior::IGNORE_RANGE) {
 				response.status = 200;
-				SetGetHeaders(response);
+				SetGetHeaders(response, generation);
 				response.set_content(data, "application/octet-stream");
 				Record(request, response.status);
 				return;
@@ -1156,7 +1183,7 @@ public:
 			range_request_started.notify_all();
 			response.status = 206;
 			response.set_header("Accept-Ranges", "bytes");
-			SetGetHeaders(response);
+			SetGetHeaders(response, generation);
 			if (!config.range.blocked.empty() && range == config.range.blocked) {
 				response.set_content_provider(data.size(), "application/octet-stream",
 				                              [this, &data](size_t offset, size_t length, httplib::DataSink &sink) {
@@ -1318,6 +1345,8 @@ public:
 public:
 	//! Server configuration and lifetime
 	MockS3ServerConfig config;
+	mutable annotated_mutex generation_lock;
+	string live_generation DUCKDB_GUARDED_BY(generation_lock);
 	unique_ptr<httplib::Server> server_owner;
 	httplib::Server &server;
 	std::thread server_thread;
@@ -1398,6 +1427,12 @@ string MockS3Server::HTTPPath() const {
 
 const string &MockS3Server::ObjectData() const {
 	return impl->config.object.data;
+}
+
+void MockS3Server::SetObjectGeneration(const string &generation) {
+	D_ASSERT(impl->config.object.generations.count(generation));
+	annotated_lock_guard<annotated_mutex> guard(impl->generation_lock);
+	impl->live_generation = generation;
 }
 
 string MockS3Server::UploadedObject() const {

--- a/test/unittest/s3/mock_s3_server.hpp
+++ b/test/unittest/s3/mock_s3_server.hpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/optional_idx.hpp"
+#include "duckdb/common/pair.hpp"
 #include "duckdb/common/unordered_map.hpp"
 
 namespace duckdb {
@@ -50,6 +51,8 @@ struct MockS3ObjectConfig {
 	string data = "abcdefghijklmnopqrstuvwxyz0123456789";
 	//! Historical GCS object bodies, selected by the generation query parameter
 	unordered_map<string, string> generations;
+	//! Initial live generation; empty uses the unversioned data above
+	string generation;
 };
 
 struct MockS3AuthConfig {
@@ -65,6 +68,7 @@ struct MockS3MetadataConfig {
 	string etag = "\"httpfs-refresh-test-etag\"";
 	//! ETag returned by GET; use etag when empty
 	string get_etag;
+	MockS3ETagBehavior get_etag_behavior = MockS3ETagBehavior::VALUE;
 	//! S3 version ID returned by selected metadata/data responses
 	string version_id;
 	bool version_on_head = false;
@@ -74,12 +78,14 @@ struct MockS3MetadataConfig {
 	//! Override the Content-Length reported by HEAD while keeping the GET body unchanged
 	optional_idx head_content_length;
 	//! Extra HEAD response headers, including repeated field lines
-	vector<std::pair<string, string>> response_headers;
+	vector<pair<string, string>> response_headers;
+	vector<pair<string, string>> get_response_headers;
+	bool enforce_generation_match = true;
 	//! Write empty response fields without optional whitespace after the colon
 	bool exact_empty_response_headers = false;
 	//! Emit one HTTP redirect before the successful HEAD response
 	bool redirect_head = false;
-	vector<std::pair<string, string>> redirect_response_headers;
+	vector<pair<string, string>> redirect_response_headers;
 };
 
 struct MockS3CompletionFaultConfig {
@@ -213,7 +219,7 @@ struct MockS3ServerConfig {
 };
 
 struct MockS3RequestObservation {
-	vector<std::pair<string, string>> headers;
+	vector<pair<string, string>> headers;
 	string method;
 	string path;
 	string target;
@@ -257,6 +263,7 @@ public:
 	string HTTPPath() const;
 	string S3Path() const;
 	const string &ObjectData() const;
+	void SetObjectGeneration(const string &generation);
 	string UploadedObject() const;
 	string CompletionBody() const;
 	vector<MockS3RequestObservation> Observations() const;

--- a/test/unittest/s3/s3_request_test.cpp
+++ b/test/unittest/s3/s3_request_test.cpp
@@ -1745,6 +1745,43 @@ TEST_CASE("GCS generation URL validation and signing", "[httpfs][s3][gcs-generat
 	}
 }
 
+TEST_CASE("GCS generation conditions are owned and signed before dispatch", "[httpfs][s3][gcs-generation]") {
+	auto config = TestAuthConfig(S3ProviderType::GCS);
+	config.credentials.access_key_id = "key";
+	config.credentials.secret_access_key = "secret";
+	auto auth = ResolveTestAuth(config);
+	const string path = "gcs://bucket/key";
+	auto parsed = S3Url::Parse(path, auth);
+	HTTPFSUtil http_util;
+	HTTPFSParams params(http_util);
+	auto snapshot = make_shared_ptr<S3RequestSnapshot>(params, auth, path, weak_ptr<ClientContext>(), false);
+	HTTPRequestSession session(snapshot);
+	::AESStateSSLFactory encryption_util;
+	S3RequestSpec spec {path, S3RequestOperation::GET_OBJECT, {}, "", "", ""};
+	spec.read_condition = {HTTPReadConditionType::GCS_GENERATION_MATCH, "123"};
+	S3RequestExecutor::RunSession(encryption_util, session, spec, [&](S3RequestData &request) {
+		auto timestamp = request.headers.GetHeaderValue("x-amz-date");
+		auto expected =
+		    S3RequestUtil::CreateHeaders(encryption_util, parsed, spec.operation, S3RequestQuery(), auth,
+		                                 timestamp.substr(0, 8), timestamp, "", "", "", {}, spec.read_condition);
+		auto unconditional = S3RequestUtil::CreateHeaders(encryption_util, parsed, spec.operation, S3RequestQuery(),
+		                                                  auth, timestamp.substr(0, 8), timestamp);
+		REQUIRE(request.http_url == parsed.GetHTTPUrl());
+		REQUIRE(request.headers.GetHeaderValue("x-goog-if-generation-match") == "123");
+		REQUIRE(request.headers.GetHeaderValue("Authorization") == expected.GetHeaderValue("Authorization"));
+		REQUIRE(request.headers.GetHeaderValue("Authorization") != unconditional.GetHeaderValue("Authorization"));
+		return make_uniq<HTTPResponse>(HTTPStatusCode::OK_200);
+	});
+	HTTPConfiguredHeaders overrides {"", {{"X-GoOg-If-GeNeRaTiOn-MaTcH", "456"}}};
+	REQUIRE_THROWS(S3RequestUtil::CreateHeaders(encryption_util, parsed, spec.operation, S3RequestQuery(), auth, "", "",
+	                                            "", "", "", overrides));
+	for (auto type : {S3ProviderType::S3, S3ProviderType::R2}) {
+		auto other = ResolveTestAuth(TestAuthConfig(type));
+		HTTPHeaders headers;
+		REQUIRE_THROWS(other.GetProvider().ApplyReadCondition(spec.read_condition, headers));
+	}
+}
+
 TEST_CASE("S3 provider version policy preserves version semantics", "[httpfs][s3][gcs-generation]") {
 	for (auto type : {S3ProviderType::S3, S3ProviderType::GCS, S3ProviderType::R2}) {
 		auto provider = ResolveTestAuth(TestAuthConfig(type)).GetProvider();


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb-httpfs/pull/429

Adds automatic generation checks for GCS reads, so replacing an object mid-query causes an error instead of mixing data from different versions.