### PR TITLE
Move from explicit sha to  workflow

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -22,14 +22,18 @@ jobs:
         id: runners
         uses: duckdb/duckdb-ci/detect-runners@main
 
+  duckdb-submodule-version:
+    uses: duckdb/extension-ci-tools/.github/workflows/_submodule_version.yml@main
+
   duckdb-stable-build:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     needs:
       - prepare
+      - duckdb-submodule-version
     with:
       extension_name: httpfs
-      duckdb_version: 31151d40e6906f2056db8a2c45b336b153c9f871
+      duckdb_version: ${{ needs.duckdb-submodule-version.outputs.version }}
       ci_tools_version: main
       runners: ${{ needs.prepare.outputs.runners }}
 
@@ -38,21 +42,24 @@ jobs:
     needs:
       - prepare
       - duckdb-stable-build
+      - duckdb-submodule-version
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@main
     secrets: inherit
     with:
       extension_name: httpfs
-      duckdb_version: 31151d40e6906f2056db8a2c45b336b153c9f871
+      duckdb_version: ${{ needs.duckdb-submodule-version.outputs.version }}
       ci_tools_version: main
       deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') }}
       deploy_versioned: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}
 
   code-quality:
     name: Code Quality
+    needs:
+      - duckdb-submodule-version
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main
     with:
       extension_name: httpfs
-      duckdb_version: 31151d40e6906f2056db8a2c45b336b153c9f871
+      duckdb_version: ${{ needs.duckdb-submodule-version.outputs.version }}
       ci_tools_version: main
       extra_toolchains: 'python3'
       format_checks: 'format'


### PR DESCRIPTION
This trades few extra seconds (via the extra dependency) per CI cycle with the fact that on bumping duckdb it doesn't need to be happening in two separate places (the `duckdb/` submodule and the `.github/workflows/MainDistributionPipeline.yml` file) but now only duckdb submodule is enough.

See also the related https://github.com/duckdb/duckdb-quack/pull/268 and the implementation at https://github.com/duckdb/extension-ci-tools/pull/406/changes