### PR TITLE
Update vcpkg to 2026.06.24

### DIFF
--- a/.github/workflows/IntegrationTests.yml
+++ b/.github/workflows/IntegrationTests.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11.1
         with:
-          vcpkgGitCommitId: 84bab45d415d22042bd0b9081aea57f362da3f35
+          vcpkgGitCommitId: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # Release 2026.06.24
 
       - name: Fix permissions of test secrets
         shell: bash

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -36,6 +36,8 @@ jobs:
       duckdb_version: ${{ needs.duckdb-submodule-version.outputs.version }}
       ci_tools_version: main
       runners: ${{ needs.prepare.outputs.runners }}
+      # Temporary override; remove when extension-ci-tools updates its default.
+      vcpkg_commit: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # Release 2026.06.24
 
   duckdb-stable-deploy:
     name: Deploy extension binaries
@@ -127,4 +129,4 @@ jobs:
           build-type: relassert
           build: python3 duckdb/scripts/ci/retry.py -- make relassert
           test: make unittest_relassert
-          vcpkg-commit: 84bab45d415d22042bd0b9081aea57f362da3f35
+          vcpkg-commit: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # Release 2026.06.24


### PR DESCRIPTION
This pr updates the vcpkg version to 2026.06.24.

This is part of updating all of duckdb, therefore merging should be done in coordination with stakeholders.

References:
https://github.com/duckdb/duckdb/pull/25094
https://github.com/duckdblabs/duckdb-internal/issues/10429