### PR TITLE
Add DUCKDB_S3_URL_STYLE environment variable

### DIFF
--- a/src/include/s3/s3_auth.hpp
+++ b/src/include/s3/s3_auth.hpp
@@ -197,6 +197,7 @@ public:
 	static constexpr const char *DUCKDB_USE_SSL_ENV_VAR = "DUCKDB_S3_USE_SSL";
 	static constexpr const char *DUCKDB_KMS_KEY_ID_ENV_VAR = "DUCKDB_S3_KMS_KEY_ID";
 	static constexpr const char *DUCKDB_REQUESTER_PAYS_ENV_VAR = "DUCKDB_S3_REQUESTER_PAYS";
+	static constexpr const char *DUCKDB_URL_STYLE_ENV_VAR = "DUCKDB_S3_URL_STYLE";
 
 	DBConfig &config;
 };

--- a/src/s3/s3_auth.cpp
+++ b/src/s3/s3_auth.cpp
@@ -60,6 +60,7 @@ void AWSEnvironmentCredentialsProvider::SetAll() {
 	this->SetExtensionOptionValue("s3_use_ssl", DUCKDB_USE_SSL_ENV_VAR);
 	this->SetExtensionOptionValue("s3_kms_key_id", DUCKDB_KMS_KEY_ID_ENV_VAR);
 	this->SetExtensionOptionValue("s3_requester_pays", DUCKDB_REQUESTER_PAYS_ENV_VAR);
+	this->SetExtensionOptionValue("s3_url_style", DUCKDB_URL_STYLE_ENV_VAR);
 }
 
 S3AuthParams::S3AuthParams() = default;


### PR DESCRIPTION
Makes `s3_url_style` configurable via the `DUCKDB_S3_URL_STYLE` environment variable, like the other `DUCKDB_S3_*` settings. Fixes #438.